### PR TITLE
Support saveResponseMetadata for non-http(s) responses and allow them to be edited in data-kitchen

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1666,7 +1666,7 @@ export default class Fetcher implements CallbackifyInterface {
     kb.add(responseNode, this.ns.http('statusText'),
     kb.rdfFactory.literal(response.statusText), responseNode)
 
-    if (!options.resource.value.startsWith('http')) {
+    if (!response.headers) {
       return responseNode
     }
 

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -106,7 +106,7 @@ export default class UpdateManager {
     uri = termValue(uri)
 
     if ((uri as string).slice(0, 8) === 'file:///' || (uri as string).slice(0,6) === 'app://' ) {
-      if (( typeof window != "undefined" && window.hasOwnProperty('kitchen') ) || kb.holds(
+      if (( typeof window != "undefined" && Object.prototype.hasOwnProperty.call(window,'kitchen') ) || kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
           this.store.rdfFactory.namedNode('http://www.w3.org/2007/ont/link#MachineEditableDocument'))) {

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -106,7 +106,7 @@ export default class UpdateManager {
     uri = termValue(uri)
 
     if ((uri as string).slice(0, 8) === 'file:///' || (uri as string).slice(0,6) === 'app://' ) {
-      if ((typeof window != "undefined" && window.kitchen) || kb.holds(
+      if ((typeof window != "undefined" && typeof window.kitchen !="undefined") || kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
           this.store.rdfFactory.namedNode('http://www.w3.org/2007/ont/link#MachineEditableDocument'))) {

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -106,7 +106,7 @@ export default class UpdateManager {
     uri = termValue(uri)
 
     if ((uri as string).slice(0, 8) === 'file:///' || (uri as string).slice(0,6) === 'app://' ) {
-      if (typeof kitchen != "undefined" || kb.holds(
+      if ((typeof window != "undefined" && window.kitchen) || kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
           this.store.rdfFactory.namedNode('http://www.w3.org/2007/ont/link#MachineEditableDocument'))) {

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -106,7 +106,7 @@ export default class UpdateManager {
     uri = termValue(uri)
 
     if ((uri as string).slice(0, 8) === 'file:///' || (uri as string).slice(0,6) === 'app://' ) {
-      if ((typeof window != "undefined" && typeof window.kitchen !="undefined") || kb.holds(
+      if (( typeof window != "undefined" && window.hasOwnProperty('kitchen') ) || kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
           this.store.rdfFactory.namedNode('http://www.w3.org/2007/ont/link#MachineEditableDocument'))) {

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -105,8 +105,8 @@ export default class UpdateManager {
     }
     uri = termValue(uri)
 
-    if ((uri as string).slice(0, 8) === 'file:///') {
-      if (kb.holds(
+    if ((uri as string).slice(0, 8) === 'file:///' || (uri as string).slice(0,6) === 'app://' ) {
+      if (typeof kitchen != "undefined" || kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
           this.store.rdfFactory.namedNode('http://www.w3.org/2007/ont/link#MachineEditableDocument'))) {


### PR DESCRIPTION
If we get headers, we should save them.  Solid-rest provides content-type, link, and other headers for file:// and app:// responses and we need them for data-kitchen.