### PR TITLE
Fix amd define

### DIFF
--- a/module.js
+++ b/module.js
@@ -8,7 +8,7 @@ if (typeof exports !== 'undefined') {
 }
 else {
     if (typeof define === 'function' && define.amd) {
-        define('rdflib', function() {
+        define([], function() {
             return $rdf;
         });
     }


### PR DESCRIPTION
The change in 7ce7054e3481d84be559931e5571fd265ef7133d to support different packaging systems didn't work with RequireJS, which is fixed here.

Original (and merged) pull request:
https://github.com/linkeddata/rdflib.js/pull/24
