### PR TITLE
repairs to 'Literals' in browser [linkeddata/rdflib.js#75]

### DIFF
--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -329,7 +329,8 @@ var RDFParser = function (store) {
               frame.datatype = RDFParser.ns.RDF + 'XMLLiteral'
               frame = this.buildFrame(frame)
               // Don't include the literal node, only its children
-              frame.addLiteral(dom.childNodes)
+              //frame.addLiteral(dom.childNodes);
+              frame.addLiteral(dom.innerHTML || dom.childNodes);
               dig = false
             } else if (nv === 'Resource') {
               frame = this.buildFrame(frame, frame.element)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const MinifyPlugin = require('babel-minify-webpack-plugin')
+//const MinifyPlugin = require('babel-minify-webpack-plugin')
 const WrapperPlugin = require('wrapper-webpack-plugin');
 
 module.exports = (env, args) => {
@@ -31,9 +31,9 @@ module.exports = (env, args) => {
       })
     ],
     optimization: {
-      minimizer: [
-        new MinifyPlugin({ deadcode: false }),
-      ]
+      //minimizer: [
+      //  new MinifyPlugin({ deadcode: false }),
+      //]
     },
     externals: {
       'fs': 'null',


### PR DESCRIPTION
Update to allow browser to parse `literal` elements correctly. Basically uses `innerHTML` on the browser, and if it can't find `innerHTML` assumes its on node and uses the current technique

Addresses issue [linkeddata/rdflib.js#75]