### PR TITLE
Make Options a parameter that can be passed

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -133,7 +133,7 @@ type UserCallback = (
 type HTTPMethods = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'HEAD' | 'DELETE' | 'CONNECT' | 'TRACE' | 'OPTIONS'
 
 /** All valid inputs for initFetchOptions */
-type Options = Partial<AutoInitOptions>
+export type Options = Partial<AutoInitOptions>
 
 /** Initiated by initFetchOptions, which runs on load */
 export interface AutoInitOptions extends RequestInit{
@@ -1571,8 +1571,8 @@ export default class Fetcher implements CallbackifyInterface {
   }
 
   /**
-   * A generic web opeation, at the fetch() level.
-   * does not invole the quadstore.
+   * A generic web operation, at the fetch() level.
+   * does not involve the quad store.
    *
    *  Returns promise of Response
    *  If data is returned, copies it to response.responseText before returning

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -5,26 +5,16 @@
 ** 2010-12-07 TimBL addred local file write code
 */
 import IndexedFormula from './store'
-import { docpart } from './uri'
-import Fetcher from './fetcher'
+import {docpart, join as uriJoin} from './uri'
+import Fetcher, {Options} from './fetcher'
 import Namespace from './namespace'
 import Serializer from './serializer'
-import { join as uriJoin } from './uri'
-import { isStore, isBlankNode } from './utils/terms'
+import {isBlankNode, isStore} from './utils/terms'
 import * as Util from './utils-js'
 import Statement from './statement'
 import RDFlibNamedNode from './named-node'
-import { termValue } from './utils/termValue'
-import {
-  BlankNode,
-  NamedNode,
-  Quad_Graph,
-  Quad_Object,
-  Quad_Predicate,
-  Quad_Subject,
-  Quad,
-  Term,
-} from './tf-types'
+import {termValue} from './utils/termValue'
+import {BlankNode, NamedNode, Quad, Quad_Graph, Quad_Object, Quad_Predicate, Quad_Subject, Term,} from './tf-types'
 
 interface UpdateManagerFormula extends IndexedFormula {
   fetcher: Fetcher
@@ -365,7 +355,8 @@ export default class UpdateManager {
   fire (
     uri: string,
     query: string,
-    callbackFunction: CallBackFunction
+    callbackFunction: CallBackFunction,
+    options: Options = {}
   ): Promise<void> {
     return Promise.resolve()
       .then(() => {
@@ -374,11 +365,9 @@ export default class UpdateManager {
         }
         // console.log('UpdateManager: sending update to <' + uri + '>')
 
-        let options = {
-          noMeta: true,
-          contentType: 'application/sparql-update',
-          body: query
-        }
+        options.noMeta = true;
+        options.contentType = 'application/sparql-update';
+        options.body = query;
 
         return this.store.fetcher.webOperation('PATCH', uri, options)
       })
@@ -709,6 +698,7 @@ export default class UpdateManager {
    * @param insertions - Statement or statements to be inserted.
    * @param callback - called as callbackFunction(uri, success, errorbody)
    *           OR returns a promise
+   * @param options - Options for the fetch call
    */
   update(
       deletions: ReadonlyArray<Statement>,
@@ -719,7 +709,8 @@ export default class UpdateManager {
         errorBody?: string,
         response?: Response | Error
       ) => void,
-      secondTry?: boolean
+      secondTry?: boolean,
+      options: Options = {}
   ): void | Promise<void> {
     if (!callback) {
       var thisUpdater = this
@@ -730,7 +721,7 @@ export default class UpdateManager {
           } else {
             resolve()
           }
-        }) // callbackFunction
+        }, secondTry, options) // callbackFunction
       }) // promise
     } // if
 
@@ -787,10 +778,10 @@ export default class UpdateManager {
         }
         // console.log(`Update: have not loaded ${doc} before: loading now...`);
         (this.store.fetcher.load(doc) as Promise<Response>).then(response => {
-          this.update(deletions, insertions, callback, true)
+          this.update(deletions, insertions, callback, true, options)
         }, err => {
             if (err.response.status === 404) { // nonexistent files are fine
-              this.update(deletions, insertions, callback, true)
+              this.update(deletions, insertions, callback, true, options)
             } else  {
               throw new Error(`Update: Can't get updatability status ${doc} before patching: ${err}`)
             }
@@ -869,13 +860,13 @@ export default class UpdateManager {
             // console.log('delayed downstream action:')
             downstreamAction(doc)
           }
-        })
+        }, options)
       } else if ((protocol as string).indexOf('DAV') >= 0) {
-        this.updateDav(doc, ds, is, callback)
+        this.updateDav(doc, ds, is, callback, options)
       } else {
         if ((protocol as string).indexOf('LOCALFILE') >= 0) {
           try {
-            this.updateLocalFile(doc, ds, is, callback)
+            this.updateLocalFile(doc, ds, is, callback, options)
           } catch (e) {
             callback(doc.value, false,
               'Exception trying to write back file <' + doc.value + '>\n'
@@ -896,7 +887,8 @@ export default class UpdateManager {
     doc: Quad_Subject,
     ds,
     is,
-    callbackFunction
+    callbackFunction,
+    options: Options = {}
   ): null | Promise<void> {
     let kb = this.store
     // The code below is derived from Kenny's UpdateCenter.js
@@ -929,11 +921,9 @@ export default class UpdateManager {
       targetURI = uriJoin(candidateTarget.value, targetURI)
     }
 
-    let options = {
-      contentType,
-      noMeta: true,
-      body: documentString
-    }
+    options.contentType = contentType
+    options.noMeta = true
+    options.body = documentString
 
     return kb.fetcher.webOperation('PUT', targetURI, options)
       .then(response => {
@@ -962,8 +952,9 @@ export default class UpdateManager {
    * @param ds
    * @param is
    * @param callbackFunction
+   * @param options
    */
-  updateLocalFile (doc: NamedNode, ds, is, callbackFunction): void {
+  updateLocalFile (doc: NamedNode, ds, is, callbackFunction, options: Options = {}): void {
     const kb = this.store
     // console.log('Writing back to local file\n')
 
@@ -988,12 +979,10 @@ export default class UpdateManager {
       throw new Error('File extension .' + ext + ' not supported for data write')
     }
 
-    const documentString = this.serialize(doc.value, newSts, contentType)
+    options.body = this.serialize(doc.value, newSts, contentType);
+    options.contentType = contentType;
 
-    kb.fetcher.webOperation('PUT',doc.value,{
-      "body"      : documentString,
-      contentType : contentType,
-    }).then( (response)=>{
+    kb.fetcher.webOperation('PUT', doc.value, options).then( (response)=>{
       if(!response.ok) return callbackFunction(doc.value,false,response.error)
       for (let i = 0; i < ds.length; i++) {
         kb.remove(ds[i]);


### PR DESCRIPTION
This allows function callers to alter the resulting HTTP request
instead of only having a subset of hardcoded options.

This PR came out of [this discussion](https://forum.solidproject.org/t/requesting-access-as-ess-authenticated-application/5538/29?u=smessie) where we lacked the ability to set `withCredentials: false` in the options which is needed to prevent the CORS error in ESS 2.0