### PR TITLE
+ store.sequesterLists()

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -23,6 +23,7 @@ const RDFArrayRemove = require('./util').RDFArrayRemove
 const Statement = require('./statement')
 const Node = require('./node')
 const Variable = require('./variable')
+import { namedNode } from './data-factory'
 
 // const indexedFormulaQuery = require('./query').indexedFormulaQuery
 
@@ -818,6 +819,131 @@ class IndexedFormula extends Formula { // IN future - allow pass array of statem
       }
     }
     return res
+  }
+
+  /** Remove all triples first/rest triples in valid rdf Collections.
+   * It returns a map from blank node identifier at the list head tp an
+   * array of Collection members. For example calling with these quads:
+   *   <n1> <p1> _:b1
+   *   _:b1 rdf:first <element1> ; rdf:rest _:b2
+   *   _:b2 rdf:first "element2" ; rdf:rest rdf:nill
+   * will change the database to:
+   *   <n1> <p1> _:b1
+   * and return a map from "b1" to [<element1>, "element2"]. This can be passed
+   * to N3Writer like:
+   *   new N3Writer({ prefixes: {...}, listHeads: myStore.sequesterLists() })
+   * @param {function} failParam is a function to handle malformed lists. sequesterLists
+   * will non-destructively test Collections if passed a fail function like:
+   *   myStore.sequesterLists((node, msg) => {
+   *     console.log(node, message);
+   *     return false;
+   *   })
+   */
+  sequesterLists (failParam) {
+    const store = this
+    const NsRdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    const first = NsRdf + 'first', rest = NsRdf + 'rest', nil = NsRdf + 'nil';
+    const nonEmptyLists = new Map(); // has scalar keys so could be a simple Object
+    const fail = failParam || defaultListFailFunction;
+
+    // start from the tail of each list
+    const tails = store.statementsMatching(null, namedNode(rest), namedNode(nil), null);
+    tails.forEach(tailQuad => {
+      let skipList = false; // signals the current list is malformed
+      let listQuads = []; // which triples to remove of list is well-formed
+      let head = null; // the head of the list (_:b1 in above example)
+      let headPOS = null; // set to subject or object when head is set
+      let graph = tailQuad.graph; // make sure list is in exactly one graph
+      let members = []; // the members found as objects of rdf:first quads
+
+      let li = tailQuad.subject; // li walks from the tail to the head
+      while (li && !skipList) {
+        let ins = store.statementsMatching(null, null, li, null);
+        let outs = store.statementsMatching(li, null, null, null);
+        let f = null, r = null, parent = null;
+        var i, q;
+        for (i = 0; i < outs.length && !skipList; ++i) {
+          q = outs[i];
+          if (!q.graph.equals(graph)) {
+            skipList = fail(li, 'list not confined to single graph');
+          }
+          else if (head) {
+            skipList = fail(li, 'intermediate list element has non-list arcs out');
+          }
+
+          // one rdf:first
+          else if (q.predicate.value === first) {
+            if (f) {
+              skipList = fail(li, 'multiple rdf:first arcs');
+            }
+            else {
+              f = q;
+              listQuads.push(q);
+            }
+          }
+
+          // one rdf:rest
+          else if (q.predicate.value === rest) {
+            if (r) {
+              skipList = fail(li, 'multiple rdf:rest arcs');
+            }
+            else {
+              r = q;
+              listQuads.push(q);
+            }
+          }
+
+          // alien triple
+          else if (ins.length) {
+            skipList = fail(li, 'can\'t be subject and object');
+          }
+          else {
+            head = q; // e.g. { (1 2 3) :p :o }
+            headPOS = 'subject';
+          }
+        }
+        // { :s :p (1 2) } arrives here with no head
+        // { (1 2) :p :o } arrives here with head set to the list.
+
+        for (i = 0; i < ins.length && !skipList; ++i) {
+          q = ins[i];
+          if (head) {
+            skipList = fail(li, 'list item can\'t have coreferences');
+          }
+
+          // one rdf:rest
+          else if (q.predicate.value === rest) {
+            if (parent) {
+              skipList = fail(li, 'multiple incoming rdf:rest arcs');
+            }
+            else {
+              parent = q;
+            }
+          }
+          else {
+            head = q; // e.g. { :s :p (1 2) }
+            headPOS = 'object';
+          }
+        }
+
+        members.unshift(f.object);
+        li = parent ? parent.subject : null; // null means we're done
+      }
+
+      if (head && !skipList) {
+        if (!failParam)
+          store.removeStatements(listQuads);
+        nonEmptyLists.set(head[headPOS].value, members);
+      }
+    });
+
+    return nonEmptyLists;
+
+    // ### `defaultListFailFunction` return true to signal an error and
+    // to abort recognition of the current list.
+    function defaultListFailFunction(listNode, failureMessage) {
+      return true;
+    }
   }
 }
 module.exports = IndexedFormula

--- a/tests/unit/store-sequesterLists.js
+++ b/tests/unit/store-sequesterLists.js
@@ -1,0 +1,296 @@
+/* eslint-env mocha */
+import { expect } from 'chai'
+
+import parse from '../../src/parse'
+import { namedNode, blankNode, literal, quad, graph, defaultGraph } from '../../src/data-factory'
+
+const NsXsd = 'http://www.w3.org/2001/XMLSchema#';
+const NsRdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const first = NsRdf + 'first', rest = NsRdf + 'rest', nil = NsRdf + 'nil';
+const nNil = namedNode(nil);
+
+describe('Store.sequesterLists()', () => {
+  const BASE = 'http://a.example/'
+  describe('An rdflib store containing a well-formed rdf:Collection as subject', function () {
+    var member0 = namedNode(BASE + 'element1');
+    var member1 = literal('element2');
+    var store = graph();
+    var listElements = makeList(store, null, member0, member1);
+    store.add(listElements[0], namedNode(BASE + 'p1'), namedNode(BASE + 'o1'), defaultGraph());
+    var listItemsJSON = {
+      n0: [
+        { termType: 'NamedNode', value: BASE + 'element1' },
+        { termType: 'Literal', value: 'element2',
+          datatype: { termType: 'NamedNode', value: NsXsd + 'string' } },
+      ],
+    };
+
+    describe('sequesterLists with failParam', function () {
+      var failures = [];
+      var listHeads = store.sequesterLists((li, msg) => failures.push([li, msg]));
+      var struct = mapToObject(listHeads);
+      it('should not delete triples',
+        shouldIncludeAll(store.statementsMatching(),
+                         ['_:' + listElements[0].value, BASE + 'p1', BASE + 'o1'],
+                         ['_:' + listElements[0].value, first, BASE + 'element1'],
+                         ['_:' + listElements[0].value, rest, '_:' + listElements[1].value],
+                         ['_:' + listElements[1].value, first, '"element2"'],
+                         ['_:' + listElements[1].value, rest, nil]
+                        ));
+      it('should not call failParam', function () {
+        expect(failures).to.be.empty;
+      });
+      it('should generate a list of Collections', function () {
+        expect(struct).to.deep.equal(listItemsJSON);
+      });
+    });
+
+    describe('sequesterLists without failParam', function () {
+      const store2 = copyGraph(store);
+      var listHeads = store2.sequesterLists();
+      var struct = mapToObject(listHeads);
+      it('should remove the first/rest triples and return the list members',
+        shouldIncludeAll(store2.statementsMatching(),
+                         ['_:' + listElements[0].value, BASE + 'p1', BASE + 'o1']));
+      it('should generate a list of Collections', function () {
+        expect(struct).to.deep.equal(listItemsJSON);
+      });
+    });
+  });
+
+  describe('An rdflib store containing a well-formed rdf:Collection as object', function () {
+    var member0 = namedNode(BASE + 'element1');
+    var member1 = literal('element2');
+    var store = graph();
+    var listElements = makeList(store, null, member0, member1);
+    store.add(namedNode(BASE + 's1'), namedNode(BASE + 'p1'), listElements[0], defaultGraph());
+    var listItemsJSON = {
+      n2: [
+        { termType: 'NamedNode', value: BASE + 'element1' },
+        { termType: 'Literal', value: 'element2',
+          datatype: { termType: 'NamedNode', value: NsXsd + 'string' } },
+      ],
+    };
+
+    describe('sequesterLists with failParam', function () {
+      var failures = [];
+      var listHeads = store.sequesterLists((li, msg) => failures.push([li, msg]));
+      var struct = mapToObject(listHeads);
+      it('should not delete triples',
+        shouldIncludeAll(store.statementsMatching(),
+                         [BASE + 's1', BASE + 'p1', '_:' + listElements[0].value],
+                         ['_:' + listElements[0].value, first, BASE + 'element1'],
+                         ['_:' + listElements[0].value, rest, '_:' + listElements[1].value],
+                         ['_:' + listElements[1].value, first, '"element2"'],
+                         ['_:' + listElements[1].value, rest, nil]
+                        ));
+      it('should not call failParam', function () {
+        expect(failures).to.be.empty;
+      });
+      it('should generate a list of Collections', function () {
+        expect(struct).to.deep.equal(listItemsJSON);
+      });
+    });
+
+    describe('sequesterLists without failParam', function () {
+      const store2 = copyGraph(store);
+      var listHeads = store2.sequesterLists();
+      var struct = mapToObject(listHeads);
+      it('should remove the first/rest triples and return the list members',
+        shouldIncludeAll(store2.statementsMatching(),
+                         [BASE + 's1', BASE + 'p1', '_:' + listElements[0].value]));
+      it('should generate a list of Collections', function () {
+        expect(struct).to.deep.equal(listItemsJSON);
+      });
+    });
+  });
+
+  describe('An rdflib store containing a rdf:Collection with multiple rdf:first arcs on head', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode());
+    store.add(listElements[0], namedNode(first), blankNode(), defaultGraph());
+    expectFailure(store, listElements[0]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with multiple rdf:first arcs on tail', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode());
+    store.add(listElements[1], namedNode(first), blankNode(), defaultGraph());
+    expectFailure(store, listElements[1]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with multiple rdf:rest arcs on head', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode());
+    store.add(listElements[0], namedNode(rest), blankNode(), defaultGraph());
+    expectFailure(store, listElements[0]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with multiple rdf:rest arcs on tail', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode());
+    store.add(listElements[1], namedNode(rest), blankNode(), defaultGraph());
+    expectFailure(store, listElements[1]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with non-list arcs out', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode(), blankNode());
+    store.add(listElements[1], namedNode(BASE + 'foo'), blankNode(), defaultGraph());
+    expectFailure(store, listElements[1]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with multiple incoming rdf:rest arcs', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode(), blankNode());
+    store.add(blankNode(), namedNode(rest), listElements[1], defaultGraph());
+    expectFailure(store, listElements[1]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with co-references out of head', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode(), blankNode());
+    store.add(listElements[0], namedNode(BASE + 'p1'), namedNode(BASE + 'o1'), defaultGraph());
+    store.add(listElements[0], namedNode(BASE + 'p1'), namedNode(BASE + 'o2'), defaultGraph());
+    expectFailure(store, listElements[0]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection with co-references into head', function () {
+    var store = graph();
+    var listElements = makeList(store, null, blankNode(), blankNode(), blankNode());
+    store.add(namedNode(BASE + 's1'), namedNode(BASE + 'p1'), listElements[0], defaultGraph());
+    store.add(namedNode(BASE + 's2'), namedNode(rest), listElements[0], defaultGraph());
+    store.add(namedNode(BASE + 's2'), namedNode(BASE + 'p1'), listElements[0], defaultGraph());
+    expectFailure(store, listElements[0]);
+  });
+
+  describe('An rdflib store containing a rdf:Collection spread across graphs', function () {
+    var member0 = namedNode(BASE + 'element1');
+    var member1 = literal('element2');
+    var store = graph();
+    var listElements = [
+      blankNode(),
+      blankNode(),
+    ];
+    store.add(listElements[0], namedNode(first), member0, defaultGraph());
+    store.add(listElements[0], namedNode(rest), listElements[1], namedNode(BASE + 'g1'), defaultGraph());
+    store.add(listElements[1], namedNode(first), member1, defaultGraph());
+    store.add(listElements[1], namedNode(rest), namedNode(nil), defaultGraph());
+    store.add(namedNode(BASE + 's1'), namedNode(BASE + 'p1'), listElements[0], defaultGraph());
+    describe('sequesterLists with failParam', function () {
+      var failures = [];
+      var listHeads = store.sequesterLists((li, msg) => failures.push([li, msg]));
+      var struct = mapToObject(listHeads);
+      it('should call failParam', function () {
+        expect(failures.length).to.equal(1);
+        expect(failures[0][0]).to.deep.equal(listElements[0]);
+      });
+      it('should not generate a list of Collections', function () {
+        expect(struct).to.deep.equal({});
+      });
+    });
+
+    describe('sequesterLists without failParam', function () {
+      var listHeads = store.sequesterLists();
+      var struct = mapToObject(listHeads);
+      it('should not delete triples',
+        shouldIncludeAll(store.statementsMatching(),
+                         [BASE + 's1', BASE + 'p1', '_:' + listElements[0].value],
+                         ['_:' + listElements[0].value, first, BASE + 'element1'],
+                         ['_:' + listElements[0].value, rest, '_:' + listElements[1].value, BASE + 'g1'],
+                         ['_:' + listElements[1].value, first, '"element2"'],
+                         ['_:' + listElements[1].value, rest, nil]
+                        ));
+      it('should generate an empty list of Collections', function () {
+        expect(struct).to.deep.equal({});
+      });
+    });
+  });
+})
+
+function expectFailure(store, b0rked) {
+  describe('sequesterLists with failParam', function () {
+    var failures = [];
+    var listHeads = store.sequesterLists((li, msg) => failures.push([li, msg]));
+    var struct = mapToObject(listHeads);
+    it('should call failParam', function () {
+      expect(failures.length).to.equal(1);
+      expect(failures[0][0]).to.deep.equal(b0rked);
+    });
+    it('should not generate a list of Collections', function () {
+      expect(struct).to.deep.equal({});
+    });
+  });
+
+  describe('sequesterLists without failParam', function () {
+    var listHeads = store.sequesterLists();
+    var struct = mapToObject(listHeads);
+    it('should generate an empty list of Collections', function () {
+      expect(struct).to.deep.equal({});
+    });
+  });
+}
+
+function mapToObject(listHeads) {
+  return Array.from(listHeads.entries()).reduce(
+    (acc, pair) => {
+      acc[pair[0]] = pair[1].map(m => {
+        let ret = { termType: m.termType, value: m.value }
+        if (m.language)
+          ret.language = m.language
+        if (m.datatype)
+          ret.datatype = { termType: m.datatype.termType, value: m.datatype.value }
+        return ret
+      });
+      return acc;
+    }, {});
+}
+
+function makeList(store, graph = defaultGraph()) {
+  if (!graph)
+    graph = defaultGraph()
+  if (arguments.length < 3)
+    return nNil
+
+  var listElements = [blankNode()];
+  var args = Array.prototype.slice.call(arguments, 2);
+  args.forEach(function (member, idx) {
+    store.add(listElements[idx], namedNode(first), member, graph);
+    if (idx === args.length - 1) {
+      store.add(listElements[idx], namedNode(rest), namedNode(nil), graph);
+    }
+    else {
+      listElements.push(blankNode());
+      store.add(listElements[idx], namedNode(rest), listElements[idx + 1], graph);
+    }
+  });
+  return listElements;
+}
+
+function shouldIncludeAll(result) {
+  var items = Array.prototype.slice.call(arguments, 1).map(function (arg) {
+    return quad.apply(null, arg.map(a =>
+                                    a.startsWith('_:')
+                                    ? blankNode(a.substr(2))
+                                    : a.startsWith('"')
+                                    ? literal(a.substr(1, a.length - 2))
+                                    : namedNode(a)))
+  });
+  return function () {
+    if (typeof result === 'function') result = result()
+    expect(result.length).to.eql(items.length);
+    for (var i = 0; i < items.length; i++) {
+      const lookFor = items[i]
+      const found = result.filter(q => {
+        return lookFor.equals(q)
+      }) ;if (!found) debugger;
+      expect(found.length).to.eql(1)
+    }
+  };
+}
+
+function copyGraph (store) {
+  const ret = graph()
+  ret.add(store.statementsMatching())
+  return ret
+}


### PR DESCRIPTION
38 tests:
```
./node_modules/.bin/mocha --growl --compilers js:@babel/register tests/unit/store-sequesterLists.js
```
expect:
```
(node:17834) DeprecationWarning: "--compilers" will be removed in a future version of Mocha; see https://git.io/vdcSr for more info
  Store.sequesterLists()
    An rdflib store containing a well-formed rdf:Collection as subject
      sequesterLists with failParam
        ✓ should not delete triples
        ✓ should not call failParam
        ✓ should generate a list of Collections
      sequesterLists without failParam
        ✓ should remove the first/rest triples and return the list members
        ✓ should generate a list of Collections
    An rdflib store containing a well-formed rdf:Collection as object
      sequesterLists with failParam
        ✓ should not delete triples
        ✓ should not call failParam
        ✓ should generate a list of Collections
      sequesterLists without failParam
        ✓ should remove the first/rest triples and return the list members
        ✓ should generate a list of Collections
    An rdflib store containing a rdf:Collection with multiple rdf:first arcs on head
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with multiple rdf:first arcs on tail
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with multiple rdf:rest arcs on head
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with multiple rdf:rest arcs on tail
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with non-list arcs out
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with multiple incoming rdf:rest arcs
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with co-references out of head
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection with co-references into head
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should generate an empty list of Collections
    An rdflib store containing a rdf:Collection spread across graphs
      sequesterLists with failParam
        ✓ should call failParam
        ✓ should not generate a list of Collections
      sequesterLists without failParam
        ✓ should not delete triples
        ✓ should generate an empty list of Collections


  38 passing (57ms)
```