### PR TITLE
Change Documentation to .md files for readibility

### DIFF
--- a/Documentation/turtle-intro.md
+++ b/Documentation/turtle-intro.md
@@ -1,0 +1,323 @@
+<h1>Using Turtle</h1>
+
+<p>Turtle is a language.
+  It is desiged for expressing data, partuicularly linked data on the web.
+Just as HTML is used for linked text, Turtle is used for linked data.
+Turtle expresses stuff about things.  Abstract things, real things, people,
+documents,  So where HTML uses the hash sign like in <tt>foo.html#intro</tt>
+to refer to an anchor, which is a part of the document, Turtle uses
+the same hash sign to refer to something defined by the dococument, like <tt>students.ttl#bob</tt>
+or <tt>profile.ttl#me</tt>.
+</p>
+<p>
+Turtle is simple.  The data model it uses, called RDF, is simple.
+Turtle was originally designed for writing in chat messages, and on whiteboards,
+and making quick configuration files or test files, so it tries to be concise.
+</p>
+<pre>
+  &lt;profile.ttl#me>   &lt;http://xmlns.com/foaf/0.1/knows>   &lt;students.ttl#bob>  .
+</pre>
+<p>
+That is the simplest thing you can say in Turtle: one fact, one subject-verb-object triple.
+Note it ends with a dot.
+</p>
+<ul>
+<li>The data is sets of <i>triples</i>, or sentences with just a subject,
+  a precdicate, and an object.  Like "I know bob".
+</li>
+<li> URIs like <tt>students.ttl#bob</tt> are used for the subjects, predicates and the objects.</li>
+</ul>
+<p>
+
+</p>
+  <p>
+    There is a shorthand <tt>a</tt> which you can use as a verb to give the class of a thing, to say what sort of thing it is.
+    Classes, like properties,  also have URIs.
+</p>
+    <pre>
+      &lt;profile.ttl#me>   a   &lt;http://xmlns.com/foaf/0.1/Person>  .
+    </pre>
+</p>
+<h3>Prefixes</h3>
+<p>Turtle uses URIs to identify people all the time, so it has a
+  way of abbrevating them.
+  You declare a prefix say at the top of the file, and then use <tt>foo:</tt> prefix with a colon:
+  <pre>
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/> .
+
+&lt;profile.ttl#me>   a   foaf:Person  .
+  </pre>
+<p>
+Tip: There are a ste of common prefixes for vocabularies we use a lot in @@@.
+</p>
+
+<p>When you use URIs in angle brackets, then they relative URIs, relative
+to the URI of the current document.  So if the document is, say,
+<tt>https://alice.example.com/public/profile.ttl</tt> then</p>
+
+<table>
+  <tr>
+    <td>&lt;#me></td>
+    <td>means</td>
+    <td>&lt;https://alice.example.com/public/profile.ttl#me></td>
+  </tr>
+  <tr>
+    <td>&lt;#myHome></td>
+    <td>means</td>
+    <td>&lt;https://alice.example.com/public/profile.ttl#myHome></td>
+  </tr>
+  <tr>
+    <td>&lt;students.ttl#bill></td>
+    <td>means</td>
+    <td>&lt;https://alice.example.com/public/students.ttl#bill></td>
+  </tr>
+</table>
+<p>
+  Things like <tt>&lt;#me></tt> and <tt>&lt;myhome></tt> are local identifiers
+  within the file you are creating. They are like <tt>const</tt> in a JS file
+  in a way, local identifiers. The business of the data document you are writing
+  is done in terms of those local identifiers.  Becasue local identifiers
+  are used quite a lot, it is useful to declare a prefix, the empty string
+  prefix <tt>:</tt>, so that they can be just written with a leading colon:
+</p>
+<pre>
+  @prefix : &lt;#>.  # The empty prefix means this document
+
+  :alice a :Person; :age 77 . # All local IDs
+</pre>
+<p>
+  In what follows we will often assume a file starts with
+</p>
+<pre>
+  @prefix : &lt;#>.
+</pre>
+<h3>Property trees</h3>
+
+<p>As a shorthand, when you have more than one fact about the same subject, you
+  can just use a semicolon <tt>";"</tt> to add more :
+
+  <pre>
+@prefix foaf: &lt;http://xmlns.com/foaf/0.1/> .
+
+&lt;profile.ttl#me>   a   foaf:Person ;
+          foaf:name "Alice";
+          foaf:knows  &lt;students.ttl#bob> .
+  </pre>
+<p>You can also, when have multiple objects with the same subject <i>and</i>
+   predicate, just list them with commas between them, so
+ </p>
+
+  <pre>
+&lt;profile.ttl#me> a foaf:Person ;
+                    foaf:knows  &lt;students.ttl#bob>,
+                                &lt;students.ttl#charlie>,
+                                &lt;students.ttl#david>;
+                    foaf:name "Alice".
+  </pre>
+<p>means the same as:</p>
+<pre>
+  # Means the same as above
+  &lt;profile.ttl#me> a           foaf:Person.
+  &lt;profile.ttl#me> foaf:knows  &lt;students.ttl#bob>.
+  &lt;profile.ttl#me> foaf:knows  &lt;students.ttl#charlie> .
+  &lt;profile.ttl#me> foaf:knows  &lt;students.ttl#david>.
+  &lt;profile.ttl#me> foaf:name   "Alice".
+</pre>
+<p>Periods are stronger than semicolons, which are stronger than commas, like in English.
+</p>
+<p>Turtle is a free form language: you can add or remove spaces and new lines
+   anywhere.  Comments start with a hash sign.
+</p>
+<h3>Data Values</h3>
+
+<p>Above we have shown the triples each expressing the ralationship between things: people
+  and classes. You can also put data values in the object position, like the strng "Alice" above.
+  In Turtle (and the RDF data model underneath) values are typed.
+</p>
+
+<table>
+  <tr>
+    <td>"Alice"</td>
+    <td>means the string Alice</td>
+  </tr>
+  <tr>
+    <td>"20"</td>
+    <td>means a string "20", not the number 20</td>
+  </tr>
+  <tr>
+    <td>20</td>
+    <td>means the integer (whole number) 20.</td>
+  </tr>
+  <tr>
+    <td>20.0</td>
+    <td>means a decimal number</td>
+  </tr>
+  <tr>
+    <td>2.0e1</td>
+    <td>means a (double precision) floating point number 2*10^1</td>
+  </tr>
+</table>
+<p>These data types cover a lot of values.
+  You can also explictly write something
+  with and explicit data type from the XML data types @@link standard, XSD.
+  To do that you write the data value as a string, then two carets
+  <tt>^^</tt> and then the XSD datatype itself.
+</p>
+
+<pre>
+  @prefix xsd: &lt;http://www.w3.org/2001/XMLShema#>.
+  &lt;profile.ttl#me>   a   foaf:Person ;
+                        foaf:name "Alice";
+                        foaf:age  21;
+                        foaf:height  1.76e0;
+                        foaf:bithDate @@@ "1990-03-31"^^xsd:date .
+</pre>
+
+<p>Its also worth mentioning that URIs are yor freind if you wat to
+  given email addresses or telephone numbers, as there are RI schemes for those.
+</p>
+
+<table>
+  <tr>
+  <td>&lt;tel:+1781-555-1212></td>
+  <td>How to do a phone number as a URI</td>
+</tr>
+<tr>
+<td>&lt;mailto:alice@example.com></td>
+<td>How to put in an email address.</td>
+</tr>
+</table>
+
+<p>Why give an explicit <tt>tel:</tt> URI or an explictly typed data field instead of
+  just a string?  Because it means that the systems which re-use the data
+  will be able to be smarter, to automatically pick the appropriate way of
+  displaying it or converting into an other format, and so on.
+  The tradition in linked data is stronger data typing, like Python or C rather than
+  JS.
+</p>
+
+<h2>Structure</h2>
+You can add structure to your data in Turtle using the square brackets <tt>[ ... ]</tt>,
+which can be read as "Something which has ...".   So instead of a flat set of properties like
+<pre>
+  :Alice :homeAddressStreet "Accaia Ave";
+         :homeAddressNumber 123;
+         :homeAddressCity "Anytown";
+         :homePhone &lt;tel:+1-781-555-1212> .
+</pre>
+<p>its best to add structure for the home and the address.</p>
+
+
+<pre>
+  :Alice :home [
+            :address [
+                :street "Accaia Ave";
+                :number 123;
+                :city "Anytown"
+            ]
+            :phone &lt;tel:+1-781-555-1212>
+         ] .
+</pre>
+<p>This reads in English like "Alice has a home which has an address with
+street "Aaccia Avenue", number 123 and city ANytown, and has a phone number of +1785551212."
+<p>
+<p>This sort of tree structure is very common: in JSON the nested things
+  are objects; in XML they are elements. In Turtle they are called blank nodes,
+  because they are not labelled with a URI.  There is another way of
+  writing them in Turtle, where you make up local ids for them like <tt>_:foo</tt>
+  to keep track of them but <b>these are not URIs</b>. The <tt>_:</tt>
+    is a special one for blank nodes.
+</p>
+<pre>
+:Alice :home _:a .
+          _:a address _:b .
+          _:b   street "Accaia Ave";
+                number 123;
+                city "Anytown" .
+          _a :phone &lt;tel:+1-781-555-1212> .
+</pre>
+<p>
+The square bracket syntax is obviously clearer.  You can use it in place of object or subject.
+</p>
+
+<h3>Lists</h3>
+In turtle, ordered arrays of things are given with <b>round</b> brackets.
+They are called collections or lists, and are like LISP lists, or
+JS or Python arrays.
+<pre>
+<#alice>  foaf:children  ( &lt;#bob> &lt;#charlie>  &lt;#dave>  )  .
+</pre>
+<p>Imagine we store user input as a string, but separately generate the list of words.
+</p>
+<pre>
+<#userInput>  ex:line   "turn on light";
+              ex:inWords ("turn" "on" "light") .
+</pre>
+<h3>Conclusion
+</h3>
+<p>That's it.  That's all there is to turtle.  You now know it.
+  It is good to get used to reading bits of turtle
+  as though it was English.  Yu can now use it in code snippits in chats
+  and in code for things like forms, configuration parameters, and so on.
+  <p>
+<hr>
+<div style="background-color: #ffe">
+  <h3>Extensions in rdflib</h3>
+<p>There a few things which you should not use in data shared
+  generally, but are shortcts for test data and quick scripts.
+  rdflib.js will understand these sytatax but never generate them
+</p>
+<h4>Naked Dates</h4>
+<table>
+  <tr>
+    <td><pre>
+      :Alice foaf:birthdate 2018-02-31 .
+    </pre>
+  </td>
+  <td>A raw ISO format date can be put in without explicit type</td>
+  </tr>
+  <tr>
+    <td><pre>
+      :x4 :lastModifiedTime  2018-02-31T08:24:00.0Z .
+    </pre>
+  </td>
+  <td>A raw ISO format date-time can be put in without explicit type</td>
+  </tr>
+</table>
+<h4>Reverse properties</h4>
+
+<p>A good philosphy is that when there two relations which are inverse of
+  each other, like <tt>parent</tt> and <tt>child</tt>, that we just use one,
+  say  <tt>child</tt>, in the data, like
+</p>
+<pre>
+  :grampa fam:child  :alice, :bob.
+  :gramma fam:child  :alice, :bob.
+  :alice  fam:child  :charlie, :davie, :ellie .
+</pre>
+<p>This makes the graph of relationships easier to query.
+  In this example, you can infact express all the information about Alice at once:
+</p>
+<pre>
+  :alice  is fam:child of :grampa, :gramma;
+          fam:child :charlie, :davie, :ellie .
+</pre>
+<p>The <tt>is</tt> ... <tt>of</tt> syntax was in the original N3 language
+  which Turtle was derived from but unfortunately left out of the turtle standard.
+</p>
+<h4>Local document prefix</h4>
+<p>It is handy to define the empty string prefix <tt>:</tt>
+  as being for the local document, so it can be used for local identifiers.
+</p>
+<pre>
+@prefix : &lt;#>.
+</pre>
+<p>This is in fact assumed by default by rdflib.js
+  so you can miss it out.
+</p>
+
+<pre>
+  :this a :Example; :age 123.
+</pre>
+  <p>is a fine test file.</p>
+</div>

--- a/Documentation/webapp-intro.md
+++ b/Documentation/webapp-intro.md
@@ -1,0 +1,593 @@
+<h2>What is rdflib?</h2>
+
+<p>The easiest and best way to work with linked data in Solid is to use a library called rdflib. Rdflib is a general toolbox for doing most things for linked data. It can store data, parse and serialize data into various formats, and keep track of changes to the data coming from the app or from the server.</p>
+
+<h3>Glossary of Terms</h3>
+
+<p>Here are some basic vocabulary terms we'll be using throughout this document.</p>
+
+<ul><li><b>Store</b> - data structure to store graph data and perform queries against. This is the simplest way to work with linked data in rdflib. You can store data from Javascript, dump data out from it, or perform raw queries.</li>
+	<li><b>Fetcher</b> - A helper object that connects to the web, loads data, and saves it back. More powerful than using a simple store object. When you have a fetcher, then you also can ask the query engine to go fetch new linked data automatically as your query makes its way across the web.</li>
+	<li><b>UpdateManager</b> - An even more helper object. The UpdateManager allows you to send small changes to the server to “patch” the data as your user changes data in real time. It also allows you to subscribe to changes other people make to the same file, keeping track of upstream and downstream changes, and signaling any conflict between them.</li>
+	<li><b>Graph</b> - A database for the semantic web. This database is seemingly arbitrary in terms of what is related to what. There are no parent or root nodes, and the connections between nodes is key.</li>
+	<li><b>Triples </b>- An RDF concept that comprise of subject, predicate, and object. For example, storing the data “I have the name John” would be represented as a triple. Similarly,</li>
+	<li><b>Quad</b> is like a triple, but also has a property to explain where the data came from.</li>
+	<li><b>Statement</b> - Another word for quad.</li>
+</ul><h3>Setting up rdflib.js</h3>
+
+<p>Typically people define rdflib in your module as $rdf, so that you an easily cut and paste code between projects and examples here, without confusion.</p>
+
+<p>Installation steps (using npm):</p>
+
+<pre>
+<code class="language-javascript">npm install rdflib --save
+</code></pre>
+
+<p>and then in your code, you will need the following line as well:</p>
+
+<pre>
+<code class="language-javascript">const $rdf = require(‘rdflib’)
+</code></pre>
+
+<h3>Setting up a Store</h3>
+
+<p>Suppose we have a store, and we set up a person and their profile. Their webid is the URI '<a href="https://example.com/alice/card#me">https://example.com/alice/card#me</a>', which is, if you like, a local variable ‘me’ within the the file '<a href="https://example.com/alice/card">https://example.com/alice/card</a>'. </p>
+
+<p>There are two ways of creating a store:  </p>
+
+<pre>
+<code class="language-javascript">const store = new $rdf.IndexedFormula
+</code></pre>
+
+<p>and the shortcut:</p>
+
+<pre>
+<code>const store  = $rdf.graph();
+</code></pre>
+
+<h3>Using the Store</h3>
+
+<p>Let's set up a variable for the person of interest, and one for their profile document.  Note that the URIs for abstract things in RDF have a # and a local id, just like anchors in HTML.   The NamedNode method doc() generates a Named Node for the document.</p>
+
+<pre>
+<code>const me = store.sym('https://example.com/alice/card#me');
+const profile = me.doc();       //i.e. store.sym(''https://example.com/alice/card#me')</code></pre>
+
+<p>We are going to be using the VCARD terms, and so we set up a <b>Namespace</b> object to which generates the right predicate URIs for each term.</p>
+
+<pre>
+<code class="language-javascript">const VCARD = new $rdf.Namespace(‘http://www.w3.org/2006/vcard/ns#‘);
+</code></pre>
+
+<p>If we don’t  know which vocabulary to use, various groups have their favorite lists. One is the <a href="https://github.com/solid/solid-ui/blob/master/src/ns.js">solid-ui list of namespaces</a>.</p>
+
+<p>We add a name to the store as though it was stored in the profile</p>
+
+<pre>
+<code class="language-javascript">store.add(me, VCARD(‘fn’), “John Bloggs”, profile);
+</code></pre>
+
+<p>The third parameter, the object, is formally an RDF Term, here it would be a <strong>Literal</strong>. But you can give a string like “John Bloggs”, and rdflib will generate the right internal object.  It will do that with strings, numbers, Javascript Date objects. </p>
+
+<p>We have some data - one quad - in our store!  Let's read it out.</p>
+
+<p>Now to check what name is given to this person <i>specifically</i> in their profile, we do:</p>
+
+<pre>
+<code class="language-javascript">let name = store.any(me, VCARD('name'), null, profile);
+</code></pre>
+
+<p>If you are <i>not</i> concerned which file the data may have come from, then you can omit the last parameter -- in fact the object too as it is a wildcard:</p>
+
+<pre>
+<code class="language-javascript">let name = store.any(me, VCARD('name'));
+</code></pre>
+
+<p>Then you will pull in any name from any file you have loaded.</p>
+
+<p>So we have added triples here to a local store. That has just been using it as an in-memory database. Most of the time in a Solid app, we’ll use it as a way of getting and saving data to the web. </p>
+
+<h4>Using the Store with Turtle</h4>
+
+<p>Let’s look at two more local operations.  If you have turtle text for some data, you can load it into the store using $rdf.parse:</p>
+
+<pre>
+<code class="language-javascript">let text = '&lt;#this&gt;  a  &lt;#Example&gt; .';
+
+let doc = $rdf.sym(‘’https://example.com/alice/card”);
+let store = $rdf.graph();
+$rdf.parse(text, store, doc.uri, ‘text/turtle’);  // pass base URI
+</code></pre>
+
+<p>Note that we must specify a document URI, as the store works by keeping track of where each triple belongs.  </p>
+
+<pre>
+<code>&gt; store.toNT()
+'{&lt;https://example.com/alice/card.ttl#this&gt; &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; &lt;https://example.com/alice/card.ttl#Example&gt; .}'
+</code></pre>
+
+<p>We can similarly generate a turtle text from the store. Serialize is the function.  You pass it the document (as a NamedNode) we are talking about, and it will just select the triples from that document to be output.</p>
+
+<pre>
+<code class="language-javascript">console.log($rdf.serialize(doc, store, aclDoc.uri, 'text/turtle'));
+</code></pre>
+
+<p>If you omit the document parameter to serialize, or pass null, then you will get all the triples in the store.  This may, if you have used a Fetcher,  possibly metadata which the fetcher has stored about the HTTP requests it made in fetching your documents.  Which might be interesting... but not what you were expecting.</p>
+
+<h4>Using match() to Search the store</h4>
+
+<p>The store’s match(s, p, o, d) method allows you to pull out any combination of quads:</p>
+
+<pre>
+<code class="language-javascript">let quads = store.match(subject, predicate, object, document);
+</code></pre>
+
+<p>Any of the parameters can be null (or undefined) as a wildcard, meaning “any”. The quads which are returned are returned as an array Statement objects.</p>
+
+<p>Examples:</p>
+
+<table><colgroup><col width="*" /><col width="*" /></colgroup><tbody><tr><td>
+			<p dir="ltr">match()</p>
+			</td>
+			<td>
+			<p dir="ltr">gives all the statements in the store</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">match(null, null, null, doc)</p>
+			</td>
+			<td>
+			<p dir="ltr">gives all the statements in the document</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">match(me, null, null, me.doc())</p>
+			</td>
+			<td>
+			<p dir="ltr">gives all the statements in my profile where I am the subject</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">match(null, null, me, me.doc())</p>
+			</td>
+			<td>
+			<p dir="ltr">gives all the statements in my profile where I am the object</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">match(null, LDP(‘contains’))</p>
+			</td>
+			<td>
+			<p dir="ltr">gives all the statements whose predicate is ldp:contains</p>
+			</td>
+		</tr></tbody></table><p>Once you have a set of statements, you typically want to look at the properties of the statement.</p>
+
+<table><colgroup><col width="*" /><col width="*" /></colgroup><tbody><tr><td>
+			<p dir="ltr">subject</p>
+			</td>
+			<td>
+			<p dir="ltr">The Node of the subject</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">predicate</p>
+			</td>
+			<td>
+			<p dir="ltr">The NamedNode of the predicate</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">object</p>
+			</td>
+			<td>
+			<p dir="ltr">The Node of the subject</p>
+			</td>
+		</tr><tr><td>
+			<p dir="ltr">why</p>
+			</td>
+			<td>
+			<p dir="ltr">The NamedNode of the document</p>
+			</td>
+		</tr></tbody></table><p>The last property is called <i>why</i> because it tells us why we should believe it.  In a simple linked data system this is a document we have read. In a more complex system this could point to an inference step. It can also be a special object put in by the Fetcher to store the results of its HTTP operations on the web.</p>
+
+<p>So to find out all the document which mention an old email address as the object of any statement</p>
+
+<pre>
+<code class="language-javascript">
+  let oldEmail = $rdf.sym('mailto:albert@example.com')
+  let outOfDate = store.match(null, null, oldEmail, null).map(st =&gt; st.why);
+</code></pre>
+
+<p>Note how we pull in all the statements and then just keep the ‘why’ parts.</p>
+
+
+<p>So to find out all the document which mention Alice as the subject or object of any statement</p>
+
+<pre>
+<code class="language-javascript">
+  let mentions = store.match(alice, null, null, null).concat(store.match(null, null, alice, null)).map(st =&gt; st.why);
+</code></pre>
+
+<p>Note also while we are here the handy<p>
+<pre>
+<code class="language-javascript">
+  let aboutAlice = store.connectedStatements(alice, alice.doc())
+</code></pre>
+
+<p>which pulls in the statements which mention Alice, plus those which mention connected blank nodes,
+  which could include things like the structure of Alice's address, for example.</p>
+
+<p>Suppose we have loaded a bunch of LDP folders and we want to pull out all the pairs of files where one is inside the other.</p>
+
+<pre>
+<code class="language-javascript">store.match(null, LDP(‘contains’)).forEach(st =&gt; {
+	console.log(st.subject + ‘ contains + st.object)
+});
+</code></pre>
+
+<p><i>We have introduced you to match() after the methods any() and each() because most of the time when you are programming we find those are actually more convenient than using match.</i></p>
+
+<h4>Making new Statements</h4>
+
+<p>You can make a new statement using:</p>
+
+<pre>
+<code class="language-javascript">let st = new $rdf.Statement(me, FOAF(‘name’), “Joe Bloggs”, me.doc());
+</code></pre>
+
+<p>or if that's too verbose, you can use a shortcut provided:</p>
+
+<pre>
+<code class="language-javascript">let st = $rdf.st(me, FOAF(‘name’), “Joe Bloggs”, me.doc());
+</code></pre>
+
+<p>The "st" shortcut exists because you can pass arrays of statements to be deleted or inserted to the UpdateManager's "update()" function as a convenient way of making small changes to the web of data.</p>
+
+<p>But before we get into using the UpdateManager, let's look at the Fetcher, which is your first level of connection to the web.</p>
+
+<h2>Using the Fetcher</h2>
+<p>The Fetcher is a "helper object" which you can attach to a store
+  to allow it to connect to the read-write web of data.
+  The Fetcher handles the HTTP requests, understands MIME types and different
+  formats.  It uses the 4th column of the quadstore to track where each triple came from.
+  It can parse data from the net (or elsewhere) and put it in the store.
+  It can generate pretty-printed formatted data from the store, the whole store,
+  or the data corresponding to one data document out there.
+</p>
+
+<p>Let's set up a store as before.</p>
+
+<pre>
+<code class="language-javascript">const store = $rdf.graph();
+const me = store.sym('https://example.com/alice/card#me');
+const profile = me.doc() //    i.e. store.sym(''https://example.com/alice/card#me');
+const VCARD = new $rdf.Namespace(‘http://www.w3.org/2006/vcard/ns#‘);
+</code></pre>
+
+<p>This time, we'll also make a Fetcher for the store. The Fetcher is a helper object which allows you to transfer data to and from the web of data. </p>
+
+<pre>
+<code class="language-javascript">const fetcher =new $rdf Fetcher(store);
+</code></pre>
+
+<p>Now let's load the document we have been talking about.</p>
+
+<pre>
+<code class="language-javascript">fetcher.load(profile).then(response =&gt; {
+   let name = store.any(me, VCARD(‘fn’));
+  console.log(`Loaded {$name || ‘wot no name?’}`);
+}, err =&gt; {
+   console.log(“Load failed “ +  err);
+});
+</code></pre>
+
+<p>Typically when dealing with people, a name and an avatar is useful in the user interface. Let's pick up the picture too, but also make the code a little more robust against people having profiles written using different terms.</p>
+
+<pre>
+<code class="language-javascript">const FOAF = $rdf.Namespace('http://xmlns.com/foaf/0.1/');
+</code></pre>
+
+<p>This way, we can try using this namespace if there is no VCARD name.</p>
+
+<pre>
+<code class="language-javascript">let name = store.any(me, VCARD(‘fn’)) || store.any(me, FOAF(‘name’));
+let picture = store.any(me, VCARD(‘hasPhoto’)) || store.any(me, FOAF(image));
+</code></pre>
+
+<p>Or we can track all the names we find instead. The function "each()" returns an array of any field it finds a value for.</p>
+
+<pre>
+<code class="language-javascript">let names = store.each(me, VCARD(‘fn’)).concat(store.each(me, FOAF(‘name’)));
+</code></pre>
+
+<h4>Fetch Full Code Example</h4>
+
+<p>Let’s build a little card for someone and set it to get a picture from the net when it can. Let’s use the raw DOM as for the sake of an example -- you translate this into the equivalent in your favorite UI framework.</p>
+
+<pre>
+<code class="language-javascript">const store = $rdf.graph();
+const fetcher = new $rdf.Fetcher(store);
+const me = store.sym('https://example.com/alice/card#me')
+
+const VCARD = new $rdf.Namespace(‘http://www.w3.org/2006/vcard/ns#‘);
+const FOAF = $rdf.Namespace('http://xmlns.com/foaf/0.1/');
+
+function cardFor (person) {
+	let div = document.createElement(div);
+	div.outerHTML = `&lt;div style = ‘padding: 0.5em;’&gt;
+	       &lt;img style = ‘max-width: 3em; min-width: 3em; border-radius: 0.6em;’
+		      src = ‘@@default person image from github.io’&gt;
+     	   &lt;span style=’text-align: center;’&gt;???&lt;/span&gt;
+        &lt;/div&gt;
+	`;
+	let image = div.children[0];
+	let span = div.children[1];
+
+    store.load(person).then( response =&gt; {
+	    let name = store.any(person, VCARD(‘fn’));
+	    if (name) {
+	    	label.textContent =  name.value; // name is a Literal object
+        }
+
+        let pic = store.any(person, VCARD(‘hasPhoto’));
+	    if (pic) {
+		    image.setAttribute(‘src’, pic.uri); // pic is a NamedNode
+        }
+
+    });
+    return div;
+}
+</code></pre>
+
+<p>Then inside of our web application, we could run the following commands:</p>
+
+<pre>
+<code class="language-javascript">div.appendChild(card(me)); // My card
+
+fetcher.load(me.doc).then(resp -&gt; {
+	store.each(me, FOAF(‘friend’)).forEach(friend =&gt; div.appendChild(card(friend)));
+});
+</code></pre>
+
+<p>This will pull in the user’s profile to make the picture and name for my own card.  Then we explicitly pull it in again to find the list of friends.  This is reasonable as the fetcher’s `load` method really means “load if you haven’t already” so continues immediately if it has already been fetched.  It’s wise to explicitly load the things you need and let the system track what has already been loaded.</p>
+
+<p>Then for each of the friends it will load their profile to fill in the name and picture of the friend.</p>
+
+<p><i>Tip: if you are doing this in the Solid world it is good to make any representation of a thing </i><b><i>draggable</i></b><i> with the URI of the thing as the dragged URI. That means users of your UI will be able to drag say, people from your window into another solid app, to say add them to a group, give them access to things, and so on. Similarly, if your window real estate would be a logical place for users to drop other things or people, make it a drag target. For devices with drag and drop anyway.</i></p>
+
+<h3>Listing Data</h3>
+
+<p>Everything in RDF is a thing.  We store data about all things in the same sort of way, just using different vocabulary.  Suppose you want to list the content of the folder in someone’s solid space.  It is very like listing their friends.  The namespace for the contents of folders is LDP. So..</p>
+
+<pre>
+<code class="language-javascript">const LDP = $rdf.Namespace(‘http://www.w3.org/ns/ldp#&gt;’);
+
+let folder = $rdf.sym(‘https://alice.example.com/Public/’);  // NOTE: Ends in a slash
+
+fetcher.load(folder).then(() =&gt; {
+	let files = store.any(folder, LDP(‘contains’));
+	files.forEach(file) {
+        console.log(‘ contains ‘ + file);
+    }
+});
+</code></pre>
+
+<p>The Solid pods give you a bit of metadata about each contained file, including size and type. For example we can look at the RDF type ldp:Container to see when we can list something as a subfolder:</p>
+
+<pre>
+<code class="language-javascript">function list(folder, indent) {
+    indent = indent || ‘’;
+    fetcher.load(folder).then(() =&gt; {
+		let files = store.any(folder,  LDP(‘contains’));
+		files.forEach(file) {
+            console.log(indent + folder + ‘ contains ‘ + file);
+            if (store.holds(file,  RDF(‘type’), LDP(‘Container’)) {
+	            list(file, indent + ‘   ‘);
+            }
+        }
+    });
+}
+
+
+list(rdf.sym(‘https://alice.example.com/Public/’));</code></pre>
+
+<p>The results will come asynchronously. If we were building a UI, each would get slotted into the right place.</p>
+
+
+
+<h2>Update: Using UpdateManager to update the web</h2>
+
+<p>The UpdateManager is another helper object for the store.  Just as the Fetcher
+  allows the store to read and write resources from the web, generally a resource (file) at a time,
+  the UpdateManager object allows the store to send small changes to the data web.
+  It also allows the web app to subscribe to a stream of changes that other people have made,
+  and so keep all places where the data is displayed in sync.
+</p>
+<pre>
+    const store = $rdf.graph()
+    const fetcher = new $rdf.Fetcher(store)
+    const updater = new $rdf.UpdateManager(store)
+...
+
+    function setName(person, name, doc) {
+      let ins = $rdf.st(person, VCARD('fn'), name, doc)
+      let del = []
+      updater.update(del, ins, (uri, ok, message) => {
+        if (ok) console.log('Name changed to '+ name)
+        else alert(message)
+      })
+    }
+
+</pre>
+<p>
+  The first parameter to update() is the array of statements to be deleted.
+If it is empty then update() just adds data to the store.
+(Note for this the user only needs Append privileges, not full Write).
+The second parameter to update() is the array of statements to be deleted.
+</p>
+<pre>
+  function modifyName(person, name, doc) {
+    let ins = $rdf.st(person, VCARD('fn'), name, doc)
+    let del = store.statementsMatching(person, VCARD('fn'), null, doc) // null is wildcard
+    updater.update(del, ins, (uri, ok, message, response) => {
+      if (ok) console.log('Name changed to '+ name)
+      else alert(message)
+    })
+  }
+
+</pre>
+
+  <p>So in this second case, the function will first find any statements which
+    give the name of the person. It then asked update to in one operation
+    remove the old statements (quads) from the store, and add the new one.
+  </p>
+  <h4>409 Conflict</h4>
+<p>Note that update operation (which does a PATCH operation) is specified by solid
+  to be atomic, in that it will either complete both deletion and insertion, or
+  it will fail and do nothing. If the server is not able to delete the statements,
+  for example because someone else has just deleted them first, then the update
+  must fail with a <b>409 conflict</b>.   In that case, the web app will typically
+  beep or turn pink and back out the user's attempted change in the UI.
+</p>
+
+<h2>Deleting resources</h2>
+<p>To delete triples, or any combination of them, from a resource, use the UpdateManager above.  If you
+want to delete whole resources, then you use the HTTP <tt>DELETE</tt> method.</p>
+<pre>
+  store.fetcher.webOperation('DELETE', doc.uri).then(...)
+</pre>
+<h4>Example: recursive delete of Solid folders</h4>
+  <p>Like in Unix, you can't (currently, 2018) delete a folder unless it is empty.
+    So if you want to, you have to delete everything in it first.
+    Here is your <tt>rm -r</tt> function to complete this little guide. </p>
+<pre>
+  function deleteRecursive (store, folder) {
+    return new Promise(function (resolve, reject) {
+      store.fetcher.load(folder).then(function () {
+        let promises = store.each(folder, ns.ldp('contains')).map(file => {
+          if (store.holds(file, ns.rdf('type'), ns.ldp('BasicContainer'))) {
+            return deleteRecursive(kb, file)
+          } else {
+            console.log('deleteRecursive file: ' + file)
+            if (!confirm(' Really DELETE File ' + file)) {
+              throw new Error('User aborted delete file')
+            }
+            return store.fetcher.webOperation('DELETE', file.uri)
+          }
+        })
+        console.log('deleteRecursive folder: ' + folder)
+        if (!confirm(' Really DELETE folder ' + folder)) {
+          throw new Error('User aborted delete file')
+        }
+        promises.push(store.fetcher.webOperation('DELETE', folder.uri))
+        Promise.all(promises).then(res => { resolve() })
+      })
+    })
+  }
+</pre>
+<p>Use with care.. </p>
+<h2>Tracking Changes</h2>
+<p>Using the UpdateManager above we made an app which sends changes to the data web whenever the UI changes.
+  Let's also make it so the UI changes whenever the data web changes.  The function we use is:
+</p>
+  <pre>
+    updater.addDownstreamChangeListener(doc, refreshFunction)
+  </pre>
+  <p>
+It will sign up for changes by opening a websocket with the server.
+When a message comes from the server that the document has changed, it will reload the document into the store.
+It will deal with you calling it for the same document from different places.
+It will ignore changes which you have made yourself with updater.update().
+So all you have to do is provide a function which will sync changes in the store into the UI.
+</p>
+<p>
+  If the user isn't editing the UI, just looking at it, you can more or less get away with
+</p>
+<pre>
+  const div = dom.createElement(div')
+  function refresh () { // Not recommended
+    div.innerHTML = ''
+    store.each(subject, predicate, null, doc).forEach(obj) {
+      div.appendChild(renderOneObject(obj))
+    }
+  }
+  refresh()
+  updater.addDownstreamChangeListener(doc, refresh)
+</pre>
+<p> or words to that effect. This will cause the div to be repainted.
+  That isn't as slick as writing a refresh function which adjusts the UI
+  just deleting old things and inserting new ones.  That means the user can happily be
+  looking at or editing one part while other parts change.
+</p>
+<pre>
+  mugshotDiv = div.appendChild(dom.createElement('div'))
+
+  function elementForImage (image) {
+    let img = dom.createElement('img')
+    img.setAttribute('style', 'max-height: 10em; border-radius: 1em; margin: 0.7em;')
+    img.setAttribute('src', image.uri)
+    return img
+  }
+
+  function syncMugshots () {
+    let images = kb.each(subject, ns.vcard('hasPhoto'), null, doc)
+    images.sort() // arbitrary consistency
+    images = images.slice(0, 5) // max number for the space
+    UI.utils.syncTableToArray(mugshotDiv, images, elementForImage)
+  }
+
+  syncMugshots()
+  updater.addDownstreamChangeListener(doc, syncMugshots)
+</pre>
+<p>This uses a handy function syncTableToArray, which comes with solid-ui, but is include here to
+  be complete.  Also, to encourage you to make UI which syncs in both directions, even if it isn't
+  built into the framework you are using.  So find a way that rdflib fits naturally
+  with your favorite UI framework, if you have one. See
+  <a href="https://solid.inrupt.com/docs">the Inrupt Solid documentation</a> for some hints about using
+  specific frameworks.
+</p>
+<pre>
+  function syncTableToArray (table, things, createNewRow) {
+    let foundOne, row, i
+
+    for (i = 0; i < table.children.length; i++) {
+      row = table.children[i]
+      row.trashMe = true
+    }
+
+    for (let g = 0; g < things.length; g++) {
+      var thing = things[g]
+      foundOne = false
+
+      for (i = 0; i < table.children.length; i++) {
+        row = table.children[i]
+        if (row.subject && row.subject.sameTerm(thing)) {
+          row.trashMe = false
+          foundOne = true
+          break
+        }
+      }
+      if (!foundOne) {
+        let newRow = createNewRow(thing)
+        // Insert new row in position g in the table to match array
+        if (g >= table.children.length) {
+          table.appendChild(newRow)
+        } else {
+          let ele = table.children[g]
+          table.insertBefore(newRow, ele)
+        }
+        newRow.subject = thing
+      } // if not foundOne
+    } // loop g
+
+    for (i = 0; i < table.children.length; i++) {
+      row = table.children[i]
+      if (row.trashMe) {
+        table.removeChild(row)
+      }
+    }
+  } // syncTableToArray
+</pre>
+<h2>Conclusion</h2>
+<p>
+  We've looked at how to interact directly with the store as a local in-memory triple store, and we
+  have looked at how to load it and save it, web resource at a time.
+  We see how it ina away acts as a local in-memory cache of the big wide web of linked data,
+  allowing a user-interface to keep in sync with the state of the data web.
+  As developers we can now write code which will allow users to explore, create, modify and link together
+  a web of linked data which can grow to encompass more and more domains, different applications.
+</p>


### PR DESCRIPTION
By changing to .md files, one does not need to download the documentation to eventually open it in a browser. It's a slight decrease in the effort it takes to start learning about rdflib.js.