### PR TITLE
Stop pretending that we export ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "module": "src/index.js",
   "sideEffects": false,
   "keywords": [
     "linkeddata",


### PR DESCRIPTION
This is something of a workaround for #381. Ideally, rdflib starts exporting ES Modules again, and this key in `package.json` will be re-introduced pointing to the correct location. But until then, it's best not to pretend it exports ES Modules.