### PR TITLE
Simplify example code showing setting solidFetcher

### DIFF
--- a/Documentation/alternate-fetches.md
+++ b/Documentation/alternate-fetches.md
@@ -65,7 +65,7 @@ r@1.11.2/dist/solid-client-authn.bundle.js"></script>
         });                                                                     
     }                                                                           
     async function handleRedirectAfterLogin() {                                 
-        await solidClientAuthentication.handleIncomingRedirect();                                    
+        const session = await solidClientAuthentication.handleIncomingRedirect();                                    
         if (session.info.isLoggedIn)  main();                            
     }                                                                           
     handleRedirectAfterLogin();                                                 

--- a/Documentation/alternate-fetches.md
+++ b/Documentation/alternate-fetches.md
@@ -44,10 +44,12 @@ r@1.11.2/dist/solid-client-authn.bundle.js"></script>
 <script>                                                                        
     const idp = "https://solidcommunity.net";                                   
     const privateResource = "https://jeff-zucker.solidcommunity.net/private/";  
-    const auth = solidClientAuthentication;                                     
-    async function main(session){                                               
-        const kb = $rdf.graph();                                                
-        window.solidFetcher = session.fetch;                                    
+    
+    // Set the fetcher:
+    window.solidFetcher = solidClientAuthentication.fetch;
+    
+    async function main(){                                               
+        const kb = $rdf.graph();                                                                                    
         const fetcher = $rdf.fetcher(kb)                                        
         try {                                                                   
           await fetcher.load(privateResource);                                  
@@ -56,16 +58,15 @@ r@1.11.2/dist/solid-client-authn.bundle.js"></script>
         catch(e) { alert(e) }                                                   
     }                                                                           
     document.getElementById('login').onclick = ()=> {                           
-        auth.login({                                                            
+        solidClientAuthentication.login({                                                            
             oidcIssuer: idp,                                                    
             redirectUrl: window.location.href,                                  
             clientName: "rdflib test"                                           
         });                                                                     
     }                                                                           
     async function handleRedirectAfterLogin() {                                 
-        await auth.handleIncomingRedirect();                                    
-        session = auth.getDefaultSession();                                     
-        if (session.info.isLoggedIn)  main(session);                            
+        await solidClientAuthentication.handleIncomingRedirect();                                    
+        if (session.info.isLoggedIn)  main();                            
     }                                                                           
     handleRedirectAfterLogin();                                                 
 </script></html>                                                                


### PR DESCRIPTION
In the `@inrupt/solid-client-authn-browser` SDK, we always expose a `fetch` method, so you don't need to set `solidFetcher` only after login, you can do this before and it'll switch based on whether you're logged in or not — by default the `fetch` method uses global fetch until the session is established, at which point it switches to fetch with authorization and dpop headers.