### PR TITLE
fix: double URL-encoding when serializing

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -261,7 +261,7 @@ export class Serializer {
     } else if (this.flags.indexOf('u') >= 0) { // Unicode encoding NTriples style
       uri = backslashUify(uri)
     } else {
-      uri = hexify(uri)
+      uri = hexify(decodeURI(uri))
     }
     return '<' + uri + '>'
   }

--- a/tests/unit/serialize-test.ts
+++ b/tests/unit/serialize-test.ts
@@ -554,4 +554,27 @@ const jsonldCollection1 = `{
       })
     })
   })
+
+  describe('encoded URIs', () => {
+    let srcStore
+    const base = 'http://www.example.com/'
+
+    before(() => {
+      const srcTtl = '<http://example.com#myid> <http://example.com#my%20property> "myvalue" .'
+      srcStore = graph()
+      parse(srcTtl, srcStore, base, 'text/turtle')
+    })
+
+    it("convert to ttl without base", async () => {
+      const res = await serialize(null, srcStore, undefined, 'text/turtle')
+      expect(res?.toString()).to.contain("%20")
+      expect(res?.toString()).not.to.contain("%2520")
+    })
+
+    it("convert to ttl with base", async () => {
+      const res = await serialize(null, srcStore, base, 'text/turtle')
+      expect(res?.toString()).to.contain("%20")
+      expect(res?.toString()).not.to.contain("%2520")
+    })
+  })
 })


### PR DESCRIPTION
Issue happens when base is not specified
This PR adds a unit test to check and fixes the bug in serializer's explicitURI function

#623