### PR TITLE
Support the DOM tree generated by the node.js package xmldom

### DIFF
--- a/rdfparser.js
+++ b/rdfparser.js
@@ -408,7 +408,7 @@
                     frame = frame.parent;
                     dom = frame.element;
                 }
-                var candidate = dom.childNodes[frame.lastChild];
+                var candidate = dom.childNodes && dom.childNodes[frame.lastChild];
                 if (!candidate || ! dig){
                     frame.terminateFrame();
                     if ( ! (frame = frame.parent)){


### PR DESCRIPTION
I couldn't get jsdom to work, and it really seems to be the wrong library for parsing plain RDF/XML in a node.js environment as it pretends to be a full browser environment.  xmldom worked much better, but the patch below is necessary to parse the DOM tree it returns.

It could be a good idea to replace jsdom in rdflib.js with xmldom.  Usage is easy, a direct parallel to the browser DOMParser:

```
var doc = new xmldom.DOMParser().parseFromString(xml, 'text/xml');
```

(I can do that patch too, but don't have time this week.)
