### PR TITLE
Added `prepare` hook for building directly from source (GitHub)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "test": "npm run test:unit && npm run test:serialize && npm run test:types",
     "test:clean": "rimraf tests/serialize/,*",
     "test:serialize": "npm run build && npm run test:serialize:all && npm run test:clean",
+    "test:nestedgraphs": "npm run build && cd ./tests/serialize && node data.js -in=Graph_Of_Articles.jsonld -format=application/ld+json -out=out_Graph_Of_Articles.jsonld",
     "test:serialize:all": "npm run test:serialize:1 && npm run test:serialize:2 && npm run test:serialize:3 && npm run test:serialize:4 && npm run test:serialize:5 && npm run test:serialize:6 && npm run test:serialize:7 && npm run test:serialize:10 && npm run test:serialize:11 && npm run test:serialize:12 && npm run test:serialize:13 && npm run test:serialize:14 && npm run test:serialize:15",
     "test:serialize:1": "cd ./tests/serialize && node ./data.js -in=t1.ttl -format=application/rdf+xml -out=,t1.xml && fs-grep http://www.w3.org/2001/XMLSchema#integer ,t1.xml",
     "test:serialize:2": "cd ./tests/serialize && node ./data.js -in=t2.ttl -format=application/rdf+xml  -out=,t2.xml && node diff ,t2.xml t2-ref.xml",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "build:browser": "webpack --progress",
     "build:types": "tsc --emitDeclarationOnly -d --moduleResolution node --declarationDir lib",
     "doc": "typedoc --out ./doc ./src/index.ts --excludePrivate --excludeInternal --tsconfig ./tsconfig.json",
+    "prepare": "npm run build && npm run build:types && npm run build:browser && npm run build:esm",
     "prepublishOnly": "npm ci && npm run build && npm run build:types && npm run build:browser && npm run build:esm",
     "postversion": "git push --follow-tags",
     "start": "webpack serve --port 4800",

--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -97,7 +97,7 @@ function processResource(kb, base, flatResource) {
       const graphId = id
       // this is an array of resources
       const nestedFlatResources = flatResource[property]
-
+      console.log(nestedFlatResources);
       // recursively process all flat resources in the array, but with the graphId as base.
       for (let i = 0; i < nestedFlatResources.length; i++ ) {
         kb = processResource(kb, graphId, nestedFlatResources[i])

--- a/tests/serialize/data.js
+++ b/tests/serialize/data.js
@@ -89,7 +89,7 @@ var doNext = function (remaining) {
 
         fetcher.nowOrWhenFetched(inDocument, {}, function (ok, body, xhr) {
           check(ok, body, xhr ? xhr.status : undefined)
-          // console.log(kb.statementsMatching().map(ea => ea.toString() + ' why:' + ea.why))
+          console.log(kb.statementsMatching().map(ea => ea.toString() + ' why:' + ea.why))
           doNext(remaining)
         }); // target, kb, base, contentType, callback
         return // STOP processing at this level


### PR DESCRIPTION
A standard `npm install` from source (especially GitHub) did not build all of the packages in `lib`, `dist` and `esm`.

This adds a `prepare` hook in `package.json` that ensures that everything is built properly before the `rdflib` packages is added to `node_modules`.

This fixes #559 