### PR TITLE
only remove document content

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -2004,7 +2004,11 @@ export default class Fetcher implements CallbackifyInterface {
 
       // Before we parse new data clear old but only on 200
       if (options.clearPreviousData) {
-        kb.removeDocument(options.resource)
+        // kb.removeDocument(options.resource)
+        const sts = kb.statementsMatching(undefined, undefined, undefined, options.resource).slice() // Take a copy as this is the actual index
+        for (let i = 0; i < sts.length; i++) {
+          kb.removeStatement(sts[i])
+        }
       }
 
       let isImage = contentType.includes('image/') ||

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -2005,6 +2005,7 @@ export default class Fetcher implements CallbackifyInterface {
       // Before we parse new data clear old but only on 200
       if (options.clearPreviousData) {
         // kb.removeDocument(options.resource)
+        // only remove content, keep metatdata
         const sts = kb.statementsMatching(undefined, undefined, undefined, options.resource).slice() // Take a copy as this is the actual index
         for (let i = 0; i < sts.length; i++) {
           kb.removeStatement(sts[i])


### PR DESCRIPTION
see issue#637
updater.update() fails on chat with thread since changes in removeDocument() that also removes metadata