### PR TITLE
Timbl downstream - avoid duplicate downstream actions for the same target

### DIFF
--- a/src/blank-node.js
+++ b/src/blank-node.js
@@ -7,12 +7,12 @@ class BlankNode extends Node {
     super()
     this.termType = BlankNode.termType
     if (id && (typeof id !== 'string')) {
-      throw "Bad id argument to new bkank node: " + id
+      throw new Error('Bad id argument to new blank node: ' + id)
     }
-    this.id = '' + BlankNode.nextId // Ignore param as not globally unique
-    BlankNode.nextId++
-    this.value = this.id // for API compatability
+    this.id = '' + BlankNode.nextId++  // Ignore param as not globally unique
+    this.value = id || this.id  // for API compatibility
   }
+
   compareTerm (other) {
     if (this.classOrder < other.classOrder) {
       return -1
@@ -28,18 +28,22 @@ class BlankNode extends Node {
     }
     return 0
   }
+
   copy (formula) { // depends on the formula
     var bnodeNew = new BlankNode()
     formula.copyTo(this, bnodeNew)
     return bnodeNew
   }
+
   toCanonical () {
     return '_:' + this.value
   }
+
   toString () {
     return BlankNode.NTAnonymousNodePrefix + this.id
   }
 }
+
 BlankNode.nextId = 0
 BlankNode.termType = 'BlankNode'
 BlankNode.NTAnonymousNodePrefix = '_:n'

--- a/src/blank-node.js
+++ b/src/blank-node.js
@@ -6,8 +6,12 @@ class BlankNode extends Node {
   constructor (id) {
     super()
     this.termType = BlankNode.termType
-    this.id = BlankNode.nextId++
-    this.value = id || this.id.toString()
+    if (id && (typeof id !== 'string')) {
+      throw "Bad id argument to new bkank node: " + id
+    }
+    this.id = '' + BlankNode.nextId // Ignore param as not globally unique
+    BlankNode.nextId++
+    this.value = this.id // for API compatability
   }
   compareTerm (other) {
     if (this.classOrder < other.classOrder) {

--- a/src/blank-node.js
+++ b/src/blank-node.js
@@ -6,10 +6,23 @@ class BlankNode extends Node {
   constructor (id) {
     super()
     this.termType = BlankNode.termType
-    if (id && (typeof id !== 'string')) {
-      throw new Error('Bad id argument to new blank node: ' + id)
+
+    if (id) {
+      if (typeof id !== 'string') {
+        console.log('Bad blank id:', id)
+        throw new Error('Bad id argument to new blank node: ' + id)
+      }
+      if (id.includes('#')) {
+        // Is a URI with hash fragment
+        let fragments = id.split('#')
+        id = fragments[fragments.length - 1]
+      }
+      // this.id = id
+      this.id = '' + BlankNode.nextId++
+    } else {
+      this.id = '' + BlankNode.nextId++
     }
-    this.id = id || '' + BlankNode.nextId++
+
     this.value = this.id
   }
 

--- a/src/blank-node.js
+++ b/src/blank-node.js
@@ -9,8 +9,8 @@ class BlankNode extends Node {
     if (id && (typeof id !== 'string')) {
       throw new Error('Bad id argument to new blank node: ' + id)
     }
-    this.id = '' + BlankNode.nextId++  // Ignore param as not globally unique
-    this.value = id || this.id  // for API compatibility
+    this.id = id || '' + BlankNode.nextId++
+    this.value = this.id
   }
 
   compareTerm (other) {

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1097,7 +1097,10 @@ var Fetcher = function Fetcher (store, timeout, async) {
             return
           }
 
-          var loc = xhr.headers['content-location']
+          var loc =  xhr.headers['content-location']
+          if (loc) {
+            loc = Uri.join(loc, docuri)
+          }
 
           // deduce some things from the HTTP transaction
           var addType = function (cla) { // add type to all redirected resources too

--- a/src/n3parser.js
+++ b/src/n3parser.js
@@ -655,7 +655,8 @@ __SinkParser.prototype.anonymousNode = function(ln) {
     if (term) {
         return term;
     }
-    var term = this._store.bnode(this._context, this._reason2);
+    var term = this._store.bnode(ln);
+    // var term = this._store.bnode(this._context, this._reason2); eh?
     this._anonymousNodes[ln] = ( term);
     return term;
 };

--- a/src/query.js
+++ b/src/query.js
@@ -399,17 +399,6 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
           match(f, g, bindingsSoFar, level, fetcher, // match not match2 to look up any others necessary.
             localCallback, branch)
         })
-      /*
-      if( sf ) {
-          sf.addCallback('done', function(uri) {
-              if ((kb.canon(kb.sym(uri)).uri !== path) && (uri !== kb.canon(kb.sym(path)))) {
-                  return true
-              }
-              return false
-          })
-      }
-      fetcher(requestedTerm, id)
-      */
       }
       for (i = 0; i < n; i++) {
         item = pattern[i] // for each of the triples in the query

--- a/src/update-manager.js
+++ b/src/update-manager.js
@@ -403,7 +403,7 @@ var UpdateManager = (function () {
       action(doc)
     } else {
       if (control.downstreamAction) {
-        if (control.downstreamAction === action) {
+        if ('' + control.downstreamAction === '' + action) { // @@@ Kludge comapre!!
           return
         } else {
           throw new Error("Can't wait for > 1 differnt downstream actions")

--- a/tests/serialize/t13-ref.ttl
+++ b/tests/serialize/t13-ref.ttl
@@ -34,14 +34,16 @@ str:ZooReading1
     str:time "2015-03-16T17:53Z"^^XML:dateTime.
 _:n5 str:name "Coretta Scott King".
 
-[ str:loves [] ].
-
 [
     a str:Speech;
     str:author str:MLK;
     str:date "1963-08-23"^^XML:date;
     str:title "I have a dream"
 ].
+[ str:friend str:MLK ].
+
+[ str:loves [] ].
+
 [
     a str:Marriage;
     str:offspring
@@ -64,5 +66,3 @@ _:n5 str:name "Coretta Scott King".
             ];
     str:spouse str:MLK, _:n5
 ].
-[ str:friend str:MLK ].
-


### PR DESCRIPTION
The code to do this used to compare two functions using (fa === fb)   but that doesn't work as they are in fact different equivalent functions (or maybe function comparison is not a thing) .  So now it makes strings for each one, and compares those.  This is a kludge.

Alternatives include making an action not a function at all, but make it an object like { action: "Refresh"; target: myTable }  so the actions are declarative (generally better but less extensible).
 