### PR TITLE
Removed dependency to global $rdf

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -37,6 +37,7 @@ const parseRDFaDOM = require('./rdfaparser').parseRDFaDOM
 const RDFParser = require('./rdfxmlparser')
 const Uri = require('./uri')
 const Util = require('./util')
+const serialize = require('./serialize')
 
 var Parsable = {
   'text/n3': true,
@@ -585,8 +586,8 @@ var Fetcher = function Fetcher (store, timeout, async) {
   //  Writes back to the web what we have in the store for this uri
   this.putBack = function (uri, options) {
     uri = uri.uri || uri // Accept object or string
-    var doc = $rdf.sym(uri).doc() // strip off #
-    options.data = $rdf.serialize(doc, this.store, doc.uri, options.contentType || 'text/turtle')
+    var doc = new NamedNode(uri).doc() // strip off #
+    options.data = serialize(doc, this.store, doc.uri, options.contentType || 'text/turtle')
     return this.webOperation('PUT', uri, options)
   }
 
@@ -863,7 +864,7 @@ var Fetcher = function Fetcher (store, timeout, async) {
         var h2 = h.toLowerCase()
         kb.add(response, ns.httph(h2), value, response)
         if (h2 === 'content-type') { // Convert to RDF type
-          kb.add(xhr.resource, ns.rdf('type'), $rdf.Util.mediaTypeClass(value), response)
+          kb.add(xhr.resource, ns.rdf('type'), Util.mediaTypeClass(value), response)
         }
       }
     }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -8,6 +8,7 @@
 */
 // @@@ Check the whole toStr thing tosee whetehr it still makes sense -- tbl
 const NamedNode = require('./named-node')
+const BlankNode = require('./blank-node')
 const Uri = require('./uri')
 const Util = require('./util')
 const XSD = require('./xsd')
@@ -308,7 +309,7 @@ var Serializer = function () {
       var list = x.elements
       var rest = kb.sym(rdfns + 'nill')
       for(var i = list.length - 1; i >= 0 ; i--){
-        var bnode = new $rdf.BlankNode()
+        var bnode = new BlankNode()
         str += termToNT(bnode) + ' ' + termToNT(kb.sym(rdfns + 'first')) + ' ' + termToNT(list[i]) + '.\n'
         str += termToNT(bnode) + ' ' + termToNT(kb.sym(rdfns + 'rest')) + ' ' + termToNT(rest) + '.\n'
         rest = bnode

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,7 @@
  */
 var docpart = require('./uri').docpart
 var log = require('./log')
+var NamedNode = require('./named-node')
 
 module.exports.AJAR_handleNewTerm = ajarHandleNewTerm
 module.exports.ArrayIndexOf = arrayIndexOf
@@ -27,7 +28,7 @@ module.exports.XMLHTTPFactory = xhr
 module.exports.log = log
 
 module.exports.mediaTypeClass = function(mediaType){
-  return $rdf.sym('http://www.w3.org/ns/iana/media-types/' + mediaType + '#Resource')
+  return new NamedNode('http://www.w3.org/ns/iana/media-types/' + mediaType + '#Resource')
 }
 
 /**


### PR DESCRIPTION
This is a rework of https://github.com/linkeddata/rdflib.js/pull/159
- it now **really** removes all references to the global $rdf, as I had originally intended
- I fumbled when working with GitHub and broke the link to the original PR

When including rdflib.js into a web application using webpack, the
resulting application doesn't run. The reason for this is that there are
references to the global $rdf object in modules which are initialized
before the global $rdf object has been properly initialized.

Removed all references to the global $rdf object and
replaced them by direct references to the underlying functionality.