### PR TITLE
fix #364 Unable to serialize JSON-LD

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -10,15 +10,15 @@ export function convertToJson (n3String, jsonCallback) {
   })
   asyncLib.waterfall([
     function (callback) {
-      n3Parser.parse(n3String, callback)
-    },
-    function (triple, prefix, callback) {
-      if (triple !== null) {
-        n3Writer.addTriple(triple)
-      }
-      if (typeof callback === 'function') {
-        n3Writer.end(callback)
-      }
+      n3Parser.parse(n3String, function (error, quad, prefixes) {
+        if (error) {
+          throw error;
+        } else if (quad !== null) {
+          n3Writer.addQuad(quad);
+        } else {
+          n3Writer.end(callback);
+        }
+      });
     },
     function (result, callback) {
       try {
@@ -47,15 +47,15 @@ export function convertToNQuads (n3String, nquadCallback) {
   })
   asyncLib.waterfall([
     function (callback) {
-      n3Parser.parse(n3String, callback)
-    },
-    function (triple, prefix, callback) {
-      if (triple !== null) {
-        n3Writer.addTriple(triple)
-      }
-      if (typeof callback === 'function') {
-        n3Writer.end(callback)
-      }
+      n3Parser.parse(n3String, function (error, triple, prefixes) {
+        if (error) {
+          throw error;
+        } else if (quad !== null) {
+          n3Writer.addQuad(quad);
+        } else {
+          n3Writer.end(callback);
+        }
+      });
     },
     function (result, callback) {
       nquadString = result

--- a/src/convert.js
+++ b/src/convert.js
@@ -12,7 +12,7 @@ export function convertToJson (n3String, jsonCallback) {
     function (callback) {
       n3Parser.parse(n3String, function (error, quad, prefixes) {
         if (error) {
-          throw error;
+          callback(error);
         } else if (quad !== null) {
           n3Writer.addQuad(quad);
         } else {
@@ -49,7 +49,7 @@ export function convertToNQuads (n3String, nquadCallback) {
     function (callback) {
       n3Parser.parse(n3String, function (error, triple, prefixes) {
         if (error) {
-          throw error;
+          callback(error);
         } else if (quad !== null) {
           n3Writer.addQuad(quad);
         } else {


### PR DESCRIPTION
[convertToJson's first waterfall function](https://github.com/linkeddata/rdflib.js/blob/master/src/convert.js#L13) is expected to get [called repeatedly](https://github.com/rdfjs/N3.js#from-an-rdf-document-to-quads). Apparently [async's waterfall](https://caolan.github.io/async/v3/docs.html#waterfall) expects a [single invocation](https://github.com/caolan/async/blob/master/lib/waterfall.js#L72). I moved the second callback into the first:
``` javascript
    n3Parser.parse(n3String, function (error, quad, prefix) {
      if (error) {
        throw error;
      } else if (quad !== null) {
        n3Writer.addQuad(quad);
      } else {
        n3Writer.end(callback);
      }
    });
```

https://github.com/linkeddata/rdflib.js/issues/364#issuecomment-584894816