### PR TITLE
send accept headers even outside of the tabulator extension

### DIFF
--- a/web.js
+++ b/web.js
@@ -1158,26 +1158,27 @@ $rdf.Fetcher = function(store, timeout, async) {
                         "@@ Couldn't set callback for redirects: " + err);
             }
 
-            try {
-                var acceptstring = ""
-                for (var type in this.mediatypes) {
-                    var attrstring = ""
-                    if (acceptstring != "") {
-                        acceptstring += ", "
-                    }
-                    acceptstring += type
-                    for (var attr in this.mediatypes[type]) {
-                        acceptstring += ';' + attr + '=' + this.mediatypes[type][attr]
-                    }
-                }
-                xhr.setRequestHeader('Accept', acceptstring)
-                // $rdf.log.info('Accept: ' + acceptstring)
+        }
 
-                // See http://dig.csail.mit.edu/issues/tabulator/issue65
-                //if (requester) { xhr.setRequestHeader('Referer',requester) }
-            } catch (err) {
-                throw ("Can't set Accept header: " + err)
+        try {
+            var acceptstring = ""
+            for (var type in this.mediatypes) {
+                var attrstring = ""
+                if (acceptstring != "") {
+                    acceptstring += ", "
+                }
+                acceptstring += type
+                for (var attr in this.mediatypes[type]) {
+                    acceptstring += ';' + attr + '=' + this.mediatypes[type][attr]
+                }
             }
+            xhr.setRequestHeader('Accept', acceptstring)
+            // $rdf.log.info('Accept: ' + acceptstring)
+
+            // See http://dig.csail.mit.edu/issues/tabulator/issue65
+            //if (requester) { xhr.setRequestHeader('Referer',requester) }
+        } catch (err) {
+            throw ("Can't set Accept header: " + err)
         }
 
         // Fire


### PR DESCRIPTION
this seems to work well, and at least with GET requests, no additional
CORS headers are required on the server side.
