### PR TITLE
Add XHR failed object when calling this.fireCallbacks('fail',[...])); to...

### DIFF
--- a/web.js
+++ b/web.js
@@ -464,7 +464,7 @@ $rdf.Fetcher = function(store, timeout, async) {
         this.addStatus(xhr.req, status)
         kb.add(xhr.uri, ns.link('error'), status)
         this.requested[$rdf.uri.docpart(xhr.uri.uri)] = false
-        this.fireCallbacks('fail', [xhr.requestedURI, status])
+        this.fireCallbacks('fail', [xhr.requestedURI, status, xhr])
         xhr.abort()
         return xhr
     }


### PR DESCRIPTION
... help with issue #29 of rdflib

I didn't add the http status to the args because the most open way to handle this is to provide directly the xhr object.
There may not even be any http status codes for certain errors (like same origin policy errors, timeout errors etc...)

The XHR object contains the URI, the http status code and more informations that can be useful to the callback user. This is not the most "user friendly" but at least it handles all the cases
