### PR TITLE
reverting PR#445

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -92,14 +92,14 @@ const getNS = (factory?: RdfJsDataFactory) => {
 }
 const ns = getNS()
 
-export interface FetchError extends Error {
+interface FetchError extends Error {
   statusText?: string
   status?: StatusValues
   response?: ExtendedResponse
 }
 
 /** An extended interface of Response, since RDFlib.js adds some properties. */
-export interface ExtendedResponse extends Response {
+interface ExtendedResponse extends Response {
   /** String representation of the Body */
   responseText?: string
   /** Identifier of the reqest */
@@ -134,7 +134,7 @@ type HTTPMethods = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'HEAD' | 'DELETE' | 'CONNE
 type Options = Partial<AutoInitOptions>
 
 /** Initiated by initFetchOptions, which runs on load */
-export interface AutoInitOptions extends RequestInit{
+interface AutoInitOptions extends RequestInit{
   /** The used Fetch function */
   fetch?: Fetch
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import BlankNode from './blank-node'
 import Collection from './collection'
 import * as convert from './convert'
 import Empty from './empty'
-import Fetcher, { AutoInitOptions, ExtendedResponse, FetchError } from './fetcher'
+import Fetcher from './fetcher'
 import Formula from './formula'
 import Store from './store'
 import jsonParser from './jsonparser'
@@ -69,9 +69,6 @@ export {
   DataFactory,
   Empty,
   Fetcher,
-  AutoInitOptions,
-  ExtendedResponse,
-  FetchError,
   Formula,
   Store,
   jsonParser,


### PR DESCRIPTION
@ludwigschubi 
It seems that `export interface ... extends ...` do not export any js code because it is only declarative in typescript

PR reverting your PR#445 which had the following issues : 
- issue #500 
- and in building mashlib : 
```
WARNING in ../rdflib/esm/index.js 61:0-63:72
"export 'AutoInitOptions' was not found in './fetcher'
 @ ./src/index.ts
 @ multi ./src/index.ts

WARNING in ../rdflib/esm/index.js 61:0-63:72
"export 'ExtendedResponse' was not found in './fetcher'
 @ ./src/index.ts
 @ multi ./src/index.ts

WARNING in ../rdflib/esm/index.js 61:0-63:72
"export 'FetchError' was not found in './fetcher'
 @ ./src/index.ts
 @ multi ./src/index.ts

```