### PR TITLE
Add vscode configuration to launch tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ dist
 doc
 parsers/*.js
 node_modules
-.vscode/
 npm-debug.log
 dist/rdflib.min.js
 lib/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Unit Test Current File",
+            "program": "${workspaceFolder}/node_modules/.bin/mocha",
+            "args": [
+                "--require",
+                "./tests/babel-register.js",
+                "${fileDirname}/${fileBasename}",
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Unit Test All Files",
+            "program": "${workspaceFolder}/node_modules/.bin/mocha",
+            "args": [
+                "--require",
+                "./tests/babel-register.js",
+                "tests/unit/**-test.*",
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+        }
+    ]
+}


### PR DESCRIPTION
I noticed that the `.vscode` folder is ignored in git, but I think it's useful to include some files in there.

For example, I had to create the `launch.json` file manually to run tests using the step debugger of VSCode. It would be nice if that's included in the repository by default.