### PR TITLE
Update package.json engine to support node 7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "an RDF library for node.js. Suitable for client and server side.",
   "version": "0.14.0",
   "engines": {
-    "node": "^6.0"
+    "node": ">=6.0"
   },
   "private": false,
   "author": {


### PR DESCRIPTION
When `npm install` node-solid-server using node 7.6.0 (latest release is 7.7.2), I got the following error:

```
error rdflib@0.12.3: The engine "node" is incompatible with this module. Expected version "^6.0".
```

I believe this change would resolve. FWIW, this changes the engine string to match [that of node-solid-server](https://github.com/solid/node-solid-server/blob/master/package.json#L124)