### PR TITLE
A fix to accept headers not being sent correctly in the Fetcher

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1102,7 +1102,7 @@ export default class Fetcher implements CallbackifyInterface {
 
     let { actualProxyURI } = options
 
-    return this._fetch((actualProxyURI as string), options)
+    return this._fetch((actualProxyURI as string), options as any)
       .then(response => this.handleResponse(response, docuri, options),
       error => { // @@ handleError?
         // @ts-ignore Invalid response object
@@ -1541,7 +1541,7 @@ export default class Fetcher implements CallbackifyInterface {
     Fetcher.setCredentials(uri, options)
 
     return new Promise(function (resolve, reject) {
-      fetcher._fetch(uri, options).then(response => {
+      fetcher._fetch(uri, options as any).then(response => {
         if (response.ok) {
           if (method === 'PUT' || method === 'PATCH' || method === 'POST' || method === 'DELETE') {
             fetcher.invalidateCache (uri)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1101,8 +1101,9 @@ export default class Fetcher implements CallbackifyInterface {
     }
 
     let { actualProxyURI } = options
-
-    return this._fetch((actualProxyURI as string), Object.assign({},options))
+    let requestOptions = Object.assign({}, options);
+    requestOptions.headers = Object.assign({}, options.headers);
+    return this._fetch((actualProxyURI as string), requestOptions)
       .then(response => this.handleResponse(response, docuri, options),
       error => { // @@ handleError?
         // @ts-ignore Invalid response object
@@ -1539,9 +1540,10 @@ export default class Fetcher implements CallbackifyInterface {
       (options as any).headers['content-type'] = options.contentType
     }
     Fetcher.setCredentials(uri, options)
-
+    let requestOptions = Object.assign({}, options);
+    requestOptions.headers = Object.assign({}, options.headers);
     return new Promise(function (resolve, reject) {
-      fetcher._fetch(uri, Object.assign({}, options)).then(response => {
+      fetcher._fetch(uri, Object.assign({}, requestOptions)).then(response => {
         if (response.ok) {
           if (method === 'PUT' || method === 'PATCH' || method === 'POST' || method === 'DELETE') {
             fetcher.invalidateCache (uri)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1102,7 +1102,7 @@ export default class Fetcher implements CallbackifyInterface {
 
     let { actualProxyURI } = options
 
-    return this._fetch((actualProxyURI as string), options as any)
+    return this._fetch((actualProxyURI as string), Object.assign({},options))
       .then(response => this.handleResponse(response, docuri, options),
       error => { // @@ handleError?
         // @ts-ignore Invalid response object
@@ -1541,7 +1541,7 @@ export default class Fetcher implements CallbackifyInterface {
     Fetcher.setCredentials(uri, options)
 
     return new Promise(function (resolve, reject) {
-      fetcher._fetch(uri, options as any).then(response => {
+      fetcher._fetch(uri, Object.assign({}, options)).then(response => {
         if (response.ok) {
           if (method === 'PUT' || method === 'PATCH' || method === 'POST' || method === 'DELETE') {
             fetcher.invalidateCache (uri)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -754,8 +754,14 @@ export default class Fetcher implements CallbackifyInterface {
 
   static crossSiteProxy (uri: string): undefined | any {
     if (Fetcher.crossSiteProxyTemplate) {
-      return Fetcher.crossSiteProxyTemplate
+      if (Fetcher.crossSiteProxyTemplate.indexOf('={uri}') !== -1){
+        return Fetcher.crossSiteProxyTemplate
         .replace('{uri}', encodeURIComponent(uri))
+      } else {
+        return Fetcher.crossSiteProxyTemplate
+        .replace('{uri}', encodeURI(uri))
+      }
+      
     } else {
       return undefined
     }
@@ -831,8 +837,13 @@ export default class Fetcher implements CallbackifyInterface {
         typeof document !== 'undefined' && document.location &&
         ('' + document.location).slice(0, 6) === 'https:' && // origin is secure
         uri.slice(0, 5) === 'http:') { // requested data is not
-      return Fetcher.crossSiteProxyTemplate
-        .replace('{uri}', encodeURIComponent(uri))
+          if (Fetcher.crossSiteProxyTemplate.indexOf('={uri}') !== -1){
+            return Fetcher.crossSiteProxyTemplate
+            .replace('{uri}', encodeURIComponent(uri))
+          } else {
+            return Fetcher.crossSiteProxyTemplate
+            .replace('{uri}', encodeURI(uri))
+          }
     }
 
     return uri

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -835,7 +835,6 @@ export default class Fetcher implements CallbackifyInterface {
     // prevent it loading insecure http: stuff so we need proxy.
     if (Fetcher.crossSiteProxyTemplate &&
         typeof document !== 'undefined' && document.location &&
-        ('' + document.location).slice(0, 6) === 'https:' && // origin is secure
         uri.slice(0, 5) === 'http:') { // requested data is not
           if (Fetcher.crossSiteProxyTemplate.indexOf('={uri}') !== -1){
             return Fetcher.crossSiteProxyTemplate


### PR DESCRIPTION
There are 3 fixes contained inside this PR. 

1. Added support for another proxy URL template where the proxy servers doesn't work with URL parameters. This is the case where the proxy server only works with the following template : `http://proxy.com/{uri}`. For example, https://proxy.linkeddatafragments.org/ does this. 

2. We also added support for sending proxy request from `http` instead of requiring `https`. Maybe this might not be necessary, but it was needed in our use case. It would be nice if we could add an option to use `http` instead. 

3. Accept headers weren't being sent correctly with the HTTP requests. Apparently, the problem lies in the `Header` interface from typescript where the specified accept types doesn't get parsed correctly. We fixed it by making use of native javascript `Object.assign({}, header}`. Hopefully it won't cause a security concern with the fix. 