### PR TITLE
Allow falsy targets to be passed to the serializer

### DIFF
--- a/src/serialize.js
+++ b/src/serialize.js
@@ -9,7 +9,7 @@ const Serializer = require('./serializer')
  * through mutiple conversions.
  */
 function serialize (target, kb, base, contentType, callback, options) {
-  base = base || target.uri
+  base = base || (target ? target.uri : null)
   options = options || {}
   contentType = contentType || 'text/turtle' // text/n3 if complex?
   var documentString = null


### PR DESCRIPTION
While updating rdflib from `0.12.x` to `0.17.x` in [solid-permissions](https://github.com/solid/solid-permissions/), I noticed that a bunch of unit tests in solid-permissions fail with the following error:
```
(node:12527) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'uri' of null
    at Object.serialize (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/node_modules/rdflib/lib/serialize.js:14:25)
    at Promise (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/src/permission-set.js:807:11)
    at new Promise (<anonymous>)
    at PermissionSet.serialize (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/src/permission-set.js:806:12)
    at Test.<anonymous> (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/test/unit/permission-set-test.js:245:13)
    at Test.bound [as _cb] (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/node_modules/tape/lib/test.js:76:32)
    at Test.run (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/node_modules/tape/lib/test.js:95:10)
    at Test.bound [as run] (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/node_modules/tape/lib/test.js:76:32)
    at Immediate.next [as _onImmediate] (/Users/rtaelman/Documents/UGent/nosync/solid/solid-permissions/node_modules/tape/lib/results.js:71:15)
    at runCallback (timers.js:810:20)
```

This crash occurs because the `serialize.js` assumes that `target` is defined, while solid-permissions sometimes passes `null`. Not sure who is at fault here, but in this PR I assume that rdflib should accept falsy `target` values.

With this change, all unit tests from solid-permissions pass on rdflib 0.17.x.