### PR TITLE
removeMetadata

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -875,6 +875,7 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
    * @param doc - The document / graph
    */
   removeMetadata(doc: Quad_Graph): IndexedFormula {
+    // temporary until the issue on COLLECTION is resolved see https://github.com/linkeddata/rdflib.js/issues/631
     const meta = this.fetcher?.appNode // this.sym('chrome://TheCurrentSession')
     const linkNamespaceURI = 'http://www.w3.org/2007/ont/link#'
     const kb = this

--- a/tests/unit/update-manager-test.js
+++ b/tests/unit/update-manager-test.js
@@ -223,6 +223,17 @@ describe('UpdateManager', () => {
       expect(updater.editable(doc1)).to.equal(undefined)
     })
 
+    it('Should not detect a document is editable from metadata after removeMetadata', () => {
+      loadMeta(updater.store)
+      updater.store.removeMetadata(doc1)
+      expect(updater.editable(doc1)).to.equal(undefined)
+    })
+
+    it('Should not detect a document is editable from metadata after removeDocument', () => {
+      loadMeta(updater.store)
+      updater.store.removeDocument(doc1)
+      expect(updater.editable(doc1)).to.equal(undefined)
+    })
 
     it('Async version should detect a document is editable from metadata', async () => {
       loadMeta(updater.store)
@@ -233,13 +244,9 @@ describe('UpdateManager', () => {
 
     it('Async version should not detect a document is editable from metadata after flush', async () => {
       loadMeta(updater.store)
-
       expect(updater.editable(doc1)).to.equal('SPARQL')
-
       updater.flagAuthorizationMetadata()
-
       const result = await updater.checkEditable(doc1)
-
       expect(result).to.equal(undefined)
     })
 


### PR DESCRIPTION
`store.remove()` fails on triple containing a `Collection`