### PR TITLE
Egp fix timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:serialize:12": "cd ./tests/serialize && node ./data.js -in=structures.n3 -format=text/turtle -out=,structures.ttl && node diff ,structures.ttl t12-ref.ttl",
     "test:serialize:13": "cd ./tests/serialize && node ./data.js -in=structures.n3 -format=application/n-triples -out=,structures.nt && node ./data.js -format=application/n-triples -in=,structures.nt -format=text/turtle -out=,structures.nt.ttl && node diff ,structures.nt.ttl t13-ref.ttl",
     "test:unit": "mocha --growl --require babel-register tests/unit/**-test.js",
+    "test:unit:egp": "mocha --require babel-register tests/unit/fetcher-egp-test.js",
     "test:unit:dev": "mocha --watch --growl --require babel-register tests/unit/**-test.js"
   },
   "files": [

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -453,6 +453,7 @@ class Fetcher {
     //   'unsupported_protocol'  URI is not a protocol Fetcher can deal with
     //   other strings mean various other errors.
     //
+    this.timeouts = {}; // list of timeouts associated with a requested URL
     this.redirectedTo = {} // When 'redirected'
     this.fetchQueue = {}
     this.fetchCallbacks = {} // fetchCallbacks[uri].push(callback)
@@ -671,10 +672,14 @@ class Fetcher {
       this.cleanupFetchRequest(originalUri, options, this.timeout)
     }
 
-    return pendingPromise
+    return pendingPromise.then(x => {
+      clearTimeout(this.timeouts[uri]);
+      return x;
+    })
   }
 
   cleanupFetchRequest (originalUri, options, timeout) {
+    return;
     setTimeout(() => {
       if (!this.isPending(originalUri)) {
         delete this.fetchQueue[originalUri]
@@ -1543,7 +1548,7 @@ class Fetcher {
 
   setRequestTimeout (uri, options) {
     return new Promise((resolve) => {
-      setTimeout(() => {
+      this.timeouts[uri] = setTimeout(() => {
         if (this.isPending(uri) &&
             !options.retriedWithNoCredentials &&
             !options.proxyUsed) {

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -786,7 +786,21 @@ class Fetcher {
 
     return this._fetch(actualProxyURI, options)
       .then(response => this.handleResponse(response, docuri, options))
-      .catch(error => this.handleError(error, docuri, options))
+      .catch(
+        error =>
+          // handleError expects a response so we fake some important bits.
+          this.handleError({
+            url: actualProxyURI,
+            status: -1,
+            statusText: 'network failure: ' + (error.errno || error.code || -1),
+            headers: Headers(),
+            ok: false,
+            body: null,
+            bodyUsed: false,
+            size: 0,
+            timeout: 0
+          }, docuri, options)
+      )
   }
 
   /**

--- a/tests/unit/fetcher-egp-test.js
+++ b/tests/unit/fetcher-egp-test.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+'use strict'
+
+import chai from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import dirtyChai from 'dirty-chai'
+import nock from 'nock'
+import rdf from '../../src/index'
+
+chai.use(sinonChai)
+chai.use(dirtyChai)
+const { expect } = chai
+chai.should()
+
+const { Fetcher, BlankNode } = rdf
+
+describe('Fetcher', () => {
+  describe('nowOrWhenFetched', () => {
+    let fetcher, docuri, rterm, options, userCallback
+
+    it('should invoke userCallback with caught error', done => {
+nock('http://localhost')
+  // .persist() // 
+  .get('/asdf')
+  .reply(200, '<html></html>', {'Content-type': 'text/html'})
+;
+// require('node-fetch')(uri).then(handle);
+let kb = rdf.graph();
+let fetcher = rdf.fetcher(kb, {a:1})
+const uri = 'http://localhost/asdf'
+  fetcher.nowOrWhenFetched(kb.sym(uri), {force: true}, function (ok, status, resp) {
+    if (ok)
+      console.dir(resp.status + ' ' + resp.statusText + ' ' + resp.responseText.length + ' characters')
+    else
+      console.log("Failed: " + status + ", status: " + resp.error)
+    if (ok)
+      done();
+    return 7;
+  })
+    })
+
+  })
+
+})

--- a/tests/unit/fetcher-egp-test.js
+++ b/tests/unit/fetcher-egp-test.js
@@ -7,6 +7,11 @@ import rdf from '../../src/index'
 
 const { expect } = chai
 chai.should()
+// get rid of @@ console logs
+const noLog = () => undefined
+// console.log = noLog
+// console.warn = noLog
+const oldConsoleLog = console.log
 
 describe('Fetcher', () => {
   describe('nowOrWhenFetched', () => {
@@ -16,13 +21,18 @@ describe('Fetcher', () => {
     it('should handle 200', done => {
       let path = '/200'
       const bodyText = '<html></html>'
-      nock(goodServer)
+      let c = nock(goodServer)
         .get(path)
         .reply(200, bodyText, {'Content-type': 'text/html'})
       ;
+      console.log(c);
+      c.on('request', function () { console.log(arguments); })
+      c.on('replied', function () { console.log(arguments); })
       let kb = rdf.graph();
+      console.log = noLog
       let fetcher = rdf.fetcher(kb, {a:1})
       fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, function (ok, status, resp) {
+        console.log = oldConsoleLog;
         expect(ok).to.be.true;
         expect(status).to.equal(200);
         expect(resp.responseText.length).to.equal(bodyText.length)

--- a/tests/unit/fetcher-egp-test.js
+++ b/tests/unit/fetcher-egp-test.js
@@ -16,15 +16,14 @@ describe('Fetcher', () => {
     it('should handle 200', done => {
       let path = '/200'
       const bodyText = '<html></html>'
-      let c = nock(goodServer)
-        .get(path)
-        .reply(200, bodyText, {'Content-type': 'text/html'})
-      ;
+      let c = nock(goodServer).get(path)
+          .reply(200, bodyText, {'Content-type': 'text/html'})
+
       let kb = rdf.graph();
       let fetcher = rdf.fetcher(kb, {a:1})
-      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, status, resp) {
-        expect(ok).to.be.true;
-        expect(status).to.equal(200);
+      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, statusOrErrorText, resp) {
+        expect(ok).to.be.true
+        expect(statusOrErrorText).to.equal(200)
         expect(resp.responseText.length).to.equal(bodyText.length)
       }))
     })
@@ -32,15 +31,13 @@ describe('Fetcher', () => {
     it('should handle 404', done => {
       let path = '/404'
       const bodyText = '<html></html>'
-      nock(goodServer)
-        .get(path)
-        .reply(404)
-      ;
+      nock(goodServer).get(path).reply(404)
+
       let kb = rdf.graph();
       let fetcher = rdf.fetcher(kb, {a:1})
-      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, status, resp) {
-        expect(ok).to.be.false;
-        expect(status).to.equal(404);
+      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, statusOrErrorText, resp) {
+        expect(ok).to.be.false
+        expect(statusOrErrorText).to.include(404)
         expect(resp.error).to.match(/404/)
       }))
     })
@@ -48,15 +45,11 @@ describe('Fetcher', () => {
     it('should handle dns error', done => {
       let path = '/200'
       const bodyText = '<html></html>'
-      nock(goodServer)
-        .get(path)
-        .reply(404)
-      ;
       let kb = rdf.graph();
       let fetcher = rdf.fetcher(kb, {a:1})
-      fetcher.nowOrWhenFetched(kb.sym(badServer + path), {force: true}, trywrap(done, function (ok, status, resp) {
-        expect(ok).to.be.false;
-        expect(status).to.equal(-1);
+      fetcher.nowOrWhenFetched(kb.sym(badServer + path), {force: true}, trywrap(done, function (ok, statusOrErrorText, resp) {
+        expect(ok).to.be.false
+        expect(statusOrErrorText).to.include(999);
         expect(resp.error).to.match(/ENOTFOUND/)
       }))
     })
@@ -64,19 +57,16 @@ describe('Fetcher', () => {
     it('should handle nock failure', done => {
       let path = '/200'
       const bodyText = '<html></html>'
-      nock(goodServer)
-        .get(path)
-        .reply(404)
-      ;
+      nock(goodServer).get(path).reply(404)
 
       // Use up the nock path (note no .persistent() on nock).
       require('node-fetch')(goodServer + path).then(() => null);
       let kb = rdf.graph();
       let fetcher = rdf.fetcher(kb, {a:1})
-      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, status, resp) {
+      fetcher.nowOrWhenFetched(kb.sym(goodServer + path), {force: true}, trywrap(done, function (ok, statusOrErrorText, resp) {
         expect(ok).to.be.false;
-        expect(status).to.equal(404);
-        expect(resp.error).to.match(/404/)
+        expect(statusOrErrorText).to.match(/Nock: No match for request/);
+        expect(resp.status).to.equal(999)
       }))
     })
 


### PR DESCRIPTION
optimal path through fetch interface left two timeouts (30s) which kept node.js apps from returning