### PR TITLE
support non-http resources

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -116,8 +116,8 @@ declare global {
     panes?: any
     solidFetcher?: any
   }
+  var solidFetcher:Function
 }
-
 declare var $SolidTestEnvironment: {
   localSiteMap?: any
 }
@@ -752,7 +752,10 @@ export default class Fetcher implements CallbackifyInterface {
     this.ns = getNS(this.store.rdfFactory)
     this.timeout = options.timeout || 30000
 
-    this._fetch = options.fetch || (typeof window !== 'undefined' && window.solidFetcher) || crossFetch
+    this._fetch = options.fetch
+               || (typeof global !== 'undefined' && global.solidFetcher)
+               || (typeof window !== 'undefined' && window.solidFetcher)
+               || crossFetch
     if (!this._fetch) {
       throw new Error('No _fetch function available for Fetcher')
     }
@@ -1694,7 +1697,7 @@ export default class Fetcher implements CallbackifyInterface {
     kb.add(responseNode, this.ns.http('statusText'),
     kb.rdfFactory.literal(response.statusText), responseNode)
 
-    if (!options.resource.value.startsWith('http')) {
+    if (!response.headers) {
       return responseNode
     }
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1697,10 +1697,6 @@ export default class Fetcher implements CallbackifyInterface {
     kb.add(responseNode, this.ns.http('statusText'),
     kb.rdfFactory.literal(response.statusText), responseNode)
 
-    if (!response.headers) {
-      return responseNode
-    }
-
     // Save the response headers
     response.headers.forEach((value, header) => {
       kb.add(responseNode, this.ns.httph(header), this.store.rdfFactory.literal(value), responseNode)

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -112,7 +112,7 @@ export default class UpdateManager {
     }
     uri = termValue(uri)
 
-    if ( this.isHttpUri(uri as string) ) {
+    if ( !this.isHttpUri(uri as string) ) {
       if (kb.holds(
           this.store.rdfFactory.namedNode(uri),
           this.store.rdfFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
@@ -161,7 +161,7 @@ export default class UpdateManager {
             }
           }
 
-          if ( this.isHttpUri(uri as string) ) {
+          if ( !this.isHttpUri(uri as string) ) {
             if( !wacAllow ) return false;
             else return 'LOCALFILE';
           }		  


### PR DESCRIPTION
This PR makes rdflib's update-manager available to non-http fetchers that supply wac-allow and other related headers, a critical feature for apps like data-kitchen and for the local-storage part of gitter-solid.

With this PR, rdflib will now assesses the editability of a non-http response (file: etc)  the same way it does with http responses - it will check the wac-allow header to see if the resource is writable/appendable, then check the accept-patch and ms-authorVia headers to see if the resource can be edited with a SPARQL patch. 

Rdflib will also now write to local files the same way it does for web resources - with a fetcher.webOperation PUT.  This replaces the firefox-extension specific writing.  If someone wants to write in an extension, they can create a solid-rest plugin or create an alternate fetcher which does its own PUT.  Either way, the actual writing belongs in the fetcher, not in rdflib.

The PR does not put anything in rdflib specific to solid-node-client or solid-rest, but it will now respect the headers they (or other alternate fetchers) send.  Solid rest now checks the native file permissions and creates a wac-allow header that gives wac write/append/control if the current user has write permissions to the resource on the native file system and gives wac read permissions to  both user and public if the user has read permission on the native resource.

If the user invokes a file: handler other than solid-rest/solid-node-client (or defaults to cross-fetch), there may not be any of the relevant  headers.  In that case, we fall back to the old method - check for triple containing "MachineEditableDocument".

Changes in this PR :

  * fetcher now checks for global.solidFetcher, not just window.solidFetcher
    (otherwise we can't set the global fetcher in nodejs)

  * fetcher now saves the metadata in headers from non-http responses

  * update-manager does not fail if MachineEditableDocument is missing,
    it now checks for wac-allow headers and only fails if they are missing too

  * update-manager now checks accept-patch and ms-authorVia headers to
    determine SPARQL editability of non-http resources

  * update-manager now saves local files via webOperation/PUT rather than the
    previous firefox-extension specific method

  * checks for 'file://' are replaced with checks for !http - this supports
    handling of any alternate protocol that supplies appropriate headers
    e.g. solid-rest currently supports app://
