### PR TITLE
fixed logic for using proxy

### DIFF
--- a/web.js
+++ b/web.js
@@ -621,8 +621,8 @@ $rdf.Fetcher = function(store, timeout, async) {
         if (typeof tabulator != 'undefined' && tabulator.isExtension) return uri; // Extenstion does not need proxy
                         // browser does 2014 on as https browser script not trusted
         if ($rdf.Fetcher.crossSiteProxyTemplate && document && document.location
-			&& ('' + document.location).slice(0,6) === 'https:'
-                && uri.slice(0,5) === 'http:') {
+			&& (('' + document.location).slice(0,6) === 'https:'
+                || uri.slice(0,5) === 'http:')) {
               return $rdf.Fetcher.crossSiteProxyTemplate.replace('{uri}', encodeURIComponent(uri));
         }
         return uri;


### PR DESCRIPTION
We've been using the proxy functionality and found that it was still throwing cors errors in the console but recovering. We tracked it down to a logic error. 