### PR TITLE
Bump jsonld version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "xmldom": "*",
     "xmlhttprequest": "^1.7.0",
     "n3": "^0.4.1",
-    "jsonld": "^0.3.22",
+    "jsonld": "^0.4.5",
     "async": "^0.9.x",
     "browserify": "*",
     "coffee-script": "*"


### PR DESCRIPTION
Closes issue #90 (old version broke installation on Node 5 / Ubuntu).

Also addresses downstream issue https://github.com/linkeddata/ldnode/issues/139