### PR TITLE
`atomicTermToN3` now checks for `DefaultGraph` term type

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -561,6 +561,8 @@ export class Serializer {
         return str
       case 'NamedNode':
         return this.symbolToN3(expr)
+      case 'DefaultGraph':
+        return '';
       default:
         throw new Error('Internal: atomicTermToN3 cannot handle ' + expr + ' of termType: ' + expr.termType)
     }


### PR DESCRIPTION
This is a fix for issue #561

If a term is of type `DefaultGraph` the `atomicTermToN3` function in `serializer.js` will return an empty string rather than throw an error.