### PR TITLE
Strip spaces and any params from media type when generating an RDF type

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -584,9 +584,8 @@ var Fetcher = function Fetcher (store, timeout, async) {
   // Returns promise of XHR
   //
   //  Writes back to the web what we have in the store for this uri
-  this.putBack = function (uri, options) {
+  this.putBack = function (uri, options = {}) {
     uri = uri.uri || uri // Accept object or string
-    options = options || {}
     var doc = new NamedNode(uri).doc() // strip off #
     options.data = serialize(doc, this.store, doc.uri, options.contentType || 'text/turtle')
     return this.webOperation('PUT', uri, options)
@@ -594,8 +593,8 @@ var Fetcher = function Fetcher (store, timeout, async) {
 
   // Returns promise of XHR
   //
-  this.webOperation = function (method, uri, options) {
-    uri = uri.uri || uri; options = options || {}
+  this.webOperation = function (method, uri, options = {}) {
+    uri = uri.uri || uri
     uri = this.proxyIfNecessary(uri)
     var fetcher = this
     return new Promise(function (resolve, reject) {

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -586,6 +586,7 @@ var Fetcher = function Fetcher (store, timeout, async) {
   //  Writes back to the web what we have in the store for this uri
   this.putBack = function (uri, options) {
     uri = uri.uri || uri // Accept object or string
+    options = options || {}
     var doc = new NamedNode(uri).doc() // strip off #
     options.data = serialize(doc, this.store, doc.uri, options.contentType || 'text/turtle')
     return this.webOperation('PUT', uri, options)

--- a/src/named-node.js
+++ b/src/named-node.js
@@ -15,7 +15,7 @@ class NamedNode extends Node {
     super()
     this.termType = NamedNode.termType
     if (!iri.includes(':')) {
-      throw new Error('NamedNode IRI "' + iri + '" must be absolute. Relative URIs will fail in future versions')
+      throw new Error('NamedNode IRI "' + iri + '" must be absolute.')
     }
     if (iri.includes(' ')) {
       var message = 'Error: NamedNode IRI "' + iri + '" must not contain unencoded spaces.'

--- a/src/named-node.js
+++ b/src/named-node.js
@@ -14,14 +14,12 @@ class NamedNode extends Node {
   constructor (iri) {
     super()
     this.termType = NamedNode.termType
-    if (iri.indexOf(':') < 0) {
-      console.log('Error: NamedNode IRI "' + iri + '" must be absolute. Relative URIs will fail in future versions')
+    if (!iri.includes(':')) {
+      throw new Error('NamedNode IRI "' + iri + '" must be absolute. Relative URIs will fail in future versions')
     }
-    if (iri.indexOf(' ') >= 0) {
+    if (iri.includes(' ')) {
       var message = 'Error: NamedNode IRI "' + iri + '" must not contain unencoded spaces.'
-      console.log(message)
-      // throw new Error(message)
-      iri = encodeURI(iri)
+      throw new Error(message)
     }
     this.value = iri
   }

--- a/src/named-node.js
+++ b/src/named-node.js
@@ -15,7 +15,13 @@ class NamedNode extends Node {
     super()
     this.termType = NamedNode.termType
     if (iri.indexOf(':') < 0) {
-      console.log('Warning: NamedNode IRI "' + iri + '" must be absolute. Relative URIs will fail in future versions')
+      console.log('Error: NamedNode IRI "' + iri + '" must be absolute. Relative URIs will fail in future versions')
+    }
+    if (iri.indexOf(' ') >= 0) {
+      var message = 'Error: NamedNode IRI "' + iri + '" must not contain unencoded spaces.'
+      console.log(message)
+      // throw new Error(message)
+      iri = encodeURI(iri)
     }
     this.value = iri
   }

--- a/src/parse.js
+++ b/src/parse.js
@@ -18,6 +18,7 @@ const Util = require('./util')
  * Hence the mess below with executeCallback.
  */
 function parse (str, kb, base, contentType, callback) {
+  contentType = contentType || 'text/turtle'
   try {
     if (contentType === 'text/n3' || contentType === 'text/turtle') {
       var p = N3Parser(kb, kb, base, base, null, null, '', null)

--- a/src/util.js
+++ b/src/util.js
@@ -29,6 +29,7 @@ module.exports.XMLHTTPFactory = xhr
 module.exports.log = log
 
 module.exports.mediaTypeClass = function(mediaType){
+  mediaType = mediaType.split(';')[0].trim()  // remove media type parameters
   return new NamedNode('http://www.w3.org/ns/iana/media-types/' + mediaType + '#Resource')
 }
 

--- a/tests/unit/named-node-test.js
+++ b/tests/unit/named-node-test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+import { expect } from 'chai'
+
+import NamedNode from '../../src/named-node'
+
+describe.only('NamedNode', () => {
+  describe('constructor()', () => {
+    it('should throw an error on spaces in the uri', () => {
+      expect(() => { new NamedNode('https://url with spaces') }).to.throw(Error)
+    })
+
+    it('should throw an error on relative uri', () => {
+      expect(() => { new NamedNode('./local') }).to.throw(Error)
+    })
+  })
+})


### PR DESCRIPTION
Strip spaces and any params from media type when generating an RDF type
Add content type default of turtle to rdf.parse