### PR TITLE
Fix prefixed namespaces not working beyond rdf

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -68,8 +68,8 @@ var Serializer = (function () {
   __Serializer.prototype.suggestNamespaces = function (namespaces) {
     for (var px in namespaces) {
       this.suggestPrefix(px, namespaces[px])
-      return this
     }
+    return this
   }
 
   __Serializer.prototype.checkIntegrity = function () {


### PR DESCRIPTION
The suggestNamespaces function was just prefixing "RDF" because it's the default one, and quitting on the first result due to a incorrectly placed return.