### PR TITLE
add jsonld capabilities

### DIFF
--- a/web.js
+++ b/web.js
@@ -357,6 +357,13 @@ $rdf.Fetcher = function(store, timeout, async) {
                     return
                 }
 
+                if (rt.slice(0, 500).match(/["']@(context|vocab)["']:/)) {
+                    sf.addStatus(xhr.req, "May be JSON-LD. We'll assume it's that "
+                            + "but its content-type wasn't JSON or JSON-LD.\n")
+                    sf.switchHandler('JSONLDHandler', xhr, cb)
+                    return
+                }
+
                 // We give up finding semantics - this is not an error, just no data
                 sf.addStatus(xhr.req, "Plain text document, no known RDF semantics.");
                 sf.doneFetch(xhr, [xhr.resource.uri]);
@@ -421,6 +428,66 @@ $rdf.Fetcher = function(store, timeout, async) {
         } // pre 2008
     }
     $rdf.Fetcher.N3Handler.pattern = new RegExp("(application|text)/(x-)?(rdf\\+)?(n3|turtle)")
+
+    /***********************************************/
+
+    $rdf.Fetcher.JSONLDHandler = function() {
+        this.handlerFactory = function(xhr) {
+            xhr.handle = function(cb) {
+                // Parse the text of this non-XML file
+                //$rdf.log.debug("web.js: Parsing as JSON-LD " + xhr.resource.uri);
+                var rt = xhr.responseText;
+                var nodemapper = [];
+                var convert = function convert(jsonldthing)
+                {
+                    if (jsonldthing.type === 'IRI')
+                        return sf.store.sym(jsonldthing.value);
+                    else if (jsonldthing.type === 'blank node')
+                    {
+                        if (nodemapper[jsonldthing.value] === undefined)
+                            nodemapper[jsonldthing.value] = sf.store.bnode();
+                        return nodemapper[jsonldthing.value];
+                    }
+                    else if (jsonldthing.type === 'literal')
+                    {
+                        return sf.store.literal(jsonldthing.value, jsonldthing.language, jsonldthing.datatype ? sf.store.sym(jsonldthing.datatype) : undefined);
+                    }
+                    else
+                        throw new TypeError('JSON-LD library generated unexpected type ' + jsonldthing.type + '.');
+                }
+                try {
+                    jsonld.toRDF(JSON.parse(rt), {'base': xhr.resource.uri}, function(err, data) {
+                        if (err === null) {
+                            for (var i in data['@default'])
+                            {
+                                var stmt = data['@default'][i];
+                                sf.store.add(convert(stmt.subject), convert(stmt.predicate), convert(stmt.object), xhr.resource);
+                                var s = data['@default'][i].subject
+                            }
+                            sf.addStatus(xhr.req, "JSON-LD parsed: " + data['@default'].length + " triples.")
+                            sf.store.add(xhr.resource, ns.rdf('type'), ns.link('RDFDocument'), sf.appNode);
+                            args = [xhr.resource.uri]; // Other args needed ever?
+                            sf.doneFetch(xhr, args)
+                        } else {
+                            sf.failFetch(xhr, "Error trying to parse " + xhr.resource + " as JSON-LD:\n" + err + ':\n' + e.stack);
+                        }
+                    });
+                } catch (e) {
+                    var msg = ("Error trying to parse " + xhr.resource + " as JSON-LD:\n" + e +':\n'+e.stack)
+                    // dump(msg+"\n")
+                    sf.failFetch(xhr, msg)
+                    return;
+                }
+            }
+        }
+    };
+    $rdf.Fetcher.JSONLDHandler.term = this.store.sym(this.thisURI + ".JSONLDHandler");
+    $rdf.Fetcher.JSONLDHandler.toString = function() { return "JSONLDHandler"; };
+    $rdf.Fetcher.JSONLDHandler.register = function(sf) {
+        sf.mediatypes['application/ld+json'] = {'q': '1.0'};
+        sf.mediatypes['application/json'] = {'q': '0.1'};
+    }
+    $rdf.Fetcher.JSONLDHandler.pattern = new RegExp("application/(ld\\+)?json");
 
     /***********************************************/
 
@@ -508,8 +575,7 @@ $rdf.Fetcher = function(store, timeout, async) {
     this.store.add(this.appNode, ns.rdfs('label'), this.store.literal('This Session'), this.appNode);
 
     ['http', 'https', 'file', 'chrome'].map(this.addProtocol); // ftp? mailto:?
-    [$rdf.Fetcher.RDFXMLHandler, $rdf.Fetcher.XHTMLHandler, $rdf.Fetcher.XMLHandler, $rdf.Fetcher.HTMLHandler, $rdf.Fetcher.TextHandler, $rdf.Fetcher.N3Handler ].map(this.addHandler)
-
+    [$rdf.Fetcher.RDFXMLHandler, $rdf.Fetcher.XHTMLHandler, $rdf.Fetcher.XMLHandler, $rdf.Fetcher.HTMLHandler, $rdf.Fetcher.TextHandler, $rdf.Fetcher.N3Handler, $rdf.Fetcher.JSONLDHandler ].map(this.addHandler)
 
 
     /** Note two nodes are now smushed
@@ -1398,6 +1464,8 @@ $rdf.parse = function parse(str, kb, base, contentType) {
             return;
         }
 
+        // FIXME jsonld here too? how'd i test it?
+
         if (contentType == 'application/rdf+xml') {
             var parser = new $rdf.RDFParser(kb);
             parser.parse($rdf.Util.parseXML(str), base, kb.sym(base));
@@ -1462,7 +1530,7 @@ $rdf.serialize = function(target, kb, base, contentType, callback) {
 ////////////////// JSON-LD code currently requires Node
 if (typeof module !== 'undefined' && module.require) { // Node
     var asyncLib = require('async');
-    var jsonld = require('jsonld');
+    var jsonld_module = require('jsonld');
     var N3 = require('n3');
 
     var convertToJson = function(n3String, jsonCallback) {
@@ -1485,7 +1553,7 @@ if (typeof module !== 'undefined' && module.require) { // Node
             },
             function(result, callback) {
                 try {
-                    jsonld.fromRDF(result, {
+                    jsonld_module.fromRDF(result, {
                         format: 'application/nquads'
                     }, callback);
                 } catch (err) {


### PR DESCRIPTION
this only works if the jsonld.js library[1] is included. no dedicated
parser is implemented, the work is delegated to that library, and a file
type handler takes care of converting jsonld.js' node format into rdflib
terms.

current caveats are:
- jsonld.js brings has to launch xmlhttprequests by itself
- there is content type handling code which i failed to trigger (see
  FIXME comment)
- i didn't do test cases that involve the `why` part of statements, and
  my literals tests were few too (barely enough to see datatypes are
  terms but languages aren't)
- accept priorities were set arbitrarily
- no tests are implemented
- the dependency on jsonld.js is not declared, and no tests were done
  without the library present.
- when using the widespread crossSiteProxyTemplate
  `http://data.fm/proxy?uri={uri}`, be aware that json-ld does not seem
  to work with it.

[1] https://github.com/digitalbazaar/jsonld.js
