### PR TITLE
[on hold] Trying to add unit test for sparql-update

### DIFF
--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -2,6 +2,7 @@
 import { expect } from 'chai'
 
 import parse from '../../src/parse'
+import { SPARQLUpdateContentType } from '../../src/types'
 import CanonicalDataFactory from '../../src/factories/canonical-data-factory'
 import defaultXSD from '../../src/xsd'
 import DataFactory from '../../src/factories/rdflib-data-factory'
@@ -228,6 +229,17 @@ describe('Parse', () => {
         expect(collection.object.elements[2].value).to.equal(`http://example.com/2`)
 
       })
+    })
+  })
+  describe('sparlq-update', () => {
+    it.only('add a triple to an empty document', () => {
+      let base = 'https://example.com/'
+      let mimeType = SPARQLUpdateContentType
+      console.log(mimeType)
+      let store = DataFactory.graph()
+      let content = 'INSERT DATA { <https://example.com/#s> <https://example.com/#p> <https://example.com/#o>. }'
+      parse(content, store, base, mimeType)
+      expect(store.statements[0]).to.eql([])
     })
   })
 })

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -232,14 +232,26 @@ describe('Parse', () => {
     })
   })
   describe('sparlq-update', () => {
-    it.only('add a triple to an empty document', () => {
+    it('parses a query into the store as subgraphs', () => {
+      // FIXME: are subgraphs allowed in RDF?
+      // See https://github.com/linkeddata/rdflib.js/pull/401
       let base = 'https://example.com/'
       let mimeType = SPARQLUpdateContentType
-      console.log(mimeType)
       let store = DataFactory.graph()
       let content = 'INSERT DATA { <https://example.com/#s> <https://example.com/#p> <https://example.com/#o>. }'
       parse(content, store, base, mimeType)
-      expect(store.statements[0]).to.eql([])
+      expect(store.toNT()).to.eql('{<https://example.com/#query> <http://www.w3.org/ns/pim/patch#insert> {<https://example.com/#s> <https://example.com/#p> <https://example.com/#o> .} .}')
     })
+  })
+})
+
+describe('sparlqUpdateParser', () => {
+  it('adds a triple to insert graph of patch object', () => {
+    let base = 'https://example.com/'
+    let mimeType = SPARQLUpdateContentType
+    let store = DataFactory.graph()
+    let content = 'INSERT DATA { <https://example.com/#s> <https://example.com/#p> <https://example.com/#o>. }'
+    const patchObject = sparqlUpdateParser(content, store, base)
+    expect(patchObject.insert.toNT()).to.eql('{<https://example.com/#s> <https://example.com/#p> <https://example.com/#o> .}')
   })
 })


### PR DESCRIPTION
This PR adds a unit test that fails.
The error seems to come from:
https://github.com/linkeddata/rdflib.js/blob/master/src/n3parser.js#L810

Followed by:
https://github.com/linkeddata/rdflib.js/blob/master/src/patch-parser.js#L70

`res2[0]` there is an `IndexedFormula` containing the triple that was inserted, but it's being used as the object in a triple of the form `<query> snqs:insert [IndexedFormula]`. I think the intention of this code must have been to insert a list or a collection or a blank node or something there.

I'll delve into the git history because I'm pretty sure this did work last year.