### PR TITLE
Serializer set namespace prefix

### DIFF
--- a/src/formula.ts
+++ b/src/formula.ts
@@ -5,7 +5,7 @@ import log from './log'
 import RDFlibNamedNode from './named-node'
 import Namespace from './namespace'
 import Node from './node-internal'
-import Serializer from './serialize'
+import serialize from './serialize'
 import Statement from './statement'
 import {
   Bindings,
@@ -723,31 +723,8 @@ export default class Formula extends Node {
    * @param provenance - The provenance URI
    */
   serialize (base, contentType, provenance) {
-    let documentString
-    let sts
-    let sz
-    sz = Serializer(this)
-    sz.suggestNamespaces(this.ns)
-    sz.setBase(base)
-    if (provenance) {
-      sts = this.statementsMatching(void 0, void 0, void 0, provenance)
-    } else {
-      sts = this.statements
-    }
-    switch (
-    contentType != null ? contentType : 'text/n3') {
-      case 'application/rdf+xml':
-        documentString = sz.statementsToXML(sts)
-        break
-      case 'text/n3':
-      case 'text/turtle':
-        documentString = sz.statementsToN3(sts)
-        break
-      default:
-        throw new Error('serialize: Content-type ' + contentType +
-          ' not supported.')
-    }
-    return documentString
+    // delegate the graph serialization to the implementation in ./serialize
+    return serialize(provenance, this, base, contentType);
   }
 
   /**

--- a/src/formula.ts
+++ b/src/formula.ts
@@ -721,10 +721,11 @@ export default class Formula extends Node {
    * @param base - The base string
    * @param contentType - The content type of the syntax to use
    * @param provenance - The provenance URI
+   * @param options  - options to pass to the serializer, as defined in serialize method
    */
-  serialize (base, contentType, provenance) {
+  serialize (base, contentType, provenance, options?) {
     // delegate the graph serialization to the implementation in ./serialize
-    return serialize(provenance, this, base, contentType);
+    return serialize(provenance, this, base, contentType, undefined, options);
   }
 
   /**

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -73,6 +73,46 @@ export class Serializer {
     return this.store.fromNT(s)
   }
 
+  /**
+   * Defines a set of [prefix, namespace] pairs to be uised by this Serializer instance.
+   * Overrides previous prefixes if any
+   * @param namespaces
+   * @return {Serializer}
+   */
+  setNamespaces(namespaces) {
+    for (var px in namespaces) {
+      this.setPrefix(px, namespaces[px])
+    }
+    return this
+  }
+
+  /**
+   * Defines a namespace prefix, overriding any existing prefix for that URI
+   * @param prefix
+   * @param uri
+   */
+  setPrefix(prefix, uri) {
+    if (prefix.slice(0, 7) === 'default') return // Try to weed these out
+    if (prefix.slice(0, 2) === 'ns') return //  From others inferior algos
+    if (!prefix || !uri) return // empty strings not suitable
+
+    // remove any existing prefix targeting this uri
+    // for (let existingPrefix in this.namespaces) {
+    //   if (this.namespaces[existingPrefix] == uri)
+    //     delete this.namespaces[existingPrefix];
+    // }
+
+    // remove any existing mapping for this prefix
+    for (let existingNs in this.prefixes) {
+      if (this.prefixes[existingNs] == prefix)
+        delete this.prefixes[existingNs];
+    }
+
+    this.prefixes[uri] = prefix
+    this.namespaces[prefix] = uri
+  }
+
+
   /* Accumulate Namespaces
   **
   ** These are only hints.  If two overlap, only one gets used

--- a/src/store.ts
+++ b/src/store.ts
@@ -1163,12 +1163,19 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
     return res
   }
 
-  serialize (base, contentType, provenance) {
+  serialize (base, contentType, provenance, options?) {
 
     // override Formula.serialize to force the serializer namespace prefixes
     // to those of this IndexedFormula
-    const namespaces = this.namespaces;
-    return serialize(provenance, this, base, contentType, undefined, { namespaces });
+
+    // if namespaces are explicitly passed in options, let them override the existing namespaces in this formula
+    const namespaces = options?.namespaces ? {...this.namespaces, ...options.namespaces} : {...this.namespaces};
+
+    options = {
+      ...(options || {}),
+      namespaces
+    }
+    return serialize(provenance, this, base, contentType, undefined, options);
   }
 }
 IndexedFormula.handleRDFType = handleRDFType

--- a/src/store.ts
+++ b/src/store.ts
@@ -52,6 +52,7 @@ import {
   Term,
 } from './tf-types'
 import { namedNode } from './index'
+import serialize from "./serialize";
 import BlankNode from './blank-node'
 import DefaultGraph from './default-graph'
 import Empty from './empty'
@@ -1160,6 +1161,14 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
       }
     }
     return res
+  }
+
+  serialize (base, contentType, provenance) {
+
+    // override Formula.serialize to force the serializer namespace prefixes
+    // to those of this IndexedFormula
+    const namespaces = this.namespaces;
+    return serialize(provenance, this, base, contentType, undefined, { namespaces });
   }
 }
 IndexedFormula.handleRDFType = handleRDFType

--- a/src/store.ts
+++ b/src/store.ts
@@ -1046,6 +1046,13 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
     if (prefix.slice(0, 2) === 'ns' || prefix.slice(0, 7) === 'default') {
       return
     }
+
+    // remove any prefix that currently targets nsuri
+    for (let existingPrefix in this.namespaces) {
+      if (this.namespaces[existingPrefix] == nsuri)
+        delete this.namespaces[existingPrefix];
+    }
+
     this.namespaces[prefix] = nsuri
   }
 

--- a/tests/unit/serialize-test.ts
+++ b/tests/unit/serialize-test.ts
@@ -165,5 +165,78 @@ describe('serialize', () => {
 
 `)
         });
+
+
+
+      it('use setPrefix to define a namespace prefix', () => {
+        const doc = sym("https://doc.example");
+        const statement = st(
+          sym('https://example.com/subject'),
+          sym('http://schema.org/predicate'),
+          lit("123e-2", undefined, sym("http://www.w3.org/2001/XMLSchema#double")),
+          doc
+        )
+        const kb = graph()
+        kb.setPrefixForURI("example", "https://example.com/")
+        kb.add(statement)
+        const result = serialize(doc, kb, null, 'text/turtle')
+        expect(result).to.equal(`@prefix : <#>.
+@prefix schema: <http://schema.org/>.
+@prefix example: <https://example.com/>.
+
+example:subject schema:predicate 123e-2 .
+
+`)
+      });
+
+
+      it('use setPrefix to override a graph prefix', () => {
+        const doc = sym("https://doc.example");
+        const statement = st(
+          sym('https://example.com/subject'),
+          sym('http://schema.org/predicate'),
+          lit("123e-2", undefined, sym("http://www.w3.org/2001/XMLSchema#double")),
+          doc
+        )
+        const kb = graph()
+        kb.setPrefixForURI("example", "https://example.com/")
+
+        kb.setPrefixForURI("example2", "https://example.com/")
+        kb.add(statement)
+        const result = serialize(doc, kb, null, 'text/turtle')
+        expect(result).to.equal(`@prefix : <#>.
+@prefix schema: <http://schema.org/>.
+@prefix example2: <https://example.com/>.
+
+example2:subject schema:predicate 123e-2 .
+
+`)
+      });
+
+      it('use setPrefix to override a default prefix', () => {
+        const doc = sym("https://doc.example");
+        const statement = st(
+          sym('https://example.com/subject'),
+          sym('http://schema.org/predicate'),
+          lit("123e-2", undefined, sym("http://www.w3.org/2001/XMLSchema#double")),
+          doc
+        )
+        const kb = graph();
+        kb.setPrefixForURI("example", "https://example.com/")
+        kb.setPrefixForURI("schema2", "http://schema.org/")
+        kb.add(statement)
+
+        const result = kb.serialize(null, 'text/turtle', null);
+
+        //const result = serialize(doc, kb, null, 'text/turtle')
+        expect(result).to.equal(`@prefix schema2: <http://schema.org/>.
+@prefix example: <https://example.com/>.
+
+example:subject schema2:predicate 123e-2 .
+
+`)
+      });
+
+
     });
 });


### PR DESCRIPTION
This PR adds the possibility to (forcefully) set namespaces prefixes on a Serializer instance, as opposed to the current `suggestNamespaces` and `suggestPrefix` methods that propose prefixes but cannot override defaults prefixes.

What it does is

- fix `IndexedFormula.setPrefixForURI` that did allow multiple namespaces to be mapped on the same prefix
- add `setNamespaces` and `setPrefix` methods on `Serializer` that can override default prefixes
- add a `options.namespaces`  to the `serialize` function, that defines namespaces that should be forcefully set
- override the `IndexedFormula.serialize` method so that the current graph namespaces are kept as mandatory prefixes

As a result ,
```
const graph: IndexedFormula = ...;

graph.serialize(base, contentType, provenance);
// is equivalent to
serialize(provenance, graph, base, contentType, undefined, { namespaces: graph.namespaces });
```
and keeps the graph namespace prefixes, while 
```
serialize(provenance, graph, base, contentType, undefined);
```
behaves as before, i.e. giving priority to default prefixes