### PR TITLE
support file:/// URIs

### DIFF
--- a/example/file-update.js
+++ b/example/file-update.js
@@ -1,0 +1,45 @@
+// import {SolidNodeClient} from '../../solid-node-client';
+// import * as $rdf from '../';
+const SolidNodeClient = require('../../../solid-node-client').SolidNodeClient;
+const $rdf = require('../')
+const client = new SolidNodeClient({parser:$rdf});
+
+const store   = $rdf.graph();
+const fetcher = $rdf.fetcher(store,{fetch:client.fetch.bind(client)});
+const updater = new $rdf.UpdateManager(store);
+
+let testUrl   = `file://${process.cwd()}/test.ttl`;
+
+let subject   = store.sym(testUrl);
+let predicate = store.sym('https://example.org/message');
+let object    = store.literal('hello world');
+let why       = subject.doc();
+let newObject = store.literal('hello rdflib-via-solid-node-client world');
+
+async function main(){
+  store.add( subject, predicate, object, why );
+  await fetcher.putBack( why );
+  await store.remove( subject, predicate, object, why );
+  show('before load');
+  await fetcher.load(why)
+  show('after load');
+  let ins = $rdf.st( subject, predicate, newObject, why )
+  let del = store.statementsMatching( subject, predicate )
+  updater.update(del, ins, async (uri, ok, message, response) => {
+    if(ok) {
+      await fetcher.load(why);
+      show('after update');
+      let response = await fetcher.webOperation('DELETE',why);
+      console.log("\nDelete operation returned status : "+response.status)
+    }
+    else {
+      console.warn("Could not update :"+message)
+    }
+  });
+}
+function show(state){
+  let message = store.any( subject, predicate );
+  if(message) console.warn("\n",state + ' store contains '+message.value)
+  else console.warn("\n",state + ' store is empty')
+}
+main();

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1711,9 +1711,6 @@ export default class Fetcher implements CallbackifyInterface {
     if (!response.headers) {
       return responseNode;
     } 
-    // if (!options.resource.value.startsWith('http')) {
-    //  return responseNode
-    // }
 
     // Save the response headers
     response.headers.forEach((value, header) => {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1707,9 +1707,13 @@ export default class Fetcher implements CallbackifyInterface {
     kb.add(responseNode, this.ns.http('statusText'),
     kb.rdfFactory.literal(response.statusText), responseNode)
 
-    if (!options.resource.value.startsWith('http')) {
-      return responseNode
-    }
+    // save metadata based on its existence, not on the protocol
+    if (!response.headers) {
+      return responseNode;
+    } 
+    // if (!options.resource.value.startsWith('http')) {
+    //  return responseNode
+    // }
 
     // Save the response headers
     response.headers.forEach((value, header) => {

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -119,7 +119,7 @@ export default class UpdateManager {
       // console.log('UpdateManager.editable: Not MachineEditableDocument file ' +
       //   uri + '\n')
       // console.log(sts.map((x) => { return (x as Statement).toNT() }).join('\n'))
-      // do NOT fail on file://, check for wac-allow first (see below)
+      // (Jeff: return false later, only if no wac-allow headers)
       // return false
       // @@ Would be nifty of course to see whether we actually have write access first.
     }
@@ -163,12 +163,16 @@ export default class UpdateManager {
               }
             }
           }
-         // respect wac-allow headers for non-http URIs if they exist
+
+         // handle non-http response headers if they exist
+         // respect wac-allow headers
+         // patch with SPARQL if it is supported, otherwise treat as LOCALFILE
          if ((uri as string).slice(0, 4) != 'http') {
            if( !wacAllow ) return false;
            if( !acceptPatch.length && !authorVia.length)
              return 'LOCALFILE';
           }		  
+
           var status = kb.each(response, this.ns.http('status'))
           if (status.length) {
             for (let i = 0; i < status.length; i++) {
@@ -954,14 +958,13 @@ export default class UpdateManager {
 
   /**
    * Likely deprecated, since this lib no longer deals with browser extension
-   * NO - don't deprecate, use solid-rest to write to file or browser storage
    *
    * @param doc
    * @param ds
    * @param is
    * @param callbackFunction
    */
- updateLocalFile (doc: NamedNode, ds, is, callbackFunction): void {
+  updateLocalFile (doc: NamedNode, ds, is, callbackFunction): void {
     const kb = this.store
     // console.log('Writing back to local file\n')
     // See http://simon-jung.blogspot.com/2007/10/firefox-extension-file-io.html
@@ -987,19 +990,46 @@ export default class UpdateManager {
     }
 
     const documentString = this.serialize(doc.value, newSts, contentType)
-    kb.fetcher.webOperation('PUT',doc.value,{
-      "body"      : documentString,
-      contentType : contentType,
-    }).then( ()=>{
-      for (var _i13 = 0; _i13 < ds.length; _i13++) {
-        kb.remove(ds[_i13]);
-      }
-      for (var _i14 = 0; _i14 < is.length; _i14++) {
-        kb.add(is[_i14].subject, is[_i14].predicate, is[_i14].object, doc);
-      }
-      callbackFunction(doc.value, true, '')  // success!
-    })
-}
+
+    // Write the new version back
+    // create component for file writing
+    // console.log('Writing back: <<<' + documentString + '>>>')
+    var filename = doc.value.slice(7) // chop off   file://  leaving /path
+    // console.log("Writeback: Filename: "+filename+"\n")
+    // @ts-ignore Where does Component come from? Perhaps deprecated?
+    var file = Components.classes[ '@mozilla.org/file/local;1' ]
+    // @ts-ignore Where does Component come from? Perhaps deprecated?
+      .createInstance(Components.interfaces.nsILocalFile)
+    file.initWithPath(filename)
+    if (!file.exists()) {
+      throw new Error('Rewriting file <' + doc.value +
+        '> but it does not exist!')
+    }
+    // {
+    // file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420)
+    // }
+    // create file output stream and use write/create/truncate mode
+    // 0x02 writing, 0x08 create file, 0x20 truncate length if exist
+    // @ts-ignore Where does Component come from? Perhaps deprecated?
+    var stream = Components.classes[ '@mozilla.org/network/file-output-stream;1' ]
+    // @ts-ignore Where does Component come from? Perhaps deprecated?
+      .createInstance(Components.interfaces.nsIFileOutputStream)
+
+    // Various JS systems object to 0666 in struct mode as dangerous
+    stream.init(file, 0x02 | 0x08 | 0x20, parseInt('0666', 8), 0)
+
+    // write data to file then close output stream
+    stream.write(documentString, documentString.length)
+    stream.close()
+
+    for (let i = 0; i < ds.length; i++) {
+      kb.remove(ds[ i ])
+    }
+    for (let i = 0; i < is.length; i++) {
+      kb.add(is[ i ].subject, is[ i ].predicate, is[ i ].object, doc)
+    }
+    callbackFunction(doc.value, true, '') // success!
+  }
 
   /**
    * @throws {Error} On unsupported content type


### PR DESCRIPTION
Adds support for wac-allow and other headers in fetcher and updater.  This will allow rdflib to make use of solid-rest or other package to provide full access to file:/// (and other non-http requests such as cloud or in-browser storage).   Should close issue #204.