### PR TITLE
Don't pack Node's webcrypto, use browser's crypto instead

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
   },
   externals: {
     'node-fetch': 'fetch',
-    'xmldom': 'window'
+    'xmldom': 'window',
+    '@trust/webcrypto': 'crypto'
   },
   devtool: 'source-map',
   plugins: [


### PR DESCRIPTION
When using webpack to compile a browser version, we shouldn't rely on Node's `@trust/webcrypto`'s module. Instead, we can use the browser's implementation through the `crypto` object.