### PR TITLE
Don't force application/rdf+xml to DOMParser since it is not a supportedType

### DIFF
--- a/dist/rdflib-node.js
+++ b/dist/rdflib-node.js
@@ -371,7 +371,6 @@ $rdf.Util.parseXML = function (str, options) {
 
     var DOMParser = require('xmldom').DOMParser // 2015-08 on https://github.com/jindw/xmldom
     var dom = new DOMParser().parseFromString(str, options.contentType || 'application/xhtml+xml')
-    console.log(dom)
     return dom
   } else {
     if (typeof window !== 'undefined' && window.DOMParser) {
@@ -10824,7 +10823,7 @@ $rdf.parse = function parse (str, kb, base, contentType, callback) {
       executeCallback()
     } else if (contentType === 'application/rdf+xml') {
       var parser = new $rdf.RDFParser(kb)
-      parser.parse($rdf.Util.parseXML(str, {contentType: 'application/rdf+xml'}), base, kb.sym(base))
+      parser.parse($rdf.Util.parseXML(str), base, kb.sym(base))
       executeCallback()
     } else if (contentType === 'application/xhtml+xml') {
       $rdf.parseRDFaDOM($rdf.Util.parseXML(str, {contentType: 'application/xhtml+xml'}), kb, base)
@@ -11090,5 +11089,5 @@ if (typeof exports !== 'undefined') {
   // Leak a global regardless of module system
   root['$rdf'] = $rdf
 }
-$rdf.buildTime = "2016-05-10T18:00:41";
+$rdf.buildTime = "2016-05-11T17:28:02";
 })(this);

--- a/dist/rdflib.js
+++ b/dist/rdflib.js
@@ -19766,7 +19766,6 @@ $rdf.Util.parseXML = function (str, options) {
 
     var DOMParser = require('xmldom').DOMParser // 2015-08 on https://github.com/jindw/xmldom
     var dom = new DOMParser().parseFromString(str, options.contentType || 'application/xhtml+xml')
-    console.log(dom)
     return dom
   } else {
     if (typeof window !== 'undefined' && window.DOMParser) {
@@ -30219,7 +30218,7 @@ $rdf.parse = function parse (str, kb, base, contentType, callback) {
       executeCallback()
     } else if (contentType === 'application/rdf+xml') {
       var parser = new $rdf.RDFParser(kb)
-      parser.parse($rdf.Util.parseXML(str, {contentType: 'application/rdf+xml'}), base, kb.sym(base))
+      parser.parse($rdf.Util.parseXML(str), base, kb.sym(base))
       executeCallback()
     } else if (contentType === 'application/xhtml+xml') {
       $rdf.parseRDFaDOM($rdf.Util.parseXML(str, {contentType: 'application/xhtml+xml'}), kb, base)
@@ -30485,7 +30484,7 @@ if (typeof exports !== 'undefined') {
   // Leak a global regardless of module system
   root['$rdf'] = $rdf
 }
-$rdf.buildTime = "2016-05-10T18:00:41";
+$rdf.buildTime = "2016-05-11T17:28:02";
 })(this);
 
 },{"async":1,"jsonld":13,"n3":14,"xmldom":39,"xmlhttprequest":undefined}]},{},[])("rdflib")

--- a/util.js
+++ b/util.js
@@ -370,7 +370,6 @@ $rdf.Util.parseXML = function (str, options) {
 
     var DOMParser = require('xmldom').DOMParser // 2015-08 on https://github.com/jindw/xmldom
     var dom = new DOMParser().parseFromString(str, options.contentType || 'application/xhtml+xml')
-    console.log(dom)
     return dom
   } else {
     if (typeof window !== 'undefined' && window.DOMParser) {

--- a/web.js
+++ b/web.js
@@ -1571,7 +1571,7 @@ $rdf.parse = function parse (str, kb, base, contentType, callback) {
       executeCallback()
     } else if (contentType === 'application/rdf+xml') {
       var parser = new $rdf.RDFParser(kb)
-      parser.parse($rdf.Util.parseXML(str, {contentType: 'application/rdf+xml'}), base, kb.sym(base))
+      parser.parse($rdf.Util.parseXML(str), base, kb.sym(base))
       executeCallback()
     } else if (contentType === 'application/xhtml+xml') {
       $rdf.parseRDFaDOM($rdf.Util.parseXML(str, {contentType: 'application/xhtml+xml'}), kb, base)


### PR DESCRIPTION
Minor change that'll be important in the future. The current code actually ends up requiring xmldom's DOMParser for both Node and in the browser. application/rdf+xml works fine either way right now because internally it uses its own XMLReader. If/when the code gets restructured to use browser's native DOMParser, it will complain about application/rdf+xml not being a supportedType.