### PR TITLE
Typed node elements

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -786,7 +786,7 @@ var Serializer = (function () {
       for (var i = 0; i < sts.length; i++) {
         st = sts[i]
         // look for a type
-        if (st.predicate.uri === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' && !type && st.object.termType === 'symbol') {
+        if (st.predicate.uri === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' && !type && st.object.termType === 'NamedNode') {
           type = st.object
           continue // don't include it as a child element
         }

--- a/tests/serialize/t11-ref.xml
+++ b/tests/serialize/t11-ref.xml
@@ -13,7 +13,7 @@
     <rdf:Description rdf:nodeID="_g_L4C88">
        <str:name>Coretta Scott King</str:name>
     </rdf:Description>
-    <rdf:Description rdf:nodeID="_g_L6C140">
+    <str:Marriage rdf:nodeID="_g_L6C140">
         <str:offspring rdf:parseType="Collection">
                 <rdf:Description rdf:about="/structures.n3#MLK3">
                    <str:name>Martin Luther King III</str:name>
@@ -30,8 +30,7 @@
         </str:offspring>
         <str:spouse rdf:resource="/structures.n3#MLK"/>
         <str:spouse rdf:nodeID="_g_L4C88"/>
-        <rdf:type rdf:resource="/structures.n3#Marriage"/>
-    </rdf:Description>
+    </str:Marriage>
     <rdf:Description rdf:about="/structures.n3#MLK3">
        <str:name>Martin Luther King III</str:name>
     </rdf:Description>
@@ -47,12 +46,11 @@
     <rdf:Description rdf:nodeID="_g_L22C530">
        <str:loves rdf:parseType="Resource"></str:loves>
     </rdf:Description>
-    <rdf:Description rdf:nodeID="_g_L24C602">
+    <str:Speech rdf:nodeID="_g_L24C602">
         <str:author rdf:resource="/structures.n3#MLK"/>
         <str:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1963-08-23</str:date>
         <str:title>I have a dream</str:title>
-        <rdf:type rdf:resource="/structures.n3#Speech"/>
-    </rdf:Description>
+    </str:Speech>
     <rdf:Description rdf:about="/structures.n3#ZooReading1">
         <str:boolDisabled rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">0</str:boolDisabled>
         <str:boolEnabled rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">1</str:boolEnabled>


### PR DESCRIPTION
See issue #215 

When searching for type of a resource, 'NamedNode' termType is checked instead of 'symbol'.