### PR TITLE
Fix an issue where serializer flags didn't affect strings

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -498,7 +498,7 @@ var Serializer = (function () {
   __Serializer.prototype.forbidden1 = new RegExp(/[\\"\b\f\r\v\t\n\u0080-\uffff]/gm)
   __Serializer.prototype.forbidden3 = new RegExp(/[\\"\b\f\r\v\u0080-\uffff]/gm)
   __Serializer.prototype.stringToN3 = function stringToN3 (str, flags) {
-    if (!flags) flags = 'e'
+    if (!flags) flags = this.flags || 'e'
     var res = ''
     var i, j, k
     var delim


### PR DESCRIPTION
The `stringToN3` method didn't account for flags set on the object, which caused multiline strings to be serialized in n-triples.