### PR TITLE
fix serializing more than one custom namespaces

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -71,8 +71,8 @@ export default (function () {
   __Serializer.prototype.suggestNamespaces = function (namespaces) {
     for (var px in namespaces) {
       this.suggestPrefix(px, namespaces[px])
-      return this
     }
+    return this
   }
 
   __Serializer.prototype.checkIntegrity = function () {

--- a/tests/serialize/t10-ref.ttl
+++ b/tests/serialize/t10-ref.ttl
@@ -1,32 +1,32 @@
 @prefix : </details.ttl#>.
 @prefix dc: <http://purl.org/dc/elements/1.1/>.
-@prefix sch: <http://www.w3.org/ns/pim/schedule#>.
+@prefix sched: <http://www.w3.org/ns/pim/schedule#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix c: <https://www.w3.org/People/Berners-Lee/card#>.
-@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
 @prefix sp: <http://www.w3.org/ns/pim/space#>.
 @prefix det: <http://linkeddata.github.io/app-schedule/details.ttl#>.
-@prefix rd: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix ic: <http://www.w3.org/2002/12/cal/ical#>.
 @prefix n0: <http://xmlns.com/foaf/0.1/>.
+@prefix rd: <http://www.w3.org/2000/01/rdf-schema#>.
 
 :event
-    a sch:SchedulableEvent;
+    a sched:SchedulableEvent;
     dc:author c:i;
-    dc:created "2015-09-15T11:20:05Z"^^XML:dateTime;
+    dc:created "2015-09-15T11:20:05Z"^^xsd:dateTime;
     sp:inspiration det:event1.
 :event1
     dc:author :id1442316021316;
     dc:title "TAG 2016 Q1 Meeting ";
     rd:comment "Three day meeting, starting date:";
     ic:location "Melbourne Australia";
-    sch:availabilityOptions sch:YesNoMaybe;
-    sch:invitee
+    sched:availabilityOptions sched:YesNoMaybe;
+    sched:invitee
         :id1442316021320, :id1442316359855, :id1442316381050, :id1442316382860,
         :id1442316551915, :id1442316616585, :id1442316618393, :id1442316627647,
         :id1442316628781;
-    sch:option :id1442316021318, :id1442316021319;
-    sch:ready "2015-09-15T11:20:21Z"^^XML:dateTime;
-    sch:results </results.ttl>.
+    sched:option :id1442316021318, :id1442316021319;
+    sched:ready "2015-09-15T11:20:21Z"^^xsd:dateTime;
+    sched:results </results.ttl>.
 :id1442316021316 n0:mbox "timbl@w3.org"; n0:name "Tim BL".
 
 :id1442316021318 ic:dtstart "2016-01-13".


### PR DESCRIPTION
Fixes issue #183 where only the first namespace defined in the store gets used by the serializer for the output.