### PR TITLE
Fix for `BlankNode` as `NamedNode` when parsing JSON-LD #555

### DIFF
--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -43,10 +43,7 @@ export function jsonldObjectToTerm (kb, obj) {
     return kb.rdfFactory.literal(obj['@value'])
   }
 
-  // I'm not sure we should return a literal if we don't have any of the above.
-  // I think this should be a blank node by default
-  return kb.rdfFactory.BlankNode();
-  // return kb.rdfFactory.literal(obj)
+  return kb.rdfFactory.literal();
 }
 
 /**

--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -22,7 +22,13 @@ export function jsonldObjectToTerm (kb, obj) {
   }
 
   if (Object.prototype.hasOwnProperty.call(obj, '@id')) {
-    return kb.rdfFactory.namedNode(obj['@id'])
+    if (obj['@id'].startsWith('_:')) {
+      // This object is a Blank Node
+      return kb.rdfFactory.blankNode(obj['@id']);
+    } else {
+      // This object is a Named Node
+      return kb.rdfFactory.namedNode(obj['@id']);
+    }    
   }
 
   if (Object.prototype.hasOwnProperty.call(obj, '@language')) {


### PR DESCRIPTION
The JSON-LD parser currently uses the JSON-LD flattening algorithm of `jsonld.js`. This algorithm assigns `@id` attributes to blank nodes, but the JSON-LD parser only creates a `BlankNode` when no `@id` is present. 

This means that currently, the blank nodes in JSON-LD are interpreted as `NamedNode`, which is incorrect.

This pull request does the following:

* Add a check to see whether the `@id` value starts with `_:`. 
* If it does, it is a `BlankNode`, otherwise it is a `NamedNode`.
* If it is a blank node, strip it from the `_:` as this will be added by the instantiation of the `BlankNode` class.
* Make sure to perform this check whenever a new object node is created (there were three separate checks in the code)

This fixes #555 

Also raised an issue in `rdf-canonize` (<https://github.com/digitalbazaar/rdf-canonize/issues/45>) to flag the problem that blank node identifiers generated by `jsonld.js` are not unique across loads (this is the cause of issue #405 )