### PR TITLE
N3Parser: support escape sequences in local names

### DIFF
--- a/src/n3parser.js
+++ b/src/n3parser.js
@@ -1244,12 +1244,22 @@ export class SinkParser {
             var ln = "";
             while ((i < pyjslib_len(str))) {
                 var c = str.charAt(i);
-                if ((_notNameChars.indexOf(c) < 0)) {
-                    var ln =  ( ln + c ) ;
-                    var i =  ( i + 1 ) ;
-                }
-                else {
-                    break;
+                if (c ==='\\'){
+                    var c2 = str.charAt(i+1)
+                    if ((_notNameChars.indexOf(c2) >= 0)) {
+                        var ln =  ( ln + c2 ) ;
+                        var i =  ( i + 2 ) ;
+                    }
+                    else {
+                        break;
+                    }
+                } else {
+                    if ((_notNameChars.indexOf(c) < 0)) {
+                        var ln = (ln + c);
+                        var i = (i + 1);
+                    } else {
+                        break;
+                    }
                 }
             }
             res.push(new pyjslib_Tuple([pfx, ln]));


### PR DESCRIPTION
According to [RDF 1.1 Turtle specification](https://www.w3.org/TR/turtle/#grammar-production-PN_LOCAL), the grammar accepts local names as production node, for ex `foaf:name`

This local name can contain escape sequences:
![image](https://user-images.githubusercontent.com/43246610/172656652-468c95bc-75fa-42d2-be71-da36c33075ad.png)
which are enumerated as follows:
```
[172s] | PN_LOCAL_ESC | ::= | '\' ('_' \| '~' \| '.' \| '-' \| '!' \| ' \| '&' \| "'" \| '(' \| ')' \| '*' \| '+' \| ',' \| ';' \| '=' \| '/' \| '?' \| '#' \| '@' \| '%')
```

However, when trying to parse the following turtle with rdflib,
```
@prefix interop: <http://www.w3.org/ns/solid/interop#> .

@prefix alice: <https://alice.example/#> .
@prefix alice-work: <https://work.alice.example/> .
@prefix alice-personal: <https://personal.alice.example/> .


alice:registries
  a interop:RegistrySet;
  interop:hasAgentRegistry alice:agents ;
  interop:hasAuthorizationRegistry alice:authorization ;
  interop:hasDataRegistry
    alice-work:data\/ ,
    alice-personal:data\/ .
```
Source: [Solid Data Interoperability Panel](https://solid.github.io/data-interoperability-panel/specification/#data-registry)

The following error is returned:
```Error: Fetcher: Error trying to parse <file:///home/hba/Documents/Git/SOLID/files/data/registries.ttl> as Notation3:
SyntaxError: Line 25 of <file:///Git/RDF/files/data/registries.ttl>: Bad syntax: expected '.' or '}' or ']' at end of statement
at: "/ ,
    alice-personal:data .
"

    at Fetcher.failFetch (/home/hba/Documents/Git/shex-methods/node_modules/rdflib/lib/fetcher.js:1100:17)
    at N3Handler.parse (/home/hba/Documents/Git/shex-methods/node_modules/rdflib/lib/fetcher.js:549:24)
    at /home/hba/Documents/Git/shex-methods/node_modules/rdflib/lib/fetcher.js:1890:24

```

I tracked the issue in the N3 parser in the following location. It is because the method breaks out of the loop when it finds the notNameChar `\` instead of considering an escape sequence.

The following code change may be worth further investigation, as I am not sure what side-effect this may have.