### PR TITLE
Single rdflib.js for node, amd/requirejs and bare browser environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 R=util.js uri.js term.js rdfparser.js n3parser.js identity.js query.js sparql.js sparqlUpdate.js jsonparser.js serialize.js updatesVia.js web.js
 
-targets=$(addprefix dist/, rdflib.js node-rdflib.js rdflib-rdfa.js)
+targets=$(addprefix dist/, rdflib.js rdflib-rdfa.js)
 coffeejs=$(patsubst %.coffee,%.js,$(wildcard *.coffee))
 
 all: dist $(targets)
@@ -10,28 +10,19 @@ all: dist $(targets)
 dist:
 	mkdir -p dist
 
-dist/rdflib.js: $R
-	echo "\$$rdf = function() {" > $@
-	cat $R >> $@
-	echo "return \$$rdf;}()" >> $@
-
-# Currently the blow is suboptimal == you have to say $rdf=require(â€¦).$rdf
-# but this doesn't work at all: echo "module.\$$rdf = function() {" > $@
-# But module.exports = $rdf should
-
-dist/node-rdflib.js: $R
-	echo "module.exports = \$$rdf = function() {" > $@
-	cat $R >> $@
-	echo "return \$$rdf;}()" >> $@
+dist/rdflib.js: $R module.js
+	echo "(function(root, undef) {" > $@
+	cat $R module.js >> $@
+	echo "})(this);" >> $@
 
 J=dist
 X=jquery.uri.js jquery.xmlns.js
 
-dist/rdflib-rdfa.js: $X $R rdfa.js
+dist/rdflib-rdfa.js: $X $R rdfa.js module.js
 	cat $X > $@
-	echo "\$$rdf = function() {" >> $@
-	cat $R rdfa.js >> $@
-	echo "return \$$rdf;}()" >> $@
+	echo "(function(root, undef) {" > $@
+	cat $R rdfa.js module.js >> $@
+	echo "})(this);" >> $@
 
 jquery.uri.js:
 	wget http://rdfquery.googlecode.com/svn-history/trunk/jquery.uri.js -O $@

--- a/module.js
+++ b/module.js
@@ -1,0 +1,18 @@
+
+// Handle node, amd, and global systems
+if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+        exports = module.exports = $rdf;
+    }
+    exports.$rdf = $rdf;
+}
+else {
+    if (typeof define === 'function' && define.amd) {
+        define('rdflib', function() {
+            return $rdf;
+        });
+    }
+
+    // Leak a global regardless of module system
+    root['$rdf'] = $rdf;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdflib",
   "description": "an rdf parser for node.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "author": "J. Presbrey <presbrey@mit.edu>",
   "license": "MIT",
@@ -22,9 +22,9 @@
     "test": "make test"
   },
   "files": [
-    "dist/node-rdflib.js"
+    "dist/rdflib.js"
   ],
-  "main": "dist/node-rdflib.js",
+  "main": "dist/rdflib.js",
   "keywords": [
     "linkeddata", "linked data",  "rdf", "rdfa",
     "turtle", "semantic", "web"


### PR DESCRIPTION
This patch to the build process means that the resulting rdflib.js can be used both in node.js, in a RequireJS environment (tested in Aloha Editor), and as a bare file.  This is based on the code in https://github.com/SlexAxton/Jed.
