### PR TITLE
Fix ignored fetcher timeout attribute for bug #30 of rdflib

### DIFF
--- a/web.js
+++ b/web.js
@@ -606,7 +606,7 @@ $rdf.Fetcher = function(store, timeout, async) {
      */
     this.requestURI = function(docuri, rterm, force) { //sources_request_new
         if (docuri.indexOf('#') >= 0) { // hash
-            throw ("requestURI should not be called with fragid: " + uri)
+            throw ("requestURI should not be called with fragid: " + docuri);
         }
 
         var pcol = $rdf.uri.protocol(docuri);
@@ -978,6 +978,7 @@ $rdf.Fetcher = function(store, timeout, async) {
                 url: uri2,
                 accepts: {'*': 'text/turtle,text/n3,application/rdf+xml'},
                 processData: false,
+                timeout: sf.timeout,
                 error: function(xhr, s, e) {
                     if (s == 'timeout')
                         sf.failFetch(xhr, "requestTimeout");
@@ -992,6 +993,10 @@ $rdf.Fetcher = function(store, timeout, async) {
             var xhr = $rdf.Util.XMLHTTPFactory();
             xhr.onerror = onerrorFactory(xhr);
             xhr.onreadystatechange = onreadystatechangeFactory(xhr);
+            xhr.timeout = sf.timeout;
+            xhr.ontimeout = function () {
+                sf.failFetch(xhr, "requestTimeout");
+            }
             try {
                 xhr.open('GET', uri2, this.async);
             } catch (er) {


### PR DESCRIPTION
This has been tested successfully with the following code, both with and without JQuery

```
<!DOCTYPE html>
<html>
<head>
    <title></title>
    <script src="rdflib.js"></script>
    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>

</head>
<body>


<script>
    function createNewRdfStore() {
        var store = new $rdf.IndexedFormula();
        var fetcherTimeout = 10000;
        $rdf.fetcher(store, fetcherTimeout, true);
        return store;
    }
    var store = createNewRdfStore();


    var urlToFetch = "http://bblfish.net/people/henry/card";
    var urlToFetchTimeout = "http://purl.org/captsolo/semweb/foaf-captsolo.rdf";
    var urlToFetchTimeout2 = "http://unknown.localhost.com";
    var urlToFetchTimeout3 = "https://localhost:8443/srv/cors?url=http://purl.org/captsolo/semweb/foaf-captsolo.rdf";

    store.fetcher.nowOrWhenFetched(urlToFetchTimeout3, undefined, function(isError,errorStatus) {
        console.error("isError?",isError," Status=",errorStatus)
    });

</script>
</body>
</html>
```

In my case I needed a cors proxy to be able to simulate the timeout because there were errors due to same origin policy.
Btw these errors were not very explicit in errorStatus :(
