### PR TITLE
Migrate source to ES6 import/export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   presets: [
-    ["@babel/env", { "modules": "commonjs" }],
+    ["@babel/env"],
   ],
   "plugins": [
     "@babel/plugin-transform-runtime"

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,6 +985,35 @@
         "text-encoding": "^0.6.1"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -1173,6 +1202,16 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "acorn": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
@@ -1206,6 +1245,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
     "ansi-regex": {
@@ -1277,10 +1322,31 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "dev": true
+    },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -1360,6 +1426,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "asynckit": {
@@ -1516,6 +1588,12 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1546,6 +1624,52 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        }
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1695,6 +1819,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "dev": true
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1705,6 +1835,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cacache": {
@@ -1965,6 +2101,38 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.40.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1982,6 +2150,12 @@
         "typedarray": "^0.0.6"
       }
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -1995,6 +2169,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "convert-source-map": {
@@ -2013,6 +2210,18 @@
           "dev": true
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -2208,6 +2417,16 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
+    "default-gateway": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+      "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2258,10 +2477,42 @@
         }
       }
     },
+    "del": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.0",
@@ -2273,10 +2524,22 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
     "detect-file": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "diff": {
@@ -2301,6 +2564,31 @@
       "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
       "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
       "dev": true
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "^1.0.0"
+      }
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -2361,6 +2649,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "electron-to-chromium": {
       "version": "1.3.232",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.232.tgz",
@@ -2391,6 +2685,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
@@ -2461,6 +2761,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2504,11 +2810,32 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
       "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
       "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -2577,6 +2904,70 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -2685,6 +3076,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -2712,6 +3112,21 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -2805,6 +3220,32 @@
         }
       }
     },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2826,6 +3267,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2834,6 +3281,12 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -3627,6 +4080,27 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -3636,6 +4110,12 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "handle-thing": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+      "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
       "dev": true
     },
     "har-schema": {
@@ -3749,6 +4229,112 @@
         "parse-passwd": "^1.0.0"
       }
     },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+      "dev": true
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -3828,6 +4414,16 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
+    "internal-ip": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+      "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+      "dev": true,
+      "requires": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      }
+    },
     "interpret": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
@@ -3847,6 +4443,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
+      "integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -3980,6 +4600,30 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.2"
       }
     },
     "is-plain-obj": {
@@ -4182,6 +4826,12 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -4240,6 +4890,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
+    "killable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+      "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
       "dev": true
     },
     "kind-of": {
@@ -4337,6 +4993,12 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "loglevel": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+      "dev": true
     },
     "lolex": {
       "version": "4.2.0",
@@ -4444,6 +5106,12 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -4497,6 +5165,18 @@
         }
       }
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4527,6 +5207,12 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -4787,6 +5473,22 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
     "n3": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/n3/-/n3-0.4.5.tgz",
@@ -4817,6 +5519,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
@@ -5224,6 +5932,27 @@
         "isobject": "^3.0.1"
       }
     },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5231,6 +5960,24 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "opn": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -5306,6 +6053,21 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true
+    },
+    "p-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+      "dev": true,
+      "requires": {
+        "retry": "^0.12.0"
       }
     },
     "p-try": {
@@ -5396,6 +6158,12 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -5424,6 +6192,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -5485,6 +6259,21 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -5501,6 +6290,34 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.22.tgz",
+      "integrity": "sha512-aZuwaz9ujJsyE8C5kurXAD8UmRxsJr+RtZWyQRvRk19Z2ri5uuHw5YS4tDBZrJlOS9Zw96uAbBuPb6W4wgvV5A==",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
       }
     },
     "posix-character-classes": {
@@ -5538,6 +6355,16 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      }
     },
     "prr": {
       "version": "1.0.1",
@@ -5619,6 +6446,12 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5636,6 +6469,32 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+          "dev": true
+        }
       }
     },
     "rdf-canonize": {
@@ -5839,6 +6698,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
     "requizzle": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
@@ -5907,6 +6772,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
@@ -5965,16 +6836,121 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+      "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+      "dev": true,
+      "requires": {
+        "node-forge": "0.7.5"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+          "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+          "dev": true
+        }
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "serialize-javascript": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -6009,6 +6985,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "dev": true
     },
     "sha.js": {
@@ -6184,6 +7166,56 @@
         }
       }
     },
+    "sockjs": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
+      "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "sockjs-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+      "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "solid-auth-cli": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/solid-auth-cli/-/solid-auth-cli-1.0.8.tgz",
@@ -6301,6 +7333,67 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spdy": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
+      "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6374,6 +7467,12 @@
           }
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -6629,6 +7728,12 @@
         }
       }
     },
+    "thunky": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+      "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+      "dev": true
+    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
@@ -6692,6 +7797,12 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -6752,6 +7863,16 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -6833,6 +7954,12 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -6911,6 +8038,16 @@
         }
       }
     },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -6939,6 +8076,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -6948,6 +8091,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -6975,6 +8124,15 @@
         "chokidar": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webidl-conversions": {
@@ -7131,6 +8289,166 @@
         }
       }
     },
+    "webpack-dev-middleware": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+      "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+      "dev": true,
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.2",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
+      "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.0",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.3",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.21",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -7148,6 +8466,23 @@
           "dev": true
         }
       }
+    },
+    "websocket-driver": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
     },
     "whatwg-fetch": {
       "version": "3.0.0",
@@ -7264,6 +8599,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
     },
     "xmlcreate": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sinon-chai": "^3.3.0",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.6",
+    "webpack-dev-server": "^3.8.0",
     "wrapper-webpack-plugin": "^2.1.0"
   },
   "scripts": {
@@ -68,6 +69,7 @@
     "build:browser": "webpack --progress",
     "doc": "rm -r doc ; jsdoc -d doc README.md src/*.js",
     "prepare": "npm run build && npm run build:browser",
+    "start": "webpack-dev-server --https --port 4800",
     "test": "npm run test:unit && npm run test:serialize",
     "test:clean": "rimraf tests/serialize/,*",
     "test:serialize": "npm run build && npm run test:serialize:all && npm run test:clean",

--- a/package.json
+++ b/package.json
@@ -92,11 +92,14 @@
     "test:unit:dev": "mocha --watch --growl --require @babel/register tests/unit/**-test.js"
   },
   "files": [
+    ".babelrc",
     "src",
     "lib",
     "dist"
   ],
   "main": "lib/index.js",
+  "module": "src/index.js",
+  "sideEffects": false,
   "keywords": [
     "linkeddata",
     "linked data",

--- a/src/blank-node.js
+++ b/src/blank-node.js
@@ -1,8 +1,8 @@
 'use strict'
-const ClassOrder = require('./class-order')
-const Node = require('./node')
+import ClassOrder from './class-order'
+import Node from './node-internal'
 
-class BlankNode extends Node {
+export default class BlankNode extends Node {
   constructor (id) {
     super()
     this.termType = BlankNode.termType
@@ -63,5 +63,3 @@ BlankNode.NTAnonymousNodePrefix = '_:'
 BlankNode.prototype.classOrder = ClassOrder['BlankNode']
 BlankNode.prototype.isBlank = 1
 BlankNode.prototype.isVar = 1
-
-module.exports = BlankNode

--- a/src/class-order.js
+++ b/src/class-order.js
@@ -1,4 +1,4 @@
-var ClassOrder = {
+export default {
   'Literal': 1,
   'Collection': 3,
   'Graph': 4,
@@ -6,5 +6,3 @@ var ClassOrder = {
   'BlankNode': 6,
   'Variable': 7
 }
-
-module.exports = ClassOrder

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,9 +1,9 @@
 'use strict'
-const BlankNode = require('./blank-node')
-const ClassOrder = require('./class-order')
-const Node = require('./node')
+import BlankNode from './blank-node'
+import ClassOrder from './class-order'
+import Node from './node-internal'
 
-class Collection extends Node {
+export default class Collection extends Node {
   constructor (initial) {
     super()
     this.termType = Collection.termType
@@ -46,5 +46,3 @@ Collection.termType = 'Collection'
 Collection.prototype.classOrder = ClassOrder['Collection']
 Collection.prototype.compareTerm = BlankNode.prototype.compareTerm
 Collection.prototype.isVar = 0
-
-module.exports = Collection

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,11 +1,8 @@
-module.exports.convertToJson = convertToJson
-module.exports.convertToNQuads = convertToNQuads
+import asyncLib from 'async' // @@ Goal: remove this dependency
+import jsonld from 'jsonld'
+import N3 from 'n3'  // @@ Goal: remove this dependency
 
-var asyncLib = require('async') // @@ Goal: remove this dependency
-var jsonld = require('jsonld')
-var N3 = require('n3')  // @@ Goal: remove this dependency
-
-function convertToJson (n3String, jsonCallback) {
+export function convertToJson (n3String, jsonCallback) {
   var jsonString
   var n3Parser = N3.Parser()
   var n3Writer = N3.Writer({
@@ -42,7 +39,7 @@ function convertToJson (n3String, jsonCallback) {
   )
 }
 
-function convertToNQuads (n3String, nquadCallback) {
+export function convertToNQuads (n3String, nquadCallback) {
   var nquadString
   var n3Parser = N3.Parser()
   var n3Writer = N3.Writer({

--- a/src/data-factory.js
+++ b/src/data-factory.js
@@ -1,13 +1,28 @@
 'use strict'
-const BlankNode = require('./blank-node')
-const Collection = require('./collection')
-const DefaultGraph = require('./default-graph')
-const Fetcher = require('./fetcher')
-const IndexedFormula = require('./store')
-const Literal = require('./literal')
-const NamedNode = require('./named-node')
-const Statement = require('./statement')
-const Variable = require('./variable')
+import BlankNode from './blank-node'
+import Collection from './collection'
+import DefaultGraph from './default-graph'
+import Fetcher from './fetcher'
+import IndexedFormula from './store'
+import Literal from './literal'
+import NamedNode from './named-node'
+import Statement from './statement'
+import Variable from './variable'
+
+const DataFactory = {
+  blankNode,
+  defaultGraph,
+  fetcher,
+  graph,
+  lit,
+  literal,
+  namedNode,
+  quad,
+  st,
+  triple,
+  variable,
+}
+export default DataFactory
 
 function blankNode (value) {
   return new BlankNode(value)
@@ -54,19 +69,3 @@ function triple (subject, predicate, object) {
 function variable (name) {
   return new Variable(name)
 }
-
-// rdfjs spec factory methods
-module.exports.blankNode = blankNode
-module.exports.defaultGraph = defaultGraph
-module.exports.graph = graph
-module.exports.literal = literal
-module.exports.namedNode = namedNode
-module.exports.quad = quad
-module.exports.triple = triple
-module.exports.variable = variable
-
-// rdflib only
-module.exports.collection = collection
-module.exports.fetcher = fetcher
-module.exports.lit = lit
-module.exports.st = st

--- a/src/default-graph.js
+++ b/src/default-graph.js
@@ -1,7 +1,7 @@
 'use strict'
-const Node = require('./node')
+import Node from './node'
 
-class DefaultGraph extends Node {
+export default class DefaultGraph extends Node {
   constructor () {
     super()
     this.termType = 'DefaultGraph'
@@ -11,5 +11,3 @@ class DefaultGraph extends Node {
     return this.value
   }
 }
-
-module.exports = DefaultGraph

--- a/src/empty.js
+++ b/src/empty.js
@@ -1,10 +1,10 @@
 'use strict'
-const Node = require('./node')
+import Node from './node'
 
 /**
  * Singleton subclass of an empty Collection.
  */
-class Empty extends Node {
+export default class Empty extends Node {
   constructor () {
     super()
     this.termType = Empty.termType
@@ -14,5 +14,3 @@ class Empty extends Node {
   }
 }
 Empty.termType = 'empty'
-
-module.exports = Empty

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -25,22 +25,23 @@
  * To do:
  * Firing up a mail client for mid:  (message:) URLs
  */
-const IndexedFormula = require('./store')
-const log = require('./log')
-const N3Parser = require('./n3parser')
-const NamedNode = require('./named-node')
-const Namespace = require('./namespace')
-const rdfParse = require('./parse')
-const parseRDFaDOM = require('./rdfaparser').parseRDFaDOM
-const RDFParser = require('./rdfxmlparser')
-const Uri = require('./uri')
-const Util = require('./util')
-const serialize = require('./serialize')
+import IndexedFormula from './store'
+import log from './log'
+import N3Parser from './n3parser'
+import NamedNode from './named-node'
+import Namespace from './namespace'
+import rdfParse from './parse'
+import { parseRDFaDOM } from './rdfaparser'
+import RDFParser from './rdfxmlparser'
+import * as Uri from './uri'
+import * as Util from './util'
+import serialize from './serialize'
+
+import { fetch as solidAuthCli } from 'solid-auth-cli'
+import { fetch as solidAuthClient } from 'solid-auth-client'
 
 // This is a special fetch which does OIDC auth, catching 401 errors
-const {fetch} = (typeof window === 'undefined')
-         ? require('solid-auth-cli')
-         : require('solid-auth-client')
+const fetch = typeof window === 'undefined' ? solidAuthCli : solidAuthClient
 
 const Parsable = {
   'text/n3': true,
@@ -418,7 +419,7 @@ const HANDLERS = {
   * figuring how to parse them.  It will also refresh, remove, the data
   * and put back the fata to the web.
  */
-class Fetcher {
+export default class Fetcher {
   /**
   * @constructor
   */
@@ -1776,6 +1777,5 @@ class Fetcher {
 // whether we want to track it ot not. including ontologies loaed though the XSSproxy
 }
 
-module.exports = Fetcher
-module.exports.HANDLERS = HANDLERS
-module.exports.CONTENT_TYPE_BY_EXT = CONTENT_TYPE_BY_EXT
+Fetcher.HANDLERS = HANDLERS
+Fetcher.CONTENT_TYPE_BY_EXT = CONTENT_TYPE_BY_EXT

--- a/src/formula.js
+++ b/src/formula.js
@@ -1,18 +1,19 @@
 'use strict'
-const BlankNode = require('./blank-node')
-const ClassOrder = require('./class-order')
-const Collection = require('./collection')
-const Literal = require('./literal')
-const log = require('./log')
-const NamedNode = require('./named-node')
-const Node = require('./node')
-const Serializer = require('./serialize')
-const Statement = require('./statement')
-const Variable = require('./variable')
+import BlankNode from './blank-node'
+import ClassOrder from './class-order'
+import Collection from './collection'
+import Literal from './literal'
+import log from './log'
+import NamedNode from './named-node'
+import Namespace from './namespace'
+import Node from './node'
+import Serializer from './serialize'
+import Statement from './statement'
+import Variable from './variable'
 
 /** @module formula */
 
-class Formula extends Node {
+export default class Formula extends Node {
   /**
   * @constructor
   * @param statements - Initial array of statements
@@ -645,7 +646,5 @@ Formula.termType = 'Graph'
 Formula.prototype.classOrder = ClassOrder['Graph']
 Formula.prototype.isVar = 0
 
-Formula.prototype.ns = require('./namespace')
+Formula.prototype.ns = Namespace
 Formula.prototype.variable = name => new Variable(name)
-
-module.exports = Formula

--- a/src/index.js
+++ b/src/index.js
@@ -1,56 +1,106 @@
-var $rdf = {
-  BlankNode: require('./blank-node'),
-  Collection: require('./collection'),
-  convert: require('./convert'),
-  DataFactory: require('./data-factory'),
-  Empty: require('./empty'),
-  Fetcher: require('./fetcher'),
-  Formula: require('./formula'),
-  Store: require('./store'),
-  jsonParser: require('./jsonparser'),
-  Literal: require('./literal'),
-  log: require('./log'),
-  N3Parser: require('./n3parser'),
-  NamedNode: require('./named-node'),
-  Namespace: require('./namespace'),
-  Node: require('./node'),
-  parse: require('./parse'),
-  Query: require('./query').Query,
-  queryToSPARQL: require('./query-to-sparql'),
-  RDFaProcessor: require('./rdfaparser'),
-  RDFParser: require('./rdfxmlparser'),
-  serialize: require('./serialize'),
-  Serializer: require('./serializer'),
-  SPARQLToQuery: require('./sparql-to-query'),
-  sparqlUpdateParser: require('./patch-parser'),
-  Statement: require('./statement'),
-  term: require('./node').fromValue,
-  UpdateManager: require('./update-manager'),
-  UpdatesSocket: require('./updates-via').UpdatesSocket,
-  UpdatesVia: require('./updates-via').UpdatesVia,
-  uri: require('./uri'),
-  Util: require('./util'),
-  Variable: require('./variable')
+import BlankNode from './blank-node'
+import Collection from './collection'
+import * as convert from './convert'
+import DataFactory from './data-factory'
+import Empty from './empty'
+import Fetcher from './fetcher'
+import Formula from './formula'
+import Store from './store'
+import jsonParser from './jsonparser'
+import Literal from './literal'
+import log from './log'
+import N3Parser from './n3parser'
+import NamedNode from './named-node'
+import Namespace from './namespace'
+import Node from './node'
+import parse from './parse'
+import { Query } from './query'
+import queryToSPARQL from './query-to-sparql'
+import RDFaProcessor from './rdfaparser'
+import RDFParser from './rdfxmlparser'
+import serialize from './serialize'
+import Serializer from './serializer'
+import SPARQLToQuery from './sparql-to-query'
+import sparqlUpdateParser from './patch-parser'
+import Statement from './statement'
+import UpdateManager from './update-manager'
+import { UpdatesSocket } from './updates-via'
+import { UpdatesVia } from './updates-via'
+import * as uri from './uri'
+import * as Util from './util'
+import Variable from './variable'
+
+const NextId = BlankNode.nextId
+
+const { fromNT } = Formula.prototype;
+
+const {
+  fetcher,
+  graph,
+  lit,
+  st,
+  namedNode,
+  variable,
+  blankNode,
+  defaultGraph,
+  literal,
+  quad,
+  triple,
+} = DataFactory
+
+const { fromValue: term } = Node
+
+export {
+  BlankNode,
+  Collection,
+  convert,
+  DataFactory,
+  Empty,
+  Fetcher,
+  Formula,
+  Store,
+  jsonParser,
+  Literal,
+  log,
+  N3Parser,
+  NamedNode,
+  Namespace,
+  Node,
+  parse,
+  Query,
+  queryToSPARQL,
+  RDFaProcessor,
+  RDFParser,
+  serialize,
+  Serializer,
+  SPARQLToQuery,
+  sparqlUpdateParser,
+  Statement,
+  term,
+  UpdateManager,
+  UpdatesSocket,
+  UpdatesVia,
+  uri,
+  Util,
+  Variable,
+
+  Store as IndexedFormula, // Alias
+
+  NextId,
+
+  fromNT,
+  fetcher,
+  graph,
+  lit,
+  st,
+  namedNode as sym,
+
+  // RDFJS DataFactory interface
+  blankNode,
+  defaultGraph,
+  literal,
+  namedNode,
+  quad,
+  triple,
+  variable,
 }
-
-$rdf.IndexedFormula = $rdf.Store // Alias
-
-$rdf.NextId = $rdf.BlankNode.nextId
-
-$rdf.fromNT = $rdf.Formula.prototype.fromNT
-$rdf.fetcher = $rdf.DataFactory.fetcher
-$rdf.graph = $rdf.DataFactory.graph
-$rdf.lit = $rdf.DataFactory.lit
-$rdf.st = $rdf.DataFactory.st
-$rdf.sym = $rdf.DataFactory.namedNode
-$rdf.variable = $rdf.DataFactory.variable
-
-// RDFJS DataFactory interface
-$rdf.blankNode = $rdf.DataFactory.blankNode
-$rdf.defaultGraph = $rdf.DataFactory.defaultGraph
-$rdf.literal = $rdf.DataFactory.literal
-$rdf.namedNode = $rdf.DataFactory.namedNode
-$rdf.quad = $rdf.DataFactory.quad
-$rdf.triple = $rdf.DataFactory.triple
-
-module.exports = $rdf

--- a/src/jsonparser.js
+++ b/src/jsonparser.js
@@ -1,4 +1,4 @@
-var jsonParser = (function () {
+export default (function () {
   return {
     parseJSON: function (data, source, store) {
       var subject, predicate, object
@@ -51,5 +51,3 @@ var jsonParser = (function () {
     }
   }
 })()
-
-module.exports = jsonParser

--- a/src/literal.js
+++ b/src/literal.js
@@ -1,10 +1,10 @@
 'use strict'
-const ClassOrder = require('./class-order')
-const NamedNode = require('./named-node')
-const Node = require('./node')
-const XSD = require('./xsd')
+import ClassOrder from './class-order'
+import NamedNode from './named-node'
+import Node from './node-internal'
+import XSD from './xsd'
 
-class Literal extends Node {
+export default class Literal extends Node {
   constructor (value, language, datatype) {
     super()
     this.termType = Literal.termType
@@ -142,5 +142,3 @@ Literal.prototype.classOrder = ClassOrder['Literal']
 Literal.prototype.datatype = XSD.string
 Literal.prototype.lang = ''
 Literal.prototype.isVar = 0
-
-module.exports = Literal

--- a/src/log.js
+++ b/src/log.js
@@ -2,23 +2,12 @@
  * A Dummy log
  * @module log
  */
-module.exports = {
-  debug: function debug (x) {
-    return
-  },
-  warn: function warn (x) {
-    return
-  },
-  info: function info (x) {
-    return
-  },
-  error: function error (x) {
-    return
-  },
-  success: function success (x) {
-    return
-  },
-  msg: function msg (x) {
-    return
-  }
+const log = {
+  debug (x) {},
+  warn (x) {},
+  info (x) {},
+  error (x) {},
+  success (x) {},
+  msg (x) {},
 }
+export default log

--- a/src/n3parser.js
+++ b/src/n3parser.js
@@ -4,10 +4,10 @@
 *  http://www.webtoolkit.info/
 *
 **/
-const Uri = require('./uri')
-const ArrayIndexOf = require('./util').ArrayIndexOf
+import * as Uri from './uri'
+import { ArrayIndexOf } from './util'
 
-var N3Parser = (function () {
+export default (function () {
 
 function hexify (str) { // also used in parser
   return encodeURI(str);
@@ -1568,5 +1568,3 @@ function dummyWrite(x) {
 return SinkParser;
 
 })();
-
-module.exports = N3Parser

--- a/src/named-node.js
+++ b/src/named-node.js
@@ -1,12 +1,12 @@
 'use strict'
-const ClassOrder = require('./class-order')
-const Node = require('./node')
+import ClassOrder from './class-order'
+import Node from './node-internal'
 
 /**
  * @class NamedNode
  * @extends Node
  */
-class NamedNode extends Node {
+export default class NamedNode extends Node {
   /**
    * @constructor
    * @param iri {String}
@@ -99,5 +99,3 @@ class NamedNode extends Node {
 NamedNode.termType = 'NamedNode'
 NamedNode.prototype.classOrder = ClassOrder['NamedNode']
 NamedNode.prototype.isVar = 0
-
-module.exports = NamedNode

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -1,9 +1,7 @@
-const NamedNode = require('./named-node')
+import NamedNode from './named-node'
 
-function Namespace (nsuri) {
+export default function Namespace (nsuri) {
   return function (ln) {
     return new NamedNode(nsuri + (ln || ''))
   }
 }
-
-module.exports = Namespace

--- a/src/node-internal.js
+++ b/src/node-internal.js
@@ -1,0 +1,51 @@
+'use strict'
+
+/**
+ * The superclass of all RDF Statement objects, that is
+ * NamedNode, Literal, BlankNode, etc.
+ * @class Node
+ */
+
+export default class Node {
+  substitute (bindings) {
+    console.log('@@@ node substitute' + this)
+    return this
+  }
+  compareTerm (other) {
+    if (this.classOrder < other.classOrder) {
+      return -1
+    }
+    if (this.classOrder > other.classOrder) {
+      return +1
+    }
+    if (this.value < other.value) {
+      return -1
+    }
+    if (this.value > other.value) {
+      return +1
+    }
+    return 0
+  }
+  equals (other) {
+    if (!other) {
+      return false
+    }
+    return (this.termType === other.termType) &&
+      (this.value === other.value)
+  }
+  hashString () {
+    return this.toCanonical()
+  }
+  sameTerm (other) {
+    return this.equals(other)
+  }
+  toCanonical () {
+    return this.toNT()
+  }
+  toNT () {
+    return this.toString()
+  }
+  toString () {
+    throw new Error('Node.toString() is abstract - see the subclasses instead')
+  }
+}

--- a/src/node.js
+++ b/src/node.js
@@ -1,57 +1,12 @@
 'use strict'
 
-/**
- * The superclass of all RDF Statement objects, that is
- * NamedNode, Literal, BlankNode, etc.
- * @class Node
- */
+// This file attaches all functionality to Node
+// that would otherwise require circular dependencies.
+import Node from './node-internal'
+import Collection from './collection'
+import Literal from './literal'
 
-
-class Node {
-
-  substitute (bindings) {
-    console.log('@@@ node substitute' + this)
-    return this
-  }
-  compareTerm (other) {
-    if (this.classOrder < other.classOrder) {
-      return -1
-    }
-    if (this.classOrder > other.classOrder) {
-      return +1
-    }
-    if (this.value < other.value) {
-      return -1
-    }
-    if (this.value > other.value) {
-      return +1
-    }
-    return 0
-  }
-  equals (other) {
-    if (!other) {
-      return false
-    }
-    return (this.termType === other.termType) &&
-      (this.value === other.value)
-  }
-  hashString () {
-    return this.toCanonical()
-  }
-  sameTerm (other) {
-    return this.equals(other)
-  }
-  toCanonical () {
-    return this.toNT()
-  }
-  toNT () {
-    return this.toString()
-  }
-  toString () {
-    throw new Error('Node.toString() is abstract - see the subclasses instead')
-  }
-}
-module.exports = Node
+export default Node
 
 /**
  * Creates an RDF Node from a native javascript value.
@@ -62,9 +17,6 @@ module.exports = Node
  * @return {Node|Collection}
  */
 Node.fromValue = function fromValue (value) {
-  const Collection = require('./collection')
-  const Literal = require('./literal')
-  const NamedNode = require('./named-node')
   if (typeof value === 'undefined' || value === null) {
     return value
   }
@@ -78,7 +30,7 @@ Node.fromValue = function fromValue (value) {
   return Literal.fromValue(value)
 }
 
-const Namespace = require('./namespace')
+import Namespace from './namespace'
 const ns = { xsd: Namespace('http://www.w3.org/2001/XMLSchema#') }
 
 Node.toJS = function toJS (term) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,15 +1,13 @@
-module.exports = parse
-
-const BlankNode = require('./blank-node')
-const jsonld = require('jsonld')
-const Literal = require('./literal')
-const N3 = require('n3')  // @@ Goal: remove this dependency
-const N3Parser = require('./n3parser')
-const NamedNode = require('./named-node')
-const parseRDFaDOM = require('./rdfaparser').parseRDFaDOM
-const RDFParser = require('./rdfxmlparser')
-const sparqlUpdateParser = require('./patch-parser')
-const Util = require('./util')
+import BlankNode from './blank-node'
+import jsonld from 'jsonld'
+import Literal from './literal'
+import N3 from 'n3'  // @@ Goal: remove this dependency
+import N3Parser from './n3parser'
+import NamedNode from './named-node'
+import { parseRDFaDOM } from './rdfaparser'
+import RDFParser from './rdfxmlparser'
+import sparqlUpdateParser from './patch-parser'
+import * as Util from './util'
 
 /**
  * Parse a string and put the result into the graph kb.
@@ -17,7 +15,7 @@ const Util = require('./util')
  * Unfortunately jsdonld is currently written to need to be called async.
  * Hence the mess below with executeCallback.
  */
-function parse (str, kb, base, contentType, callback) {
+export default function parse (str, kb, base, contentType, callback) {
   contentType = contentType || 'text/turtle'
   contentType = contentType.split(';')[0]
   try {

--- a/src/patch-parser.js
+++ b/src/patch-parser.js
@@ -5,12 +5,10 @@
 // (not necessarily in that order)
 // as though it were the n3
 //   <#query> patch:where {xxx}; patch:delete {yyy}; patch:insert {zzz}.
-module.exports = sparqlUpdateParser
+import N3Parser from './n3parser'
+import Namespace from './namespace'
 
-const N3Parser = require('./n3parser')
-const Namespace = require('./namespace')
-
-function sparqlUpdateParser (str, kb, base) {
+export default function sparqlUpdateParser (str, kb, base) {
   var i, j, k
   var keywords = [ 'INSERT', 'DELETE', 'WHERE' ]
   var SQNS = Namespace('http://www.w3.org/ns/pim/patch#')

--- a/src/query-to-sparql.js
+++ b/src/query-to-sparql.js
@@ -1,6 +1,6 @@
-const log = require('./log')
+import log from './log'
 
-function queryToSPARQL (query) {
+export default function queryToSPARQL (query) {
   var indent = 0
   function getSelect (query) {
     var str = addIndent() + 'SELECT '
@@ -71,5 +71,3 @@ function queryToSPARQL (query) {
 
   return getSPARQL(query)
 }
-
-module.exports = queryToSPARQL

--- a/src/query.js
+++ b/src/query.js
@@ -17,15 +17,17 @@
 // Also, users name variables and want the same name back when stuff is printed
 /* jsl:option explicit */ // Turn on JavaScriptLint variable declaration checking
 
-const IndexedFormula = require('./store')
-const log = require('./log')
-const docpart = require('./uri').docpart
+import {
+  default as IndexedFormula,
+  defaultGraphURI as defaultDocumentURI
+}  from './store'
+import log from './log'
+import { docpart } from './uri'
 
-const defaultDocumentURI = IndexedFormula.defaultGraphURI
 /**
  * Query class, for tracking queries the user has in the UI.
  */
-class Query {
+export class Query {
   constructor (name, id) {
     this.pat = new IndexedFormula() // The pattern to search for
     this.vars = [] // Used by UI code but not in query.js
@@ -49,7 +51,7 @@ class Query {
  * @param fetcher - IGNORED OBSOLETE  f.fetecher is used as a Fetcher instance to do this.
  * @param onDone -  callback when query finished
  */
-function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
+export function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
   /** Debug strings
   */
   function bindingDebug (b) {
@@ -525,6 +527,3 @@ function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
 
    // returns nothing; callback does the work
 } // query
-
-module.exports.Query = Query
-module.exports.indexedFormulaQuery = indexedFormulaQuery

--- a/src/rdfaparser.js
+++ b/src/rdfaparser.js
@@ -12,12 +12,12 @@
 // options.base = base URI    not really an option, shopuld always be set.
 //
 
-const BlankNode = require('./blank-node')
-const Literal = require('./literal')
-const rdf = require('./data-factory')
-const NamedNode = require('./named-node')
-const Uri = require('./uri')
-const Util = require('./util')
+import BlankNode from './blank-node'
+import Literal from './literal'
+import rdf from './data-factory'
+import NamedNode from './named-node'
+import * as Uri from './uri'
+import * as Util from './util'
 
 if (typeof Node === 'undefined') { //  @@@@@@ Global. Interface to xmldom.
   var Node = {
@@ -36,7 +36,7 @@ if (typeof Node === 'undefined') { //  @@@@@@ Global. Interface to xmldom.
   }
 }
 
-class RDFaProcessor {
+export default class RDFaProcessor {
   constructor (kb, options) {
     this.options = options || {}
     this.kb = kb
@@ -950,4 +950,5 @@ RDFaProcessor.dateTimeTypes = [
     type: 'http://www.w3.org/2001/XMLSchema#gYear' }
 ]
 
-module.exports = RDFaProcessor
+const parseRDFaDOM = RDFaProcessor.parseRDFaDOM
+export { parseRDFaDOM }

--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -55,14 +55,14 @@
  * @author David Sheets <dsheets@mit.edu>
  *
 */
- const uriUtil = require('./uri')
+import * as uriUtil from './uri'
 
 /*
  * @constructor
  * @param {RDFStore} store An RDFStore object
  */
 
-var RDFParser = function (store) {
+export default function RDFParser(store) {
   var RDFParser = {}
 
   /** Standard namespaces that we know how to handle @final
@@ -453,5 +453,3 @@ var RDFParser = function (store) {
     return frame
   }
 }
-
-module.exports = RDFParser

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,14 +1,12 @@
-module.exports = serialize
-
-const convert = require('./convert')
-const Serializer = require('./serializer')
+import * as convert from './convert'
+import Serializer from './serializer'
 
 /**
  * Serialize to the appropriate format
  * @@ Currently NQuads and JSON/LD are deal with extrelemently inefficiently
  * through mutiple conversions.
  */
-function serialize (target, kb, base, contentType, callback, options) {
+export default function serialize (target, kb, base, contentType, callback, options) {
   base = base || target.uri
   options = options || {}
   contentType = contentType || 'text/turtle' // text/n3 if complex?

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -5,13 +5,13 @@
 ** This is or was https://github.com/linkeddata/rdflib.js/blob/master/src/serializer.js
 ** Licence: MIT
 */
-const NamedNode = require('./named-node')
-const BlankNode = require('./blank-node')
-const Uri = require('./uri')
-const Util = require('./util')
-const XSD = require('./xsd')
+import NamedNode from './named-node'
+import BlankNode from './blank-node'
+import * as Uri from './uri'
+import * as Util from './util'
+import XSD from './xsd'
 
-var Serializer = (function () {
+export default (function () {
   var __Serializer = function (store) {
     this.flags = ''
     this.base = null
@@ -959,5 +959,3 @@ var Serializer = (function () {
   var Serializer = function (store) { return new __Serializer(store) }
   return Serializer
 }())
-
-module.exports = Serializer

--- a/src/sparql-to-query.js
+++ b/src/sparql-to-query.js
@@ -9,15 +9,14 @@ function SQuery () {
 STerm.prototype.toString = STerm.val
 SQuery.prototype.add = function (str) {this.terms.push()}*/
 
-const log = require('./log')
-const Query = require('./query').Query
-// const Fetcher = require('./fetcher')
+import log from './log'
+import { Query } from './query'
 
 /**
  * @SPARQL: SPARQL text that is converted to a query object which is returned.
  * @testMode: testing flag. Prevents loading of sources.
  */
-function SPARQLToQuery (SPARQL, testMode, kb) {
+export default function SPARQLToQuery (SPARQL, testMode, kb) {
   // AJAR_ClearTable()
   var variableHash = []
   function makeVar (name) {
@@ -517,5 +516,3 @@ function SPARQLToQuery (SPARQL, testMode, kb) {
 // checkVars()
 // *******************************************************************//
 }
-
-module.exports = SPARQLToQuery

--- a/src/statement.js
+++ b/src/statement.js
@@ -1,7 +1,7 @@
 'use strict'
-const Node = require('./node')
+import Node from './node'
 
-class Statement {
+export default class Statement {
   /* Construct a new statment
   **
   ** @param {Term} subject - The subject of the triple.  What the efact is about
@@ -62,5 +62,3 @@ class Statement {
     return this.toNT()
   }
 }
-
-module.exports = Statement

--- a/src/store.js
+++ b/src/store.js
@@ -16,20 +16,18 @@
 
 /** @module store */
 
-const ArrayIndexOf = require('./util').ArrayIndexOf
-const Formula = require('./formula')
-// const log = require('./log')
-const RDFArrayRemove = require('./util').RDFArrayRemove
-const Statement = require('./statement')
-const Node = require('./node')
-const Variable = require('./variable')
-
-// const indexedFormulaQuery = require('./query').indexedFormulaQuery
-
+import { ArrayIndexOf } from './util'
+import Formula from './formula'
+import { RDFArrayRemove } from './util'
+import Statement from './statement'
+import Node from './node'
+import Variable from './variable'
+import { Query, indexedFormulaQuery } from './query'
 
 const owlNamespaceURI = 'http://www.w3.org/2002/07/owl#'
 
 const defaultGraphURI = 'chrome:theSession'
+export { defaultGraphURI }
 // var link_ns = 'http://www.w3.org/2007/ont/link#'
 
 // Handle Functional Property
@@ -71,7 +69,7 @@ function handleRDFType (formula, subj, pred, obj, why) {
 /**
  * Indexed Formula aka Store
  */
-class IndexedFormula extends Formula { // IN future - allow pass array of statements to constructor
+export default class IndexedFormula extends Formula { // IN future - allow pass array of statements to constructor
   /**
    * @constructor
    * @param {Array<String>} features - What sort of autmatic processing to do? Array of string
@@ -119,7 +117,6 @@ class IndexedFormula extends Formula { // IN future - allow pass array of statem
   }
 
   applyPatch (patch, target, patchCallback) { // patchCallback(err)
-    const Query = require('./query').Query
     var targetKB = this
     var ds
     var binding = null
@@ -520,8 +517,6 @@ class IndexedFormula extends Formula { // IN future - allow pass array of statem
   }
 
   query (myQuery, callback, dummy, onDone) {
-    let indexedFormulaQuery = require('./query').indexedFormulaQuery
-
     return indexedFormulaQuery.call(this, myQuery, callback, dummy, onDone)
   }
 
@@ -540,7 +535,6 @@ class IndexedFormula extends Formula { // IN future - allow pass array of statem
     var results = []
     var done = false
     myQuery.sync = true
-    let indexedFormulaQuery = require('./query').indexedFormulaQuery
 
     indexedFormulaQuery.call(this, myQuery, saveBinginds, null, onDone)
     if (!done) {
@@ -820,5 +814,4 @@ class IndexedFormula extends Formula { // IN future - allow pass array of statem
     return res
   }
 }
-module.exports = IndexedFormula
 IndexedFormula.handleRDFType = handleRDFType

--- a/src/update-manager.js
+++ b/src/update-manager.js
@@ -4,14 +4,14 @@
 ** 2010-08-08 TimBL folded in Kenny's WEBDAV
 ** 2010-12-07 TimBL addred local file write code
 */
-const IndexedFormula = require('./store')
-const docpart = require('./uri').docpart
-const Fetcher = require('./fetcher')
-const namedNode = require('./data-factory').namedNode
-const Namespace = require('./namespace')
-const Serializer = require('./serializer')
-const uriJoin = require('./uri').join
-const Util = require('./util')
+import IndexedFormula from './store'
+import { docpart } from './uri'
+import Fetcher from './fetcher'
+import { namedNode } from './data-factory'
+import Namespace from './namespace'
+import Serializer from './serializer'
+import { join as uriJoin } from './uri'
+import * as Util from './util'
 
 /** Update Manager
 *
@@ -21,7 +21,7 @@ const Util = require('./util')
 * and also looking out for concurrent updates from other agents
 */
 
-class UpdateManager {
+export default class UpdateManager {
   /** @constructor
    * @param {IndexedFormula} store - the quadstore to store data and metadata. Created if not passed.f
   */
@@ -1076,5 +1076,3 @@ class UpdateManager {
     })
   }
 }
-
-module.exports = UpdateManager

--- a/src/updates-via.js
+++ b/src/updates-via.js
@@ -1,9 +1,9 @@
 /*
  * Updates-Via
  */
-const namedNode = require('./data-factory').namedNode
+import { namedNode } from './data-factory'
 
-class UpdatesSocket {
+export class UpdatesSocket {
   constructor (parent, via) {
     this.parent = parent
     this.via = via
@@ -103,7 +103,7 @@ class UpdatesSocket {
   }
 }
 
-class UpdatesVia {
+export class UpdatesVia {
   constructor (fetcher) {
     this.fetcher = fetcher
     this.graph = {}
@@ -140,6 +140,3 @@ class UpdatesVia {
     return this.via[via].subscribe(uri)
   }
 }
-
-module.exports.UpdatesSocket = UpdatesSocket
-module.exports.UpdatesVia = UpdatesVia

--- a/src/uri.js
+++ b/src/uri.js
@@ -10,16 +10,9 @@
  */
 var alert = alert || console.log
 
-module.exports.docpart = docpart
-module.exports.document = document
-module.exports.hostpart = hostpart
-module.exports.join = join
-module.exports.protocol = protocol
-module.exports.refTo = refTo
+import NamedNode from './named-node'
 
-const NamedNode = require('./named-node')
-
-function docpart (uri) {
+export function docpart (uri) {
   var i
   i = uri.indexOf('#')
   if (i < 0) {
@@ -29,11 +22,11 @@ function docpart (uri) {
   }
 }
 
-function document (x) {
+export function document (x) {
   return new NamedNode(docpart(x.uri))
 }
 
-function hostpart (u) {
+export function hostpart (u) {
   var m = /[^\/]*\/\/([^\/]*)\//.exec(u)
   if (m) {
     return m[1]
@@ -42,7 +35,7 @@ function hostpart (u) {
   }
 }
 
-function join (given, base) {
+export function join (given, base) {
   var baseColon, baseScheme, baseSingle
   var colon, lastSlash, path
   var baseHash = base.indexOf('#')
@@ -110,7 +103,7 @@ function join (given, base) {
   return base.slice(0, baseSingle) + path
 }
 
-function protocol (uri) {
+export function protocol (uri) {
   var i
   i = uri.indexOf(':')
   if (i < 0) {
@@ -120,7 +113,7 @@ function protocol (uri) {
   }
 }
 
-function refTo (base, uri) {
+export function refTo (base, uri) {
   var c, i, k, l, len, len1, n, o, p, q, ref, ref1, s
   var commonHost = new RegExp('^[-_a-zA-Z0-9.]+:(//[^/]*)?/[^/]*$')
   if (!base) {

--- a/src/util.js
+++ b/src/util.js
@@ -2,43 +2,29 @@
  * Utility functions for $rdf
  * @module util
  */
-var docpart = require('./uri').docpart
-var log = require('./log')
-var NamedNode = require('./named-node')
+import { docpart } from './uri'
+import log from './log'
+import * as uri from './uri'
+import NamedNode from './named-node'
 
-module.exports.AJAR_handleNewTerm = ajarHandleNewTerm
-module.exports.ArrayIndexOf = arrayIndexOf
-module.exports.callbackify = callbackify
-module.exports.dtstamp = dtstamp
-module.exports.DOMParserFactory = domParser
-module.exports.domToString = domToString
-module.exports.dumpNode = dumpNode
-module.exports.heavyCompare = heavyCompare
-module.exports.heavyCompareSPO = heavyCompareSPO
-module.exports.output = output
-module.exports.parseXML = parseXML
-module.exports.RDFArrayRemove = rdfArrayRemove
-module.exports.stackString = stackString
-module.exports.string_startswith = stringStartsWith
-module.exports.string = {}
-module.exports.string.template = stringTemplate
-module.exports.uri = require('./uri')  // TODO: Remove this mixed usage
-module.exports.log = log
+const string = { template: stringTemplate }
 
-module.exports.mediaTypeClass = function(mediaType){
+export { log, uri, string }
+
+export function mediaTypeClass(mediaType){
   mediaType = mediaType.split(';')[0].trim()  // remove media type parameters
   return new NamedNode('http://www.w3.org/ns/iana/media-types/' + mediaType + '#Resource')
 }
 
-module.exports.linkRelationProperty = function(relation){
+export function linkRelationProperty(relation){
   return new NamedNode('http://www.w3.org/ns/iana/link-relations/relation#' + relation.trim())
 }
 
 /**
  * Loads ontologies of the data we load (this is the callback from the kb to
- * the fetcher). Exports as `AJAR_handleNewTerm`
+ * the fetcher).
  */
-function ajarHandleNewTerm (kb, p, requestedBy) {
+export function AJAR_handleNewTerm (kb, p, requestedBy) {
   var sf = null
   if (typeof kb.fetcher !== 'undefined') {
     sf = kb.fetcher
@@ -50,7 +36,7 @@ function ajarHandleNewTerm (kb, p, requestedBy) {
   var fixuri
   if (p.uri.indexOf('#') < 0) { // No hash
     // @@ major hack for dbpedia Categories, which spread indefinitely
-    if (stringStartsWith(p.uri, 'http://dbpedia.org/resource/Category:')) return
+    if (string_startswith(p.uri, 'http://dbpedia.org/resource/Category:')) return
 
     /*
       if (string_startswith(p.uri, 'http://xmlns.com/foaf/0.1/')) {
@@ -58,14 +44,14 @@ function ajarHandleNewTerm (kb, p, requestedBy) {
       // should give HTTP 303 to ontology -- now is :-)
       } else
     */
-    if (stringStartsWith(p.uri,
+    if (string_startswith(p.uri,
             'http://purl.org/dc/elements/1.1/') ||
-          stringStartsWith(p.uri, 'http://purl.org/dc/terms/')) {
+          string_startswith(p.uri, 'http://purl.org/dc/terms/')) {
       fixuri = 'http://dublincore.org/2005/06/13/dcq'
     // dc fetched multiple times
-    } else if (stringStartsWith(p.uri, 'http://xmlns.com/wot/0.1/')) {
+    } else if (string_startswith(p.uri, 'http://xmlns.com/wot/0.1/')) {
       fixuri = 'http://xmlns.com/wot/0.1/index.rdf'
-    } else if (stringStartsWith(p.uri, 'http://web.resource.org/cc/')) {
+    } else if (string_startswith(p.uri, 'http://web.resource.org/cc/')) {
       //            log.warn("creative commons links to html instead of rdf. doesn't seem to content-negotiate.")
       fixuri = 'http://web.resource.org/cc/schema.rdf'
     }
@@ -83,10 +69,7 @@ function ajarHandleNewTerm (kb, p, requestedBy) {
   return sf.fetch(docuri, { referringTerm: requestedBy })
 }
 
-/**
- * Exports as `ArrayIndexOf`.
- */
-function arrayIndexOf (arr, item, i) {
+export function ArrayIndexOf (arr, item, i) {
   i || (i = 0)
   var length = arr.length
   if (i < 0) i = length + i
@@ -106,7 +89,7 @@ function arrayIndexOf (arr, item, i) {
  * @param obj {Object}
  * @param callbacks {Array<Function>}
  */
-function callbackify (obj, callbacks) {
+export function callbackify (obj, callbacks) {
   obj.callbacks = {}
   for (var x = callbacks.length - 1; x >= 0; x--) {
     obj.callbacks[callbacks[x]] = []
@@ -166,9 +149,8 @@ function callbackify (obj, callbacks) {
 
 /**
  * Returns a DOM parser based on current runtime environment.
- * Exports as `DOMParserFactory`
  */
-function domParser () {
+export function DOMParserFactory () {
   if (window.DOMParser) {
     return new DOMParser()
   } else if (window.ActiveXObject) {
@@ -179,7 +161,7 @@ function domParser () {
 }
 
 // From https://github.com/linkeddata/dokieli
-function domToString (node, options) {
+export function domToString (node, options) {
   options = options || {}
   var selfClosing = []
   if ('selfClosing' in options) {
@@ -196,7 +178,7 @@ function domToString (node, options) {
   return dumpNode(node, options, selfClosing, skipAttributes)
 }
 
-function dumpNode (node, options, selfClosing, skipAttributes) {
+export function dumpNode (node, options, selfClosing, skipAttributes) {
   var i
   var out = ''
   var noEsc = [ false ]
@@ -254,7 +236,7 @@ function dumpNode (node, options, selfClosing, skipAttributes) {
   return out
 }
 
-function dtstamp () {
+export function dtstamp () {
   var now = new Date()
   var year = now.getYear() + 1900
   var month = now.getMonth() + 1
@@ -274,7 +256,7 @@ function dtstamp () {
 /**
  * Compares statements (heavy comparison for repeatable canonical ordering)
  */
-function heavyCompare (x, y, g, uriMap) {
+export function heavyCompare (x, y, g, uriMap) {
   var nonBlank = function (x) {
     return (x.termType === 'BlankNode') ? null : x
   }
@@ -303,7 +285,7 @@ function heavyCompare (x, y, g, uriMap) {
   }
 }
 
-function heavyCompareSPO (x, y, g, uriMap) {
+export function heavyCompareSPO (x, y, g, uriMap) {
   return heavyCompare(x.subject, y.subject, g, uriMap) ||
     heavyCompare(x.predicate, y.predicate, g, uriMap) ||
     heavyCompare(x.object, y.object, g, uriMap)
@@ -314,26 +296,21 @@ function heavyCompareSPO (x, y, g, uriMap) {
  * @method output
  * @param o {String}
  */
-function output (o) {
+export function output (o) {
   var k = document.createElement('div')
   k.textContent = o
   document.body.appendChild(k)
 }
 
+import { DOMParser } from 'xmldom'
+
 /**
  * Returns a DOM from parsex XML.
  */
-function parseXML (str, options) {
+export function parseXML (str, options) {
   var dparser
   options = options || {}
   if (typeof module !== 'undefined' && module && module.exports) { // Node.js
-    // var libxmljs = require('libxmljs'); // Was jsdom before 2012-01 then libxmljs but that nonstandard
-    // return libxmljs.parseXmlString(str)
-
-    // var jsdom = require('jsdom');   2012-01 though 2015-08 no worky with new Node
-    // var dom = jsdom.jsdom(str, undefined, {} );// html, level, options
-
-    var DOMParser = require('xmldom').DOMParser // 2015-08 on https://github.com/jindw/xmldom
     var dom = new DOMParser().parseFromString(str, options.contentType || 'application/xhtml+xml')
     return dom
   } else {
@@ -348,9 +325,8 @@ function parseXML (str, options) {
 
 /**
  * Removes all statements equal to x from a
- * Exports as `RDFArrayRemove`
  */
-function rdfArrayRemove (a, x) {
+export function RDFArrayRemove (a, x) {
   for (var i = 0; i < a.length; i++) {
     // TODO: This used to be the following, which didnt always work..why
     // if(a[i] === x)
@@ -365,7 +341,7 @@ function rdfArrayRemove (a, x) {
   throw new Error('RDFArrayRemove: Array did not contain ' + x + ' ' + x.why)
 }
 
-function stringStartsWith (str, pref) { // missing library routines
+export function string_startswith (str, pref) { // missing library routines
   return (str.slice(0, pref.length) === pref)
 }
 
@@ -385,7 +361,7 @@ function stringTemplate (base, subs) {
 
 // Stack dump on errors - to pass errors back
 
-function stackString (e) {
+export function stackString (e) {
   var str = '' + e + '\n'
   if (!e.stack) {
     return str + 'No stack available.\n'

--- a/src/variable.js
+++ b/src/variable.js
@@ -1,7 +1,7 @@
 'use strict'
-const ClassOrder = require('./class-order')
-const Node = require('./node')
-const Uri = require('./uri')
+import ClassOrder from './class-order'
+import Node from './node'
+import * as Uri from './uri'
 
 /**
  * Variables are placeholders used in patterns to be matched.
@@ -11,7 +11,7 @@ const Uri = require('./uri')
  * but the ? notation has an implicit base uri of 'varid:'
  * @class Variable
  */
-class Variable extends Node {
+export default class Variable extends Node {
   constructor (name = '') {
     super()
     this.termType = Variable.termType
@@ -43,5 +43,3 @@ class Variable extends Node {
 Variable.termType = 'Variable'
 Variable.prototype.classOrder = ClassOrder['Variable']
 Variable.prototype.isVar = 1
-
-module.exports = Variable

--- a/src/xsd.js
+++ b/src/xsd.js
@@ -1,6 +1,6 @@
-const NamedNode = require('./named-node')
+import NamedNode from './named-node'
 
-class XSD {}
+export default class XSD {}
 
 XSD.boolean = new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
 XSD.dateTime = new NamedNode('http://www.w3.org/2001/XMLSchema#dateTime')
@@ -10,5 +10,3 @@ XSD.integer = new NamedNode('http://www.w3.org/2001/XMLSchema#integer')
 XSD.langString =
   new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
 XSD.string = new NamedNode('http://www.w3.org/2001/XMLSchema#string')
-
-module.exports = XSD

--- a/tests/unit/blank-node-test.js
+++ b/tests/unit/blank-node-test.js
@@ -2,7 +2,7 @@
 
 import { expect } from 'chai'
 import fs from 'fs'
-import rdf from '../../src/index'
+import * as rdf from '../../src/index'
 
 import BlankNode from '../../src/blank-node'
 

--- a/tests/unit/fetcher-egp-test.js
+++ b/tests/unit/fetcher-egp-test.js
@@ -3,7 +3,7 @@
 
 import chai from 'chai'
 import nock from 'nock'
-import rdf from '../../src/index'
+import * as rdf from '../../src/index'
 
 const { expect } = chai
 chai.should()

--- a/tests/unit/fetcher-test.js
+++ b/tests/unit/fetcher-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import dirtyChai from 'dirty-chai'
 import nock from 'nock'
-import rdf from '../../src/index'
+import * as rdf from '../../src/index'
 
 chai.use(sinonChai)
 chai.use(dirtyChai)

--- a/tests/unit/indexed-formula-test.js
+++ b/tests/unit/indexed-formula-test.js
@@ -3,26 +3,26 @@ import { expect } from 'chai'
 
 import IndexedFormula from '../../src/store'
 import NamedNode from '../../src/named-node'
-import { triple } from '../../src/data-factory'
+import DataFactory from '../../src/data-factory'
 
 describe('IndexedFormula', () => {
   describe('match', () => {
     const s1 = NamedNode.fromValue('https://example.com/subject1')
     const p1 = NamedNode.fromValue('https://example.com/predicate1')
     const o1 = NamedNode.fromValue('https://example.com/object1')
-    const triple1 = triple(s1, p1, o1)
+    const triple1 = DataFactory.triple(s1, p1, o1)
 
     const s2 = NamedNode.fromValue('https://example.com/subject2')
     const p2 = NamedNode.fromValue('https://example.com/predicate2')
     const o2 = NamedNode.fromValue('https://example.com/object2')
-    const triple2 = triple(s2, p2, o2)
+    const triple2 = DataFactory.triple(s2, p2, o2)
 
     const s3 = NamedNode.fromValue('https://example.com/subject3')
     const p3 = NamedNode.fromValue('https://example.com/predicate3')
     const o3 = NamedNode.fromValue('https://example.com/object3')
-    const triple3 = triple(s3, p3, o3)
+    const triple3 = DataFactory.triple(s3, p3, o3)
 
-    const triple4 = triple(s1, p2, o3)
+    const triple4 = DataFactory.triple(s1, p2, o3)
 
     it('when given no arguments returns all statements', () => {
       const kb = new IndexedFormula()

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai'
 
 import parse from '../../src/parse'
-import { graph } from '../../src/data-factory'
+import DataFactory from '../../src/data-factory'
 
 describe('Parse', () => {
   describe('ttl', () => {
@@ -10,7 +10,7 @@ describe('Parse', () => {
       it('handles language subtags', () => {
         let base = 'https://www.wikidata.org/wiki/Special:EntityData/Q2005.ttl'
         let mimeType = 'text/turtle'
-        let store = graph()
+        let store = DataFactory.graph()
         let content = '<http://www.wikidata.org/entity/Q328> <http://www.w3.org/2000/01/rdf-schema#label> "ангельская Вікіпэдыя"@be-x-old .'
         parse(content, store, base, mimeType)
         expect(store.statements[0].object.lang).to.eql('be-x-old')
@@ -22,7 +22,7 @@ describe('Parse', () => {
       it('handles language subtags', () => {
         let base = 'https://www.wikidata.org/wiki/Special:EntityData/Q2005.ttl'
         let mimeType = 'text/turtle;charset=UTF-8'
-        let store = graph()
+        let store = DataFactory.graph()
         let content = '<http://www.wikidata.org/entity/Q328> <http://www.w3.org/2000/01/rdf-schema#label> "ангельская Вікіпэдыя"@be-x-old .'
         parse(content, store, base, mimeType)
         expect(store.statements[0].object.lang).to.eql('be-x-old')
@@ -46,7 +46,7 @@ describe('Parse', () => {
           "@id": "../#me",
           "homepage": "xyz"
         }`
-        store = graph()
+        store = DataFactory.graph()
         parse(content, store, base, mimeType, done)
       })
 

--- a/tests/unit/query-test.js
+++ b/tests/unit/query-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import dirtyChai from 'dirty-chai'
 import nock from 'nock'
-import rdf from '../../src/index'
+import * as rdf from '../../src/index'
 
 chai.use(sinonChai)
 chai.use(dirtyChai)

--- a/tests/unit/update-manager-test.js
+++ b/tests/unit/update-manager-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import dirtyChai from 'dirty-chai'
 import nock from 'nock'
-import rdf from '../../src/index'
+import * as rdf from '../../src/index'
 
 const $rdf = rdf
 

--- a/tests/unit/uri-test.js
+++ b/tests/unit/uri-test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import { expect } from 'chai'
 
-import uri from '../../src/uri'
+import * as uri from '../../src/uri'
 
 describe('uri', () => {
   const testData = [


### PR DESCRIPTION
This commit migrates the `src` folder to use `import`/`export` rather than `require`/`module.exports`. In addition to just using more modern semantics, it allows tree shaking by webpack and others.

While it uses `default` exports for _internal_ files, the external exports (`index.js`) do _not_ use `default`. Hence, external code using `require` keeps on working.

The only breaking change is that external code that was incorrectly using `import rdf from 'rdflib'` should use `import * as rdf from 'rdflib'`. Preferably, such code imports the exposed subcomponents of `rdflib`, such that tree shaking becomes possible.