### PR TITLE
Skip n3 parser for jsonld

### DIFF
--- a/Documentation/webapp-intro.html
+++ b/Documentation/webapp-intro.html
@@ -590,7 +590,7 @@ So all you have to do is provide a function which will sync changes in the store
 
       for (i = 0; i < table.children.length; i++) {
         row = table.children[i]
-        if (row.subject && row.subject.sameTerm(thing)) {
+        if (row.subject && row.subject.equals(thing)) {
           row.trashMe = false
           foundOne = true
           break

--- a/package-lock.json
+++ b/package-lock.json
@@ -2033,6 +2033,11 @@
       "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
       "dev": true
     },
+    "canonicalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.1.tgz",
+      "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg=="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -4976,10 +4981,11 @@
       }
     },
     "jsonld": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
-      "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.0.tgz",
+      "integrity": "sha512-a3bwbR0wqFstxKsGoimUIIKBdfJ+yb9kWK+WK7MpVyvfYtITMpUtF3sNoN1wG/W+jGDgya0ACRh++jtTozxtyQ==",
       "requires": {
+        "canonicalize": "^1.0.1",
         "rdf-canonize": "^1.0.2",
         "request": "^2.88.0",
         "semver": "^5.6.0",
@@ -6491,9 +6497,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
-      "integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "async": "^3.1.x",
-    "jsonld": "^1.6.2",
+    "jsonld": "^1.8.0",
     "n3": "^1.2.0",
     "solid-auth-cli": "^1.0.8",
     "solid-auth-client": "^2.3.0",

--- a/reference/fetcher-classes.js
+++ b/reference/fetcher-classes.js
@@ -1,3 +1,5 @@
+import { isNamedNode } from '../src/util'
+
 const log = require('./log')
 const N3Parser = require('./n3parser')
 const NamedNode = require('./named-node')
@@ -459,7 +461,7 @@ class Fetcher {
     if (!xhr.options.noMeta) {
       kb.add(xhr.original, ns.link('error'), status)
     }
-    if (!xhr.resource.sameTerm(xhr.original)) {
+    if (!xhr.resource.equals(xhr.original)) {
       console.log('@@ Recording failure original ' + xhr.original +
         '( as ' + xhr.resource + ') : ' + xhr.status)
     } else {
@@ -666,7 +668,7 @@ class Fetcher {
       userCallback = p2
     } else if (typeof p2 === 'undefined') { // original calling signature
       // referingTerm = undefined
-    } else if (p2 instanceof NamedNode) {
+    } else if (isNamedNode(p2)) {
       // referingTerm = p2
       options = {referingTerm: p2}
     } else {

--- a/src/collection.js
+++ b/src/collection.js
@@ -33,7 +33,10 @@ export default class Collection extends Node {
     return new Collection(elementsCopy)
   }
   toNT () {
-    return BlankNode.NTAnonymousNodePrefix + this.id
+    return Collection.toNT(this)
+  }
+  static toNT (collection) {
+    return BlankNode.NTAnonymousNodePrefix + collection.id
   }
   toString () {
     return '(' + this.elements.join(' ') + ')'

--- a/src/data-factory-internal.js
+++ b/src/data-factory-internal.js
@@ -1,0 +1,90 @@
+import BlankNode from './blank-node'
+import Literal from './literal'
+import NamedNode from './named-node'
+import Statement from './statement'
+import Variable from './variable'
+
+export const defaultGraphURI = 'chrome:theSession'
+
+function blankNode (value) {
+  return new BlankNode(value)
+}
+
+function defaultGraph () {
+  return new NamedNode(defaultGraphURI)
+}
+
+/**
+ * Generates a unique identifier for the object.
+ *
+ * Equivalent to {Term.hashString}
+ */
+function id (term) {
+  if (!term) {
+    return term
+  }
+  if (Object.prototype.hasOwnProperty.call(term, "id") && typeof term.id === "function") {
+    return term.id()
+  }
+  if (Object.prototype.hasOwnProperty.call(term, "hashString")) {
+    return term.hashString()
+  }
+
+  switch (term.termType) {
+    case "NamedNode":
+      return '<' + term.value + '>'
+    case "BlankNode":
+      return '_:' + term.value
+    case "Literal":
+      return Literal.toNT(term)
+    case "Variable":
+      return Variable.toString(term)
+    default:
+      return undefined
+  }
+}
+
+function literal (value, languageOrDatatype) {
+  if (typeof value !== "string" && !languageOrDatatype) {
+    return Literal.fromValue(value)
+  }
+
+  const strValue = typeof value === 'string' ? value : '' + value
+  if (typeof languageOrDatatype === 'string') {
+    if (languageOrDatatype.indexOf(':') === -1) {
+      return new Literal(strValue, languageOrDatatype)
+    } else {
+      return new Literal(strValue, null, namedNode(languageOrDatatype))
+    }
+  } else {
+    return new Literal(strValue, null, languageOrDatatype)
+  }
+}
+function namedNode (value) {
+  return new NamedNode(value)
+}
+function quad (subject, predicate, object, graph) {
+  graph = graph || defaultGraph()
+  return new Statement(subject, predicate, object, graph)
+}
+function variable (name) {
+  return new Variable(name)
+}
+
+/** Contains the factory methods as defined in the spec, plus id */
+export default {
+  blankNode,
+  defaultGraph,
+  literal,
+  namedNode,
+  quad,
+  variable,
+  id,
+  supports: {
+    COLLECTIONS: false,
+    DEFAULT_GRAPH_TYPE: true,
+    EQUALS_METHOD: true,
+    NODE_LOOKUP: false,
+    VARIABLE_TYPE: true,
+  }
+}

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -34,6 +34,7 @@ import rdfParse from './parse'
 import { parseRDFaDOM } from './rdfaparser'
 import RDFParser from './rdfxmlparser'
 import * as Uri from './uri'
+import { isNamedNode } from './util'
 import * as Util from './util'
 import serialize from './serialize'
 
@@ -874,7 +875,7 @@ export default class Fetcher {
       userCallback = p2
     } else if (typeof p2 === 'undefined') { // original calling signature
       // referringTerm = undefined
-    } else if (p2 instanceof NamedNode) {
+    } else if (isNamedNode(p2)) {
       // referringTerm = p2
       options.referringTerm = p2
     } else {
@@ -963,7 +964,7 @@ export default class Fetcher {
     let isGet = meth === 'GET' || meth === 'HEAD'
 
     if (isGet) {  // only cache the status code on GET or HEAD
-      if (!options.resource.sameTerm(options.original)) {
+      if (!options.resource.equals(options.original)) {
         // console.log('@@ Recording failure  ' + meth + '  original ' + options.original +option '( as ' + options.resource + ') : ' + statusCode)
       } else {
         // console.log('@@ Recording ' + meth + ' failure for ' + options.original + ': ' + statusCode)

--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -1,0 +1,98 @@
+import jsonld from 'jsonld'
+
+import { arrayToStatements } from './util'
+
+/**
+ * Parses json-ld formatted JS objects to a rdf Term.
+ * @param kb - The DataFactory to use.
+ * @param obj - The json-ld object to process.
+ * @return {Literal|NamedNode|BlankNode|Collection}
+ */
+export function jsonldObjectToTerm (kb, obj) {
+  if (typeof obj === 'string') {
+    return kb.rdfFactory.literal(obj)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, '@list')) {
+    if (kb.rdfFactory.supports["COLLECTIONS"] === true) {
+      return listToCollection(kb, obj['@list'])
+    }
+
+    return listToStatements(kb, obj)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, '@id')) {
+    return kb.rdfFactory.namedNode(obj['@id'])
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, '@language')) {
+    return kb.rdfFactory.literal(obj['@value'], obj['@language'])
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, '@type')) {
+    return kb.rdfFactory.literal(obj['@value'], kb.rdfFactory.namedNode(obj['@type']))
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, '@value')) {
+    return kb.rdfFactory.literal(obj['@value'])
+  }
+
+  return kb.rdfFactory.literal(obj)
+}
+
+/**
+ * Adds the statements in a json-ld list object to {kb}.
+ */
+function listToStatements (kb, obj) {
+  const listId = obj['@id'] ? kb.rdfFactory.namedNode(obj['@id']) : kb.rdfFactory.blankNode()
+
+  const items = obj['@list'].map((listItem => jsonldObjectToTerm(kb, listItem)))
+  const statements = arrayToStatements(kb.rdfFactory, listId, items)
+  kb.addAll(statements)
+
+  return listId
+}
+
+function listToCollection (kb, obj) {
+  if (!Array.isArray(obj)) {
+    throw new TypeError("Object must be an array")
+  }
+  return kb.rdfFactory.collection(obj.map((o) => jsonldObjectToTerm(kb, o)))
+}
+
+/**
+ * Takes a json-ld formatted string {str} and adds its statements to {kb}.
+ *
+ * Ensure that {kb.rdfFactory} is a DataFactory.
+ */
+export default function jsonldParser (str, kb, base, callback) {
+  const baseString = base && Object.prototype.hasOwnProperty.call(base, 'termType')
+    ? base.value
+    : base
+
+  return jsonld
+    .flatten(JSON.parse(str), null, { base: baseString })
+    .then((flattened) => flattened.reduce((store, flatResource) => {
+      const id = flatResource['@id']
+        ? kb.rdfFactory.namedNode(flatResource['@id'])
+        : kb.rdfFactory.blankNode()
+
+      for (const property of Object.keys(flatResource)) {
+        if (property === '@id') {
+          continue
+        }
+        const value = flatResource[property]
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) {
+            kb.addStatement(kb.rdfFactory.quad(id, kb.rdfFactory.namedNode(property), jsonldObjectToTerm(kb, value[i])))
+          }
+        } else {
+          kb.addStatement(kb.rdfFactory.quad(id, kb.rdfFactory.namedNode(property), jsonldObjectToTerm(kb, value)))
+        }
+      }
+
+      return kb
+    }, kb))
+    .then(callback)
+    .catch(callback)
+}

--- a/src/literal.js
+++ b/src/literal.js
@@ -2,7 +2,7 @@
 import ClassOrder from './class-order'
 import NamedNode from './named-node'
 import Node from './node-internal'
-import XSD from './xsd'
+import XSD from './xsd-internal'
 
 export default class Literal extends Node {
   constructor (value, language, datatype) {
@@ -37,24 +37,27 @@ export default class Literal extends Node {
   set language (language) {
     this.lang = language || ''
   }
-  toNT () {
-    if (typeof this.value === 'number') {
-      return this.toString()
-    } else if (typeof this.value !== 'string') {
+  toNT() {
+    return Literal.toNT(this)
+  }
+  static toNT (literal) {
+    if (typeof literal.value === 'number') {
+      return '' + literal.value
+    } else if (typeof literal.value !== 'string') {
       throw new Error('Value of RDF literal is not string or number: ' +
-        this.value)
+        literal.value)
     }
-    var str = this.value
+    var str = literal.value
     str = str.replace(/\\/g, '\\\\')
     str = str.replace(/\"/g, '\\"')
     str = str.replace(/\n/g, '\\n')
     str = '"' + str + '"'
 
-    if (this.language) {
-      str += '@' + this.language
-    } else if (!this.datatype.equals(XSD.string)) {
+    if (literal.language) {
+      str += '@' + literal.language
+    } else if (!literal.datatype.equals(XSD.string)) {
       // Only add datatype if it's not a string
-      str += '^^' + this.datatype.toCanonical()
+      str += '^^' + literal.datatype.toCanonical()
     }
     return str
   }

--- a/src/n3parser.js
+++ b/src/n3parser.js
@@ -1316,9 +1316,9 @@ __SinkParser.prototype.nodeOrLiteral = function(str, i, res) {
 		var val = m[0];
 		j = i + val.length;
 		if ((val.indexOf("T") >= 0)) {
-		    res.push(this._store.literal(val, undefined, this._store.sym(DATETIME_DATATYPE)));
+		    res.push(this._store.literal(val, this._store.sym(DATETIME_DATATYPE)));
 		} else {
-		    res.push(this._store.literal(val, undefined, this._store.sym(DATE_DATATYPE)));
+		    res.push(this._store.literal(val, this._store.sym(DATE_DATATYPE)));
 		}
 
 	    } else {
@@ -1330,13 +1330,13 @@ __SinkParser.prototype.nodeOrLiteral = function(str, i, res) {
 		j =  ( i + number_syntax.lastIndex ) ;
 		var val = str.slice( i, j);
 		if ((val.indexOf("e") >= 0)) {
-		    res.push(this._store.literal(parseFloat(val), undefined, this._store.sym(FLOAT_DATATYPE)));
+		    res.push(this._store.literal(parseFloat(val), this._store.sym(FLOAT_DATATYPE)));
 		}
 		else if ((str.slice( i, j).indexOf(".") >= 0)) {
-		    res.push(this._store.literal(parseFloat(val), undefined, this._store.sym(DECIMAL_DATATYPE)));
+		    res.push(this._store.literal(parseFloat(val), this._store.sym(DECIMAL_DATATYPE)));
 		}
 		else {
-		    res.push(this._store.literal(parseInt(val), undefined, this._store.sym(INTEGER_DATATYPE)));
+		    res.push(this._store.literal(parseInt(val), this._store.sym(INTEGER_DATATYPE)));
 		}
 	    };
 	    return j; // Where we have got up to
@@ -1371,7 +1371,7 @@ __SinkParser.prototype.nodeOrLiteral = function(str, i, res) {
                 var j = this.uri_ref2(str,  ( j + 2 ) , res2);
                 var dt = res2[0];
             }
-            res.push(this._store.literal(s, lang, dt));
+            res.push(this._store.literal(s, lang || dt));
             return j;
         }
         else {

--- a/src/node.js
+++ b/src/node.js
@@ -38,17 +38,17 @@ Node.toJS = function toJS (term) {
     return term.elements.map(Node.toJS) // Array node (not standard RDFJS)
   }
   if (!term.datatype) return term // Objects remain objects
-  if (term.datatype.sameTerm(ns.xsd('boolean'))) {
+  if (term.datatype.equals(ns.xsd('boolean'))) {
     return term.value === '1'
   }
-  if (term.datatype.sameTerm(ns.xsd('dateTime')) ||
-    term.datatype.sameTerm(ns.xsd('date'))) {
+  if (term.datatype.equals(ns.xsd('dateTime')) ||
+    term.datatype.equals(ns.xsd('date'))) {
     return new Date(term.value)
   }
   if (
-    term.datatype.sameTerm(ns.xsd('integer')) ||
-    term.datatype.sameTerm(ns.xsd('float')) ||
-    term.datatype.sameTerm(ns.xsd('decimal'))
+    term.datatype.equals(ns.xsd('integer')) ||
+    term.datatype.equals(ns.xsd('float')) ||
+    term.datatype.equals(ns.xsd('decimal'))
   ) {
     let z = Number(term.value)
     return Number(term.value)

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,10 +1,7 @@
-import BlankNode from './blank-node'
 import DataFactory from './data-factory'
-import jsonld from 'jsonld'
-import Literal from './literal'
+import jsonldParser from './jsonldparser'
 import { Parser as N3jsParser } from 'n3'  // @@ Goal: remove this dependency
 import N3Parser from './n3parser'
-import NamedNode from './named-node'
 import { parseRDFaDOM } from './rdfaparser'
 import RDFParser from './rdfxmlparser'
 import sparqlUpdateParser from './patch-parser'
@@ -37,24 +34,12 @@ export default function parse (str, kb, base, contentType, callback) {
     } else if (contentType === 'application/sparql-update') { // @@ we handle a subset
       sparqlUpdateParser(str, kb, base)
       executeCallback()
-    } else if (contentType === 'application/ld+json' ||
-               contentType === 'application/nquads' ||
+    } else if (contentType === 'application/ld+json') {
+      jsonldParser(str, kb, base, executeCallback)
+    } else if (contentType === 'application/nquads' ||
                contentType === 'application/n-quads') {
       var n3Parser = new N3jsParser({ factory: DataFactory })
-      var triples = []
-      if (contentType === 'application/ld+json') {
-        var jsonDocument
-        try {
-          jsonDocument = JSON.parse(str)
-        } catch (parseErr) {
-          return callback(parseErr, null)
-        }
-        jsonld.toRDF(jsonDocument,
-          {format: 'application/nquads', base},
-          nquadCallback)
-      } else {
-        nquadCallback(null, str)
-      }
+      nquadCallback(null, str)
     } else {
       throw new Error("Don't know how to parse " + contentType + ' yet')
     }

--- a/src/query.js
+++ b/src/query.js
@@ -99,7 +99,7 @@ export function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
       if (formula.redirections[other]) {
         other = formula.redirections[other]
       }
-      if (actual.sameTerm(other) || (actual.uri && actual.uri === defaultDocumentURI)) { // Used to mean 'any graph' in a query
+      if (actual.equals(other) || (actual.uri && actual.uri === defaultDocumentURI)) { // Used to mean 'any graph' in a query
         return [[ [], null ]]
       }
       return []
@@ -309,10 +309,10 @@ export function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
       } else {
         t = bind(terms[i], bindings) // returns the RDF binding if bound, otherwise itself
         // if (terms[i]!=bind(terms[i],bindings) alert("Term: "+terms[i]+"Binding: "+bind(terms[i], bindings))
-        if (f.redirections[t.hashString()]) {
-          t = f.redirections[t.hashString()] // redirect
+        if (f.redirections[f.id(t)]) {
+          t = f.redirections[f.id(t)] // redirect
         }
-        termIndex = ind[i][t.hashString()]
+        termIndex = ind[i][f.id(t)]
 
         if (!termIndex) {
           item.index = []

--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -154,7 +154,7 @@ export default function RDFParser(store) {
         this.addSymbol(this.ARC, uri)
       },         /** Add a literal to this frame */'addLiteral': function (value) {
         if (this.parent.datatype) {
-          this.node = this.store.literal(value, '', this.store.sym(this.parent.datatype))
+          this.node = this.store.literal(value, this.store.sym(this.parent.datatype))
         } else {
           this.node = this.store.literal(value, this.lang)
         }

--- a/src/sparql-to-query.js
+++ b/src/sparql-to-query.js
@@ -110,7 +110,6 @@ export default function SPARQLToQuery (SPARQL, testMode, kb) {
       // alert(end2)
       res[1] = kb.literal(
         str.slice(ind + 1, ind + 1 + end),
-        '',
         kb.sym(removeBrackets(
           str.slice(ind + 4 + end, ind + 2 + end + end2))
         )
@@ -129,7 +128,7 @@ export default function SPARQLToQuery (SPARQL, testMode, kb) {
         parseLiterals(str.slice(end + ind + 2 + end2))
       )
     } else {
-      res[1] = kb.literal(str.slice(ind + 1, ind + 1 + end), '', null)
+      res[1] = kb.literal(str.slice(ind + 1, ind + 1 + end))
       log.info('Literal found: ' + res[1])
       res = res.concat(parseLiterals(str.slice(end + ind + 2))) // finds any other literals
     }
@@ -337,7 +336,7 @@ export default function SPARQLToQuery (SPARQL, testMode, kb) {
       return varstr + ' = ' + value.toNT()
     }
     this.test = function (term) {
-      return value.sameTerm(term)
+      return value.equals(term)
     }
     return this
   }

--- a/src/update-manager.js
+++ b/src/update-manager.js
@@ -11,6 +11,7 @@ import DataFactory from './data-factory'
 import Namespace from './namespace'
 import Serializer from './serializer'
 import { join as uriJoin } from './uri'
+import { isStore } from './util'
 import * as Util from './util'
 
 /** Update Manager
@@ -194,7 +195,7 @@ export default class UpdateManager {
     bnodes.sort() // in place sort - result may have duplicates
     var bnodes2 = []
     for (let j = 0; j < bnodes.length; j++) {
-      if (j === 0 || !bnodes[j].sameTerm(bnodes[j - 1])) {
+      if (j === 0 || !bnodes[j].equals(bnodes[j - 1])) {
         bnodes2.push(bnodes[j])
       }
     }
@@ -669,10 +670,10 @@ export default class UpdateManager {
     try {
       var kb = this.store
       var ds = !deletions ? []
-        : deletions instanceof IndexedFormula ? deletions.statements
+        : isStore(deletions) ? deletions.statements
           : deletions instanceof Array ? deletions : [ deletions ]
       var is = !insertions ? []
-        : insertions instanceof IndexedFormula ? insertions.statements
+        : isStore(insertions) ? insertions.statements
           : insertions instanceof Array ? insertions : [ insertions ]
       if (!(ds instanceof Array)) {
         throw new Error('Type Error ' + (typeof ds) + ': ' + ds)
@@ -697,7 +698,7 @@ export default class UpdateManager {
       var clauses = { 'delete': ds, 'insert': is }
       verbs.map(function (verb) {
         clauses[verb].map(function (st) {
-          if (!doc.sameTerm(st.why)) {
+          if (!doc.equals(st.why)) {
             throw new Error('update: destination ' + doc +
               ' inconsistent with delete quad ' + st.why)
           }

--- a/src/util.js
+++ b/src/util.js
@@ -20,6 +20,28 @@ export function linkRelationProperty(relation){
   return new NamedNode('http://www.w3.org/ns/iana/link-relations/relation#' + relation.trim())
 }
 
+export const appliedFactoryMethods = [
+  'blankNode',
+  'defaultGraph',
+  'literal',
+  'namedNode',
+  'quad',
+  'variable',
+  'supports',
+]
+
+export function isStatement(obj) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, "subject")
+}
+
+export function isStore(obj) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, "statements")
+}
+
+export function isNamedNode(obj) {
+  return obj && Object.prototype.hasOwnProperty.call(obj, "termType") && obj.termType === "NamedNode"
+}
+
 /**
  * Loads ontologies of the data we load (this is the callback from the kb to
  * the fetcher).
@@ -271,17 +293,21 @@ export function heavyCompare (x, y, g, uriMap) {
     lis.sort()
     return lis.join('\n')
   }
+  const comparison = Object.prototype.hasOwnProperty.call(g, "compareTerm")
+    ? g.compareTerm(x, y)
+    : x.compareTerm(y)
+
   if ((x.termType === 'BlankNode') && (y.termType === 'BlankNode')) {
-    if (x.compareTerm(y) === 0) return 0 // Same
+    if (comparison === 0) return 0 // Same
     if (signature(x) > signature(y)) return +1
     if (signature(x) < signature(y)) return -1
-    return x.compareTerm(y)  // Too bad -- this order not canonical.
+    return comparison  // Too bad -- this order not canonical.
     // throw "different bnodes indistinquishable for sorting"
   } else {
     if (uriMap && x.uri && y.uri){
       return (uriMap[x.uri] || x.uri).localeCompare(uriMap[y.uri] || y.uri)
     }
-    return x.compareTerm(y)
+    return comparison
   }
 }
 
@@ -330,10 +356,10 @@ export function RDFArrayRemove (a, x) {
   for (var i = 0; i < a.length; i++) {
     // TODO: This used to be the following, which didnt always work..why
     // if(a[i] === x)
-    if (a[i].subject.sameTerm(x.subject) &&
-      a[i].predicate.sameTerm(x.predicate) &&
-      a[i].object.sameTerm(x.object) &&
-      a[i].why.sameTerm(x.why)) {
+    if (a[i].subject.equals(x.subject) &&
+      a[i].predicate.equals(x.predicate) &&
+      a[i].object.equals(x.object) &&
+      a[i].why.equals(x.why)) {
       a.splice(i, 1)
       return
     }

--- a/src/variable.js
+++ b/src/variable.js
@@ -33,10 +33,13 @@ export default class Variable extends Node {
     return (ref = bindings[this.toNT()]) != null ? ref : this
   }
   toString () {
-    if (this.uri.slice(0, this.base.length) === this.base) {
-      return '?' + this.uri.slice(this.base.length)
+    return Variable.toString(this)
+  }
+  static toString (variable) {
+    if (variable.uri.slice(0, variable.base.length) === variable.base) {
+      return '?' + variable.uri.slice(variable.base.length)
     }
-    return '?' + this.uri
+    return '?' + variable.uri
   }
 }
 

--- a/src/xsd-internal.js
+++ b/src/xsd-internal.js
@@ -1,0 +1,11 @@
+import NamedNode from './named-node';
+
+export default {
+  boolean: new NamedNode('http://www.w3.org/2001/XMLSchema#boolean'),
+  dateTime: new NamedNode('http://www.w3.org/2001/XMLSchema#dateTime'),
+  decimal: new NamedNode('http://www.w3.org/2001/XMLSchema#decimal'),
+  double: new NamedNode('http://www.w3.org/2001/XMLSchema#double'),
+  integer: new NamedNode('http://www.w3.org/2001/XMLSchema#integer'),
+  langString: new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'),
+  string: new NamedNode('http://www.w3.org/2001/XMLSchema#string'),
+}

--- a/src/xsd.js
+++ b/src/xsd.js
@@ -1,12 +1,19 @@
-import NamedNode from './named-node'
+import CanonicalDataFactory from './data-factory-internal'
 
-export default class XSD {}
+export function createXSD(localFactory = CanonicalDataFactory) {
+  class XSD {}
 
-XSD.boolean = new NamedNode('http://www.w3.org/2001/XMLSchema#boolean')
-XSD.dateTime = new NamedNode('http://www.w3.org/2001/XMLSchema#dateTime')
-XSD.decimal = new NamedNode('http://www.w3.org/2001/XMLSchema#decimal')
-XSD.double = new NamedNode('http://www.w3.org/2001/XMLSchema#double')
-XSD.integer = new NamedNode('http://www.w3.org/2001/XMLSchema#integer')
-XSD.langString =
-  new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
-XSD.string = new NamedNode('http://www.w3.org/2001/XMLSchema#string')
+  XSD.boolean = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#boolean')
+  XSD.dateTime = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#dateTime')
+  XSD.decimal = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#decimal')
+  XSD.double = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#double')
+  XSD.integer = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#integer')
+  XSD.langString = localFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
+  XSD.string = localFactory.namedNode('http://www.w3.org/2001/XMLSchema#string')
+
+  return XSD
+}
+
+const defaultXSD = createXSD(CanonicalDataFactory)
+
+export default defaultXSD

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -2,7 +2,10 @@
 import { expect } from 'chai'
 
 import parse from '../../src/parse'
+import CanonicalDataFactory from '../../src/data-factory-internal'
 import DataFactory from '../../src/data-factory'
+import Node from '../../src/node'
+import defaultXSD from '../../src/xsd'
 
 describe('Parse', () => {
   describe('ttl', () => {
@@ -41,20 +44,154 @@ describe('Parse', () => {
             "homepage": {
               "@id": "http://xmlns.com/foaf/0.1/homepage",
               "@type": "@id"
-            }
+            },
+            "name": {
+              "@id": "http://xmlns.com/foaf/0.1/name",
+              "@container": "@language"
+            },
+            "height": {
+              "@id": "http://schema.org/height",
+              "@type": "xsd:float"
+            },
+            "list": {
+              "@id": "https://example.org/ns#listProp",
+              "@container": "@list"
+            },
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
           },
           "@id": "../#me",
-          "homepage": "xyz"
+          "homepage": "xyz",
+          "name": {
+            "en": "The Queen",
+            "de": [ "Die Königin", "Ihre Majestät" ]
+          },
+          "height": "173.9",
+          "list": [
+            "list item 0",
+            "list item 1",
+            "list item 2"
+          ]
+        }`
+        store = DataFactory.graph(undefined, { rdfFactory: CanonicalDataFactory })
+        parse(content, store, base, mimeType, done)
+      })
+
+      it('uses the specified base IRI', () => {
+        expect(store.rdfFactory.supports["COLLECTIONS"]).to.be.false
+        const homePageHeight = 5 // homepage + height + 3 x name
+        const list = 2 * 3 + 1 // (rdf:first + rdf:rest) * 3 items + listProp
+        expect(store.statements).to.have.length(homePageHeight + list);
+
+        const height = store.statements[0]
+        expect(height.subject.value).to.equal('https://www.example.org/#me')
+        expect(height.predicate.value).to.equal('http://schema.org/height')
+        expect(height.object.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#float')
+        expect(height.object.value).to.equal('173.9')
+
+        const homepage = store.statements[1]
+        expect(homepage.subject.value).to.equal('https://www.example.org/#me')
+        expect(homepage.predicate.value).to.equal('http://xmlns.com/foaf/0.1/homepage')
+        expect(homepage.object.value).to.equal('https://www.example.org/abc/xyz')
+
+        const nameDe1 = store.statements[2]
+        expect(nameDe1.subject.value).to.equal('https://www.example.org/#me')
+        expect(nameDe1.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
+        expect(nameDe1.object.value).to.equal('Die Königin')
+
+        const nameDe2 = store.statements[3]
+        expect(nameDe2.subject.value).to.equal('https://www.example.org/#me')
+        expect(nameDe2.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
+        expect(nameDe2.object.value).to.equal('Ihre Majestät')
+
+        const nameEn = store.statements[4]
+        expect(nameEn.subject.value).to.equal('https://www.example.org/#me')
+        expect(nameEn.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
+        expect(nameEn.object.value).to.equal('The Queen')
+
+        const list0First = store.statements[5]
+        expect(list0First.subject.value).to.equal('n1')
+        expect(list0First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
+        expect(list0First.object.value).to.equal('list item 0')
+
+        const list0Rest = store.statements[6]
+        expect(list0Rest.subject.value).to.equal('n1')
+        expect(list0Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
+        expect(list0Rest.object.value).to.equal(store.statements[7].subject.value)
+
+        const list1First = store.statements[7]
+        expect(list1First.subject.value).to.equal('n2')
+        expect(list1First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
+        expect(list1First.object.value).to.equal('list item 1')
+
+        const list1Rest = store.statements[8]
+        expect(list1Rest.subject.value).to.equal('n2')
+        expect(list1Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
+        expect(list1Rest.object.value).to.equal(store.statements[9].subject.value)
+
+        const list2First = store.statements[9]
+        expect(list2First.subject.value).to.equal('n3')
+        expect(list2First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
+        expect(list2First.object.value).to.equal('list item 2')
+
+        const list2Rest = store.statements[10]
+        expect(list2Rest.subject.value).to.equal('n3')
+        expect(list2Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
+        expect(list2Rest.object.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')
+
+        const listProp = store.statements[11]
+        expect(listProp.subject.value).to.equal('https://www.example.org/#me')
+        expect(listProp.predicate.value).to.equal('https://example.org/ns#listProp')
+        expect(listProp.object.value).to.equal('n1')
+      })
+    })
+
+    describe('with collections enabled', () => {
+      let store
+      before(done => {
+        const base = 'https://www.example.org/abc/def'
+        const mimeType = 'application/ld+json'
+        const content = `
+        {
+          "@context": {
+            "list": {
+              "@id": "https://example.org/ns#listProp",
+              "@container": "@list"
+            },
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+          },
+          "@id": "../#me",
+          "list": [
+            "list item 0",
+            1,
+            { "@id": "http://example.com/2" }
+          ]
         }`
         store = DataFactory.graph()
         parse(content, store, base, mimeType, done)
       })
 
       it('uses the specified base IRI', () => {
+        expect(store.rdfFactory.supports["COLLECTIONS"]).to.be.true
+        console.log(store.statements)
         expect(store.statements).to.have.length(1);
-        const statement = store.statements[0]
-        expect(statement.subject.value).to.equal('https://www.example.org/#me')
-        expect(statement.object.value).to.equal('https://www.example.org/abc/xyz')
+
+        const collection = store.statements[0]
+        expect(collection.subject.value).to.equal('https://www.example.org/#me')
+        expect(collection.predicate.value).to.equal('https://example.org/ns#listProp')
+        expect(collection.object.termType).to.equal('Collection')
+        expect(collection.object.elements.length).to.equal(3)
+
+        expect(collection.object.elements[0].termType).to.equal('Literal')
+        expect(collection.object.elements[0].datatype.value).to.equal(defaultXSD.string.value)
+        expect(collection.object.elements[0].value).to.equal(`list item 0`)
+
+        expect(collection.object.elements[1].termType).to.equal('Literal')
+        expect(collection.object.elements[1].datatype.value).to.equal(defaultXSD.integer.value)
+        expect(collection.object.elements[1].value).to.equal(`1`)
+
+        expect(collection.object.elements[2].termType).to.equal('NamedNode')
+        expect(collection.object.elements[2].value).to.equal(`http://example.com/2`)
+
       })
     })
   })


### PR DESCRIPTION
This removes the n3 library step when parsing json-ld.

I made two prior commit in order to make it possible for the implementation to use the proper rdfjs task force data factory methods on formula/indexed formula/store.
