### PR TITLE
Update link to RDF namespace in documentation

### DIFF
--- a/Documentation/webapp-intro.html
+++ b/Documentation/webapp-intro.html
@@ -92,7 +92,7 @@ const profile = me.doc();       //i.e. store.sym(''https://example.com/alice/car
 <code class="language-javascript">const VCARD = new $rdf.Namespace(‘http://www.w3.org/2006/vcard/ns#‘);
 </code></pre>
 
-<p>If we don’t  know which vocabulary to use, various groups have their favorite lists. One is the <a href="https://github.com/solid/solid-ui/blob/master/src/ns.js">solid-ui list of namespaces</a>.</p>
+<p>If we don’t know which vocabulary to use, various groups have their favorite lists. One is the <a href="https://github.com/solid/solid-namespace">collection of RDF namespaces in Solid projects</a>.</p>
 
 <p>We add a name to the store as though it was stored in the profile</p>
 


### PR DESCRIPTION
The original linked to a file that included the now linked npm package with the collection of RDF namespaces.