### PR TITLE
Use accept headers that are supplied instead of always overwriting

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1054,9 +1054,11 @@ export default class Fetcher implements CallbackifyInterface {
       options.cache = 'no-cache'
     }
 
-    let acceptString = this.acceptString()
-    // @ts-ignore
-    options.headers['accept'] = acceptString
+    if(!options.headers["accept"]){
+      let acceptString = this.acceptString()
+      // @ts-ignore
+      options.headers['accept'] = acceptString
+    }
 
     let requestedURI = Fetcher.offlineOverride(uri)
     options.requestedURI = requestedURI

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1054,7 +1054,7 @@ export default class Fetcher implements CallbackifyInterface {
       options.cache = 'no-cache'
     }
 
-    if(!options.headers["accept"]){
+    if(!options.headers["accept"] || (!(options.headers as Headers).get("accept"))){
       let acceptString = this.acceptString()
       // @ts-ignore
       options.headers['accept'] = acceptString

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1054,7 +1054,7 @@ export default class Fetcher implements CallbackifyInterface {
       options.cache = 'no-cache'
     }
 
-    if(!options.headers["accept"] || (!(options.headers as Headers).get("accept"))){
+    if(!(options.headers["accept"] || (options.headers as Headers).get("accept"))){
       let acceptString = this.acceptString()
       // @ts-ignore
       options.headers['accept'] = acceptString


### PR DESCRIPTION
I got aware of this because of the new changes made to ess (enterprise solid server). Because i tried fetching the new webId form of https://id.inrupt.com/<user> but it would not load the data (only html) even if I passed accept headers to `.load()`. These changes would allow supplied accept headers to actually work.