### PR TITLE
Disable Store fetures by default

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -195,10 +195,11 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
       this.whyIndex
     ]
     this.namespaces = {} // Dictionary of namespace prefixes
-    this.features = features || [
-      'sameAs',
-      'InverseFunctionalProperty',
-      'FunctionalProperty',
+    this.features = features || [ // By deafult devs do not expect these feaures.
+// See https://github.com/linkeddata/rdflib.js/issues/458
+//      'sameAs',
+//      'InverseFunctionalProperty',
+//      'FunctionalProperty',
     ]
     this.rdfArrayRemove = opts.rdfArrayRemove || RDFArrayRemove
     if (opts.dataCallback) {


### PR DESCRIPTION
Responds to https://github.com/linkeddata/rdflib.js/issues/458

No normal developer expects these features.   They are useful for smushing together data from many sources, such as trusted public data sources.  They not appropriate to the solid world of  where many dat source are not trusted, and any 'sameAs' inference has to be done explicitly by the application layer or the domain-specific UX layer.  