### PR TITLE
Move solid-auth-client to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,18 @@ for more information.
 
 ## Install
 
+#### Browser (using a bundler like Webpack)
+
 ```bash
-npm install
+npm install rdflib solid-auth-client
+```
+
+#### Browser (generating a <script> file to include)
+
+```bash
+git clone git@github.com:linkeddata/rdflib.js.git;
+cd rdflib.js;
+npm install;
 ```
 
 Generate the dist directory

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "jsonld": "^1.6.2",
     "n3": "^1.2.0",
     "solid-auth-cli": "^1.0.8",
-    "solid-auth-client": "^2.3.0",
     "xmldom": "^0.1.27"
+  },
+  "peerDependencies": {
+    "solid-auth-client": "^2.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
@@ -63,6 +65,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^7.4.1",
     "sinon-chai": "^3.3.0",
+    "solid-auth-client": "^2.3.0",
     "source-map-loader": "^0.2.4",
     "typescript": "^3.6.3",
     "webpack": "^4.39.2",


### PR DESCRIPTION
With solid-auth-client as a regular dependency, npm will give rdflib its own instance of it when its version no longer aligns with the one the app itself has installed. This can happen e.g. in the following situation:

```bash
npm install solid-auth-client;
npm install rdflib;
# <New version of solid-auth-client is released>
npm upgrade solid-auth-client;
```

Now `node_modules/rdflib/node_modules/solid-auth-client` contains a copy that is still pinned to the older version, whereas `node_modules/solid-auth-client` was upgraded.

I'm quite sure that that's what will happen, and that that's not intended to happen, but to be completely sure I'm also pinging @dmitrizagidulin, who I think knows most of solid-auth-client (?), and @RubenVerborgh, who [added the warning](https://github.com/solid/solid-auth-client/commit/57a862338136367eb5f92c8f853aaf5d3fdffd65) about multiple instances of solid-auth-client being loaded.

**Edit:** For those coming across later and not wanting to read the entire back-and-forth between Ruben and me below, the summary is that [Ruben is not against merging this](https://github.com/linkeddata/rdflib.js/pull/361#issuecomment-539515112), but thinks that it will not completely solve the problem, and thinks that `peerDependencies` are not meant for this use case.