### PR TITLE
Store requestedURI as NamedNode

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1597,7 +1597,8 @@ export default class Fetcher implements CallbackifyInterface {
     header: string
   ): undefined | string[] {
     const kb = this.store
-    const requests = kb.each(undefined, this.ns.link('requestedURI'), doc) as Quad_Subject[]
+    const docuri: string = doc.value
+    const requests = kb.each(undefined, this.ns.link('requestedURI'), kb.rdfFactory.literal(docuri)) as Quad_Subject[]
 
     for (let r = 0; r < requests.length; r++) {
       let request = requests[r]
@@ -1643,7 +1644,9 @@ export default class Fetcher implements CallbackifyInterface {
 
     kb.add(req, this.ns.rdfs('label'),
       kb.rdfFactory.literal(timeNow + ' Request for ' + docuri), this.appNode)
-    kb.add(req, this.ns.link('requestedURI'), kb.rdfFactory.namedNode(docuri), this.appNode)
+    // We store the docuri as a string, not as a node,
+    // see https://github.com/linkeddata/rdflib.js/pull/427#pullrequestreview-447910061
+    kb.add(req, this.ns.link('requestedURI'), kb.rdfFactory.literal(docuri), this.appNode)
     kb.add(req, this.ns.link('status'), kb.collection(), this.appNode)
   }
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1643,7 +1643,7 @@ export default class Fetcher implements CallbackifyInterface {
 
     kb.add(req, this.ns.rdfs('label'),
       kb.rdfFactory.literal(timeNow + ' Request for ' + docuri), this.appNode)
-    kb.add(req, this.ns.link('requestedURI'), kb.rdfFactory.literal(docuri), this.appNode)
+    kb.add(req, this.ns.link('requestedURI'), kb.rdfFactory.namedNode(docuri), this.appNode)
     kb.add(req, this.ns.link('status'), kb.collection(), this.appNode)
   }
 


### PR DESCRIPTION
This fixes a bug where https://github.com/linkeddata/rdflib.js/blob/master/src/fetcher.ts#L1600 would return zero results and the update manager would incorrectly end up at https://github.com/linkeddata/rdflib.js/blob/master/src/update-manager.ts#L593.
