### PR TITLE
Implement kb.match() alias and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ writable:
 	@sed -i -re 's/git:\/\/github.com\//git@github.com:/' .git/config
 
 .PHONY: test
-test: # $(LIB)
+test:
 	@nodeunit tests/*.js
 	make -C tests/serialize
+	tape tests/unit/*.js
+	make cleantest

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",
     "minifyify": "^7.3.2",
-    "nodeunit": "^0.9.1"
+    "nodeunit": "^0.9.1",
+    "tape": "^4.6.0"
   },
   "scripts": {
     "test": "make test"

--- a/src/indexed-formula.js
+++ b/src/indexed-formula.js
@@ -264,6 +264,12 @@ class IndexedFormula extends Formula {
     return st
   }
 
+  addAll (statements) {
+    statements.forEach(quad => {
+      this.add(quad.subject, quad.predicate, quad.object, quad.graph)
+    })
+  }
+
   anyStatementMatching (subj, pred, obj, why) {
     var x = this.statementsMatching(subj, pred, obj, why, true)
     if (!x || x.length === 0) {
@@ -394,6 +400,25 @@ class IndexedFormula extends Formula {
 
   formula (features) {
     return new IndexedFormula(features)
+  }
+
+  /**
+   * Returns any quads matching the given arguments.
+   * Standard RDFJS Taskforce method for Source objects, implemented as an
+   * alias to `statementsMatching()`
+   * @method match
+   * @param subject {Node|String|Object}
+   * @param predicate {Node|String|Object}
+   * @param object {Node|String|Object}
+   * @param graph {NamedNode|String}
+   */
+  match (subject, predicate, object, graph) {
+    return this.statementsMatching(
+      Node.fromValue(subject),
+      Node.fromValue(predicate),
+      Node.fromValue(object),
+      Node.fromValue(graph)
+    )
   }
 
   /**

--- a/src/indexed-formula.js
+++ b/src/indexed-formula.js
@@ -403,6 +403,20 @@ class IndexedFormula extends Formula {
   }
 
   /**
+   * Returns the number of statements contained in this IndexedFormula.
+   * (Getter proxy to this.statements).
+   * Usage:
+   *    ```
+   *    var kb = rdf.graph()
+   *    kb.length  // -> 0
+   *    ```
+   * @return {Number}
+   */
+  get length () {
+    return this.statements.length
+  }
+
+  /**
    * Returns any quads matching the given arguments.
    * Standard RDFJS Taskforce method for Source objects, implemented as an
    * alias to `statementsMatching()`

--- a/src/node.js
+++ b/src/node.js
@@ -59,6 +59,7 @@ module.exports = Node
 Node.fromValue = function fromValue (value) {
   const Collection = require('./collection')
   const Literal = require('./literal')
+  const NamedNode = require('./named-node')
   if (value instanceof Node || value instanceof Collection) {
     return value
   }
@@ -67,6 +68,9 @@ Node.fromValue = function fromValue (value) {
   }
   if (Array.isArray(value)) {
     return new Collection(value)
+  }
+  if (typeof value === 'string' && value.includes('//')) {
+    return new NamedNode(value)
   }
   return Literal.fromValue(value)
 }

--- a/tests/unit/match-test.js
+++ b/tests/unit/match-test.js
@@ -1,0 +1,66 @@
+'use strict'
+const test = require('tape')
+const rdf = require('../../index')
+
+const s1 = rdf.namedNode('https://example.com/subject1')
+const p1 = rdf.namedNode('https://example.com/predicate1')
+const o1 = rdf.namedNode('https://example.com/object1')
+const triple1 = rdf.triple(s1, p1, o1)
+
+const s2 = rdf.namedNode('https://example.com/subject2')
+const p2 = rdf.namedNode('https://example.com/predicate2')
+const o2 = rdf.namedNode('https://example.com/object2')
+const triple2 = rdf.triple(s2, p2, o2)
+
+const s3 = rdf.namedNode('https://example.com/subject3')
+const p3 = rdf.namedNode('https://example.com/predicate3')
+const o3 = rdf.namedNode('https://example.com/object3')
+const triple3 = rdf.triple(s3, p3, o3)
+
+const triple4 = rdf.triple(s1, p2, o3)
+
+test('empty .match()', t => {
+  let kb = rdf.graph()
+  kb.addAll([ triple1, triple2, triple3 ])
+  let matches = kb.match()
+  t.equals(matches.length, 3, 'An empty .match() should return all triples')
+  t.end()
+})
+
+test('match on S', t => {
+  let kb = rdf.graph()
+  kb.addAll([ triple1, triple2, triple3, triple4 ])
+  let s = 'https://example.com/subject1'
+  let matches = kb.match(s)
+  t.equals(matches.length, 2, 'match(subject) should return 2 triples')
+  matches.sort()
+  t.equals(matches[0].subject, s1)
+  t.equals(matches[1].subject, s1)
+  t.end()
+})
+
+test('match on P', t => {
+  let kb = rdf.graph()
+  kb.addAll([ triple1, triple2, triple3, triple4 ])
+  let p = rdf.namedNode('https://example.com/predicate2')
+  let matches = kb.match(null, p)
+  t.equals(matches.length, 2, 'match(null, predicate) should return 2 triples')
+  matches.sort()
+  t.equals(matches[0].predicate, p2)
+  t.equals(matches[1].predicate, p2)
+  t.end()
+})
+
+test('match on SO', t => {
+  let kb = rdf.graph()
+  kb.addAll([ triple1, triple2, triple3, triple4 ])
+  let matches = kb.match(
+    'https://example.com/subject1',
+    null,
+    'https://example.com/object1'
+  )
+  t.equals(matches.length, 1, 'match(s, null, o) should return 1 triple')
+  t.equals(matches[0].subject, s1)
+  t.equals(matches[0].object, o1)
+  t.end()
+})

--- a/tests/unit/match-test.js
+++ b/tests/unit/match-test.js
@@ -22,6 +22,7 @@ const triple4 = rdf.triple(s1, p2, o3)
 test('empty .match()', t => {
   let kb = rdf.graph()
   kb.addAll([ triple1, triple2, triple3 ])
+  t.equals(kb.length, 3)
   let matches = kb.match()
   t.equals(matches.length, 3, 'An empty .match() should return all triples')
   t.end()


### PR DESCRIPTION
- Added `.addAll()` convenience method to IndexedFormula
- Added `.match()` method to IndexedFormula, to match the RDFJS TF specs.
  This is currently an alias for `statementsMatching()`.
- Added a `tests/unit/` folder for Tape unit tests

Partly addresses issue #137 