### PR TITLE
Fix to issue#75 parseType Literal only includes child nodes

### DIFF
--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -326,10 +326,10 @@ var RDFParser = function (store) {
           if (parsetype) {
             var nv = parsetype.nodeValue
             if (nv === 'Literal') {
-              frame.datatype = RDFParser.ns.RDF + 'XMLLiteral' // (this.buildFrame(frame)).addLiteral(dom)
-              // should work but doesn't
+              frame.datatype = RDFParser.ns.RDF + 'XMLLiteral' 
               frame = this.buildFrame(frame)
-              frame.addLiteral(dom)
+              // Don't include the literal node, only its children
+              frame.addLiteral(dom.childNodes)
               dig = false
             } else if (nv === 'Resource') {
               frame = this.buildFrame(frame, frame.element)


### PR DESCRIPTION
RDF/XLM elements with parseType=Literal should not include the RDF/ XML property, only its value in the resulting XML source.