### PR TITLE
changing uncommon prefixes to common

### DIFF
--- a/tests/serialize/prefixgen.ttl
+++ b/tests/serialize/prefixgen.ttl
@@ -1,18 +1,18 @@
 
 @prefix n1: <http://csarven.ca/#>.
-@prefix n0: <http://purl.org/dc/elements/1.1/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/>.
 @prefix c: <https://www.w3.org/People/Berners-Lee/card#>.
 @prefix det: <details.ttl#>.
-@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix p: <http://www.w3.org/ns/pim/pad#>.
-@prefix n: <http://rdfs.org/sioc/ns#>.
+@prefix org: <http://rdfs.org/sioc/ns#>.
 @prefix pro: <https://deiu.me/profile#>.
 
 
 
-<>  n0:author  n1: .
+<>  dc:author  n1: .
 
-<>  n:content  "foo".
+<>  org:content  "foo".
 
 
 

--- a/tests/serialize/t1.ttl
+++ b/tests/serialize/t1.ttl
@@ -1,13 +1,13 @@
 @prefix det: <details.ttl#>.
-@prefix n0: <http://purl.org/dc/elements/1.1/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/>.
 @prefix c: <https://www.w3.org/People/Berners-Lee/card#>.
-@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix p: <http://www.w3.org/ns/pim/pad#>.
-@prefix n: <http://rdfs.org/sioc/ns#>.
+@prefix org: <http://rdfs.org/sioc/ns#>.
 
    
 <#id1443100844982>
-    n:content
+    org:content
        "kasdfjsahdkfhkjhdkjsfhjkasdfkhjkajkdsajkhadsfkhjhjkdfajsdsafhjkdfhjksa";
     p:integer
        0;     p:decimal 12.0;  p:float 3.141e0; p:date 2012-12-10; p:dateTime 2012-12-25T23:59;

--- a/tests/serialize/t12-ref.ttl
+++ b/tests/serialize/t12-ref.ttl
@@ -1,11 +1,11 @@
 @prefix : </structures.n3#>.
-@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
 :DSK :name "Dexter Scott King".
 
 :MLK
-    :born "1929-01-17"^^XML:date;
-    :died "1968-01-15"^^XML:date;
+    :born "1929-01-17"^^xsd:date;
+    :died "1968-01-15"^^xsd:date;
     :friend [];
     :name "Martin Luther King, Jr";
     :spouse _:_g_L4C88;
@@ -17,7 +17,7 @@
 :ZooReading1
     :boolDisabled false;
     :boolEnabled true;
-    :date "2015-02-28"^^XML:date;
+    :date "2015-02-28"^^xsd:date;
     :decBig 1234567890.99;
     :decBigNegative -1234567890.99;
     :decWithPoint 10.0;
@@ -29,10 +29,10 @@
     :intBig 1234567890;
     :intCount 16;
     :intNegative -123;
-    :time "2015-03-16T17:53Z"^^XML:dateTime.
+    :time "2015-03-16T17:53Z"^^xsd:dateTime.
 _:_g_L4C88 :name "Coretta Scott King".
 
-[ a :Speech; :author :MLK; :date "1963-08-23"^^XML:date; :title "I have a dream" ].
+[ a :Speech; :author :MLK; :date "1963-08-23"^^xsd:date; :title "I have a dream" ].
 
 [ :friend :MLK ].
 

--- a/tests/serialize/t13-ref.ttl
+++ b/tests/serialize/t13-ref.ttl
@@ -1,13 +1,13 @@
 @prefix : </,structures.nt#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix str: </structures.n3#>.
-@prefix XML: <http://www.w3.org/2001/XMLSchema#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
 str:DSK str:name "Dexter Scott King".
 
 str:MLK
-    str:born "1929-01-17"^^XML:date;
-    str:died "1968-01-15"^^XML:date;
+    str:born "1929-01-17"^^xsd:date;
+    str:died "1968-01-15"^^xsd:date;
     str:friend [];
     str:name "Martin Luther King, Jr";
     str:spouse _:_g_L4C88;
@@ -19,7 +19,7 @@ str:YK str:name "Yolanda King".
 str:ZooReading1
     str:boolDisabled false;
     str:boolEnabled true;
-    str:date "2015-02-28"^^XML:date;
+    str:date "2015-02-28"^^xsd:date;
     str:decBig 1234567890.99;
     str:decBigNegative -1234567890.99;
     str:decWithPoint 10.0;
@@ -31,13 +31,13 @@ str:ZooReading1
     str:intBig 1234567890;
     str:intCount 16;
     str:intNegative -123;
-    str:time "2015-03-16T17:53Z"^^XML:dateTime.
+    str:time "2015-03-16T17:53Z"^^xsd:dateTime.
 _:_g_L4C88 str:name "Coretta Scott King".
 
 [
     a str:Speech;
     str:author str:MLK;
-    str:date "1963-08-23"^^XML:date;
+    str:date "1963-08-23"^^xsd:date;
     str:title "I have a dream"
 ].
 [ str:friend str:MLK ].


### PR DESCRIPTION
e.g., `XML:` -> `xsd: <http://www.w3.org/2001/XMLSchema#>`
e.g., `n:`   -> `org: <http://rdfs.org/sioc/ns#>`
e.g., `n0:`  -> `dc: <http://purl.org/dc/elements/1.1/>`

(partly?) fixes #472