### PR TITLE
Literals with attributes should be added as rdf:value nodes

### DIFF
--- a/rdfparser.js
+++ b/rdfparser.js
@@ -275,7 +275,12 @@
             var dom = frame.element;
             var attrs = dom.attributes;
             if (dom.nodeType === RDFParser.nodeType.TEXT || dom.nodeType === RDFParser.nodeType.CDATA_SECTION){
-                  //we have a literal
+                //we have a literal
+                if(frame.parent.nodeType == frame.NODE) {
+                    //must have had attributes, store as rdf:value
+                    frame.addArc(RDFParser.ns.RDF + 'value');
+                    frame = this.buildFrame(frame);
+                }
                 frame.addLiteral(dom.nodeValue);
             }
             else if (elementURI(dom)!== RDFParser.ns.RDF + "RDF"){


### PR DESCRIPTION
As per http://www.w3.org/TR/rdf-primer/#rdfvalue

```
<rdf:RDF
  xmlns="http://purl.org/dc/elements/1.1/"
  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns:bib="http://purl.org/net/biblio#">
  <bib:Document rdf:about="something">
      <language xsi:type="dcterms:ISO639-3">eng</language>
  </bib:Document>
</rdf:RDF>
```

should result in something like

```
<something> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/net/biblio#Document> .
<something> <http://purl.org/dc/elements/1.1/language> _:n2 .
_:n2 <http://www.w3.org/2001/XMLSchema-instancetype> "dcterms:ISO639-3" .
_:n2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "eng"
```

Pre-patch, this results in

```
<something> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/net/biblio#Document> .
<something> <http://purl.org/dc/elements/1.1/language> _:n0 .
_:n0 <http://www.w3.org/2001/XMLSchema-instancetype> "dcterms:ISO639-3"
```
