### PR TITLE
Fix link to RDFJS task force spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Javascript RDF library for browsers and Node.js.
 - Read/Write Linked Data client, using WebDav or SPARQL/Update
 - Parses RDFa
 - Local API for querying a store
-- Compatible with [RDFJS task force spec](https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md)
+- Compatible with [RDFJS task force spec](https://rdf.js.org)
 - SPARQL queries (not full SPARQL)
 - Smushing of nodes from `owl:sameAs`, and `owl:{f,inverseF}unctionProperty`
 - Tracks provenance of triples keeps metadata (in RDF) from HTTP accesses


### PR DESCRIPTION
The markdown version was removed from the linked repository as the
generated HTML is available via https://rdf.js.org.