### PR TITLE
Allow query() functionality to test for the quad not just the triple.

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1052,8 +1052,8 @@ class Fetcher {
   putBack (uri, options = {}) {
     uri = uri.uri || uri // Accept object or string
     let doc = new NamedNode(uri).doc() // strip off #
-    options.data = serialize(doc, this.store, doc.uri,
-      options.contentType || 'text/turtle')
+    options.contentType = options.contentType || 'text/turtle'
+    options.data = serialize(doc, this.store, doc.uri, options.contentType)
     return this.webOperation('PUT', uri, options)
   }
 
@@ -1156,7 +1156,9 @@ class Fetcher {
           if (response.statusText) msg += ' (' + response.statusText + ')'
           msg += ' on ' + method + ' of <' + uri + '>'
           if (response.responseText) msg += ': ' + response.responseText
-          reject(new Error(msg))
+          let e2 = new Error(msg)
+          e2.response = response
+          reject(e2)
         }
       }, err => {
         let msg = 'Fetch error for ' + method + ' of <' + uri + '>:' + err
@@ -1256,7 +1258,7 @@ class Fetcher {
 
     let responseNode = kb.bnode()
 
-    kb.add(options.req, ns.link('response'), responseNode)
+    kb.add(options.req, ns.link('response'), responseNode, responseNode)
     kb.add(responseNode, ns.http('status'),
       kb.literal(response.status), responseNode)
     kb.add(responseNode, ns.http('statusText'),
@@ -1587,7 +1589,6 @@ class Fetcher {
     }
 
     let contentType = headers.get('content-type')
-
     if (!contentType || contentType.includes('application/octet-stream')) {
       let guess = this.guessContentType(options.resource.uri)
 

--- a/src/indexed-formula.js
+++ b/src/indexed-formula.js
@@ -22,6 +22,8 @@ const Node = require('./node')
 const Variable = require('./variable')
 
 const owl_ns = 'http://www.w3.org/2002/07/owl#'
+
+const defaultGraphURI = 'chrome:theSession'
 // var link_ns = 'http://www.w3.org/2007/ont/link#'
 
 // Handle Functional Property
@@ -90,6 +92,10 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
       'FunctionalProperty'
     ]
     this.initPropertyActions(this.features)
+  }
+
+  static get defaultGraphURI() {
+   return defaultGraphURI;
   }
 
   substitute (bindings) {
@@ -254,7 +260,7 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
     var st
     if (!why) {
       // system generated
-      why = this.fetcher ? this.fetcher.appNode : this.sym('chrome:theSession')
+      why = this.fetcher ? this.fetcher.appNode : this.sym(defaultGraphURI)
     }
     subj = Node.fromValue(subj)
     pred = Node.fromValue(pred)

--- a/src/node.js
+++ b/src/node.js
@@ -73,3 +73,25 @@ Node.fromValue = function fromValue (value) {
   }
   return Literal.fromValue(value)
 }
+
+Node.toJS = function fromJS (term) {
+  if (term.elements) {
+    return term.elements.map(Node.toJS) // Array node (not standard RDFJS)
+  }
+  if (!term.datatype) return term // Objects remain objects
+  if (term.datatype.equals(ns.xsd('boolean'))) {
+    return term.value === '1'
+  }
+  if (term.datatype.equals(ns.xsd('dateTime')) ||
+    term.datatype.equals(ns.xsd('date'))) {
+    return new Date(term.value)
+  }
+  if (
+    term.datatype.equals(ns.xsd('integer')) ||
+    term.datatype.equals(ns.xsd('float')) ||
+    term.datatype.equals(ns.xsd('decimal'))
+  ) {
+    return Number(term.value)
+  }
+  return term.value
+}

--- a/src/query.js
+++ b/src/query.js
@@ -21,7 +21,7 @@ import IndexedFormula from './indexed-formula'
 const log = require('./log')
 const docpart = require('./uri').docpart
 
-const defaultDocumentURI = 'chrome:theSession'
+const defaultDocumentURI = IndexedFormula.defaultGraphURI
 /**
  * Query class, for tracking queries the user has in the UI.
  */

--- a/src/query.js
+++ b/src/query.js
@@ -301,9 +301,9 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
     //    log.debug("Prepare: f has "+ f.statements.length)
     // log.debug("Prepare: Kb size "+f.statements.length+" Preparing "+item)
 
-    terms = [item.subject, item.predicate, item.object, items.why]
+    terms = [item.subject, item.predicate, item.object, item.why]
     ind = [f.subjectIndex, f.predicateIndex, f.objectIndex, f.whyIndex]
-    for (i = 0; i < 3; i++) {
+    for (i = 0; i < 4; i++) {
       // alert("Prepare "+terms[i]+" "+(terms[i] in bindings))
       if (terms[i].isVar && !(bindings[terms[i]] !== undefined)) {
         item.nvars++

--- a/src/query.js
+++ b/src/query.js
@@ -21,6 +21,7 @@ import IndexedFormula from './indexed-formula'
 const log = require('./log')
 const docpart = require('./uri').docpart
 
+const defaultDocumentURI = 'chrome:theSession'
 /**
  * Query class, for tracking queries the user has in the UI.
  */
@@ -104,7 +105,7 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
       if (formula.redirections[other]) {
         other = formula.redirections[other]
       }
-      if (actual.sameTerm(other)) {
+      if (actual.sameTerm(other) || (actual.uri && actual.uri === defaultDocumentURI)) { // Used to mean 'any graph' in a query
         return [[ [], null ]]
       }
       return []
@@ -291,10 +292,10 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
   /** prepare -- sets the index of the item to the possible matches
       * @param f - formula
       * @param item - an Statement, possibly w/ vars in it
-      * @param bindings -
-  * @returns true if the query fails -- there are no items that match **/
+      * @param bindings - Bindings so far
+  * @returns false if the query fails -- there are no items that match **/
   var prepare = function (f, item, bindings) {
-    var t, terms, termIndex, i, ind
+    var terms, termIndex, i, ind
     item.nvars = 0
     item.index = null
     // if (!f.statements) log.warn("@@@ prepare: f is "+f)
@@ -304,8 +305,11 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
     terms = [item.subject, item.predicate, item.object, item.why]
     ind = [f.subjectIndex, f.predicateIndex, f.objectIndex, f.whyIndex]
     for (i = 0; i < 4; i++) {
-      // alert("Prepare "+terms[i]+" "+(terms[i] in bindings))
-      if (terms[i].isVar && !(bindings[terms[i]] !== undefined)) {
+      let t = terms[i]
+      // console.log("  Prepare (" + t + ") "+(t in bindings))
+      if (t.uri && t.uri === defaultDocumentURI) { // chrome:session
+        // console.log('     query: Ignoring slot ' + i)
+      } else if (t.isVar && !(bindings[t] !== undefined)) {
         item.nvars++
       } else {
         t = bind(terms[i], bindings) // returns the RDF binding if bound, otherwise itself
@@ -319,13 +323,13 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
           item.index = []
           return false // Query line cannot match
         }
-        if ((item.index === null) || (item.index.length > termIndex.length)) {
+        if ((item.index === null) || (item.index.length > termIndex.length)) { // Find smallest index
           item.index = termIndex
         }
       }
     }
 
-    if (item.index === null) { // All 3 are variables?
+    if (item.index === null) { // All 4 are variables?
       item.index = f.statements
     }
     return true
@@ -451,8 +455,9 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
     var item
     for (i = 0; i < n; i++) { // For each statement left in the query, run prepare
       item = pattern[i]
-      log.info('match2: item=' + item + ', bindingsSoFar=' + bindingDebug(bindingsSoFar))
+      // log.info('match2: item=' + item + ', bindingsSoFar=' + bindingDebug(bindingsSoFar))
       prepare(f, item, bindingsSoFar)
+      // if (item.index) console.log('     item.index.length ' + item.index.length)
     }
     pattern.sort(easiestQuery)
     item = pattern[0]
@@ -473,8 +478,8 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
     for (c = 0; c < nc; c++) { // For each candidate statement
       st = item.index[c] // for each statement in the item's index, spawn a new match with that binding
       nbs1 = unifyContents(
-        [item.subject, item.predicate, item.object],
-        [st.subject, st.predicate, st.object], bindingsSoFar, f)
+        [item.subject, item.predicate, item.object, item.why],
+        [st.subject, st.predicate, st.object, st.why], bindingsSoFar, f)
       log.info(level + ' From first: ' + nbs1.length + ': ' + bindingsDebug(nbs1))
       nk = nbs1.length
       // branch.count += nk

--- a/src/query.js
+++ b/src/query.js
@@ -301,8 +301,8 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
     //    log.debug("Prepare: f has "+ f.statements.length)
     // log.debug("Prepare: Kb size "+f.statements.length+" Preparing "+item)
 
-    terms = [item.subject, item.predicate, item.object]
-    ind = [f.subjectIndex, f.predicateIndex, f.objectIndex]
+    terms = [item.subject, item.predicate, item.object, items.why]
+    ind = [f.subjectIndex, f.predicateIndex, f.objectIndex, f.whyIndex]
     for (i = 0; i < 3; i++) {
       // alert("Prepare "+terms[i]+" "+(terms[i] in bindings))
       if (terms[i].isVar && !(bindings[terms[i]] !== undefined)) {

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -453,7 +453,11 @@ var Serializer = (function () {
       case 'Variable':
         return expr.toNT()
       case 'Literal':
-        var val = expr.value.toString() // should be a string already
+        var val = expr.value
+        if (typeof val !== 'string') {
+          throw new TypeError('Value of RDF literal node must be a string')
+        }
+        // var val = expr.value.toString() // should be a string already
         if (expr.datatype && this.flags.indexOf('x') < 0) { // Supress native numbers
           switch (expr.datatype.uri) {
 
@@ -470,7 +474,7 @@ var Serializer = (function () {
               return val
 
             case 'http://www.w3.org/2001/XMLSchema#boolean':
-              return expr.value ? 'true' : 'false'
+              return expr.value === '1' ? 'true' : 'false'
           }
         }
         var str = this.stringToN3(expr.value)

--- a/tests/serialize/t12-ref.ttl
+++ b/tests/serialize/t12-ref.ttl
@@ -15,7 +15,7 @@
 :YK :name "Yolanda King".
 
 :ZooReading1
-    :boolDisabled true;
+    :boolDisabled false;
     :boolEnabled true;
     :date "2015-02-28"^^XML:date;
     :decBig 1234567890.99;

--- a/tests/serialize/t13-ref.ttl
+++ b/tests/serialize/t13-ref.ttl
@@ -17,7 +17,7 @@ str:MLK3 str:name "Martin Luther King III".
 str:YK str:name "Yolanda King".
 
 str:ZooReading1
-    str:boolDisabled true;
+    str:boolDisabled false;
     str:boolEnabled true;
     str:date "2015-02-28"^^XML:date;
     str:decBig 1234567890.99;

--- a/tests/unit/query-test.js
+++ b/tests/unit/query-test.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+'use strict'
+
+import chai from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import dirtyChai from 'dirty-chai'
+import nock from 'nock'
+import rdf from '../../src/index'
+
+chai.use(sinonChai)
+chai.use(dirtyChai)
+const { expect } = chai
+chai.should()
+
+const { IndexedFormula, NamedNode, BlankNode, Variable } = rdf
+
+describe('Query', () => {
+  after(() => {
+    BlankNode.nextId = 0
+  })
+
+  describe('basic queries', () => {
+    let options, userCallback, doneCallback
+
+    const x = new Variable('x')
+    // const y = new Variable('y')
+    // const z = new Variable('z')
+    // const w = new Variable('w')
+
+    const knows = rdf.sym('http://xmlns.com/foaf/0.1/knows')
+    const age = rdf.sym('http://xmlns.com/foaf/0.1/age')
+
+    const alice = NamedNode.fromValue('https://example.com/alice#i')
+    const aliceDoc = NamedNode.fromValue('https://example.com/alice')
+    const bob = NamedNode.fromValue('https://example.com/bob#me')
+    const bobDoc = bob.doc()
+
+    const kb = rdf.graph()
+
+    // Alice's profile asserts she is 21 qnd she knows Bob
+    kb.add(alice, age, 21, aliceDoc)
+    kb.add(alice, knows, bob, aliceDoc)
+
+    // Bob's profile asserts Alice 25 and they know each other
+    kb.add(alice, age, 25, bobDoc)
+    kb.add(bob, age, 30, bobDoc)
+    kb.add(bob, knows, alice, bobDoc)
+    kb.add(alice, knows, bob, bobDoc)
+
+    beforeEach(() => {
+      options = {}
+      userCallback = (bindings) => {}
+    })
+
+    it('should find a value only in the given document ', done => {
+      var result = null
+
+      var query = new rdf.Query()
+      query.pat.add(rdf.st(alice, age, x, aliceDoc))
+
+      kb.query(query, (bindings) => {
+        // console.log('bindings', bindings)
+        expect(bindings['?x'].value).to.equal('21') // Should only get Alice's documents value
+        result = bindings['?x'].value
+        //done()
+      }, null, () => { // fetcher, done callback
+        expect(result).to.equal('21')
+        done()
+      })
+    })
+
+    it('should find a value only in the given document 2 ', done => {
+      var result = null
+
+      var query = new rdf.Query()
+      query.pat.add(rdf.st(alice, age, x, bobDoc))
+
+      kb.query(query, (bindings) => {
+        console.log('bindings', bindings)
+        expect(bindings['?x'].value).to.equal('25') // Should only get Alice's documents value
+        result = bindings['?x'].value
+        //done()
+      }, null, () => { // fetcher, done callback
+        expect(result).to.equal('25')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
The query() system only worked a triple store not a quad store: if you put a specific value in for the graph (.why) or a variable, it was ignored.  This branch fixes that.  Note that IndexFormula, when you do not specify a graph, adds a default of <chrome:session>.   This acts then as a wildcard when it turns up in a query pattern graph position.

There had been no tests on the query() function. Added 9 basic ones to test particularly around this issue.
