### PR TITLE
Use child nodes of literal DOM instead of itself (#75)

### DIFF
--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -329,7 +329,7 @@ var RDFParser = function (store) {
               frame.datatype = RDFParser.ns.RDF + 'XMLLiteral' // (this.buildFrame(frame)).addLiteral(dom)
               // should work but doesn't
               frame = this.buildFrame(frame)
-              frame.addLiteral(dom)
+              frame.addLiteral(dom.childNodes)
               dig = false
             } else if (nv === 'Resource') {
               frame = this.buildFrame(frame, frame.element)


### PR DESCRIPTION
This is an alternative fix for the issue #75. Adding dom itself as a literal value is definitely an error since it contains literal definition tag with all its properties.
