### PR TITLE
Fix SPARQL patch parsing

### DIFF
--- a/src/utils/terms.ts
+++ b/src/utils/terms.ts
@@ -1,5 +1,5 @@
 import {
-  ObjectType, CollectionTermType, NamedNodeTermType, VariableTermType, BlankNodeTermType, LiteralTermType, DefaultGraphTermType,
+  ObjectType, CollectionTermType, NamedNodeTermType, VariableTermType, BlankNodeTermType, LiteralTermType, GraphTermType, DefaultGraphTermType,
 } from '../types'
 import Collection from '../collection'
 import IndexedFormula from '../store'
@@ -40,7 +40,8 @@ export function isRDFlibObject(obj: any): obj is ObjectType {
     obj.termType === VariableTermType ||
     obj.termType === BlankNodeTermType ||
     obj.termType === CollectionTermType ||
-    obj.termType === LiteralTermType
+    obj.termType === LiteralTermType ||
+    obj.termType === GraphTermType
   )
 }
 

--- a/tests/unit/patch-parser-test.js
+++ b/tests/unit/patch-parser-test.js
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+import { expect } from 'chai'
+
+import sparqlUpdateParser from '../../src/patch-parser'
+import IndexedFormula from '../../src/store'
+
+describe('sparqlUpdateParser', () => {
+  it('parses a basic SPARQL UPDATE query', () => {
+    const query = `
+      DELETE {
+        <#me> <http://xmlns.com/foaf/0.1/givenName> ?name.
+      }
+      INSERT {
+        <#me> <http://xmlns.com/foaf/0.1/givenName> "Ruben".
+      }
+      WHERE {
+        <#me> <http://xmlns.com/foaf/0.1/lastName> "Verborgh".
+      }`
+    const store = new IndexedFormula()
+    const baseUri = 'https://ruben.verborgh.org/profile/'
+
+    const result = sparqlUpdateParser(query, store, baseUri)
+
+    expect(result.delete.statements.map(termValues)).to.eql([
+      {
+        subject: "https://ruben.verborgh.org/profile/#me",
+        predicate: "http://xmlns.com/foaf/0.1/givenName",
+        object: "name",
+      },
+    ])
+    expect(result.insert.statements.map(termValues)).to.eql([
+      {
+        subject: "https://ruben.verborgh.org/profile/#me",
+        predicate: "http://xmlns.com/foaf/0.1/givenName",
+        object: "Ruben",
+      },
+    ])
+    expect(result.where.statements.map(termValues)).to.eql([
+      {
+        subject: "https://ruben.verborgh.org/profile/#me",
+        predicate: "http://xmlns.com/foaf/0.1/lastName",
+        object: "Verborgh",
+      },
+    ])
+  })
+})
+
+function termValues({ subject, predicate, object }) {
+  return {
+    subject: subject.value,
+    predicate: predicate.value,
+    object: object.value,
+  }
+}


### PR DESCRIPTION
Apparently SPARQL patch parsing is broken, and has been for a while (likely since typings were introduced)