### PR TITLE
Revert "removeMetadata"

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -871,47 +871,25 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
   }
 
   /**
-   * Removes all metadata
-   * @param doc - The document / graph
-   */
-  removeMetadata(doc: Quad_Graph): IndexedFormula {
-    // temporary until the issue on COLLECTION is resolved see https://github.com/linkeddata/rdflib.js/issues/631
-    const meta = this.fetcher?.appNode // this.sym('chrome://TheCurrentSession')
-    const linkNamespaceURI = 'http://www.w3.org/2007/ont/link#'
-    const kb = this
-    // removeMatches() --> removeMany() --> remove() fails on Collection
-    function removeBySubject (subject) {
-      const sts = kb.statementsMatching(subject, null, null, meta)
-      // console.log(sts)
-      for (var i = 0; i < sts.length; i++) {
-        kb.removeStatement(sts[i])
-      }
-    }
-    const requests = this.statementsMatching(null, this.sym(`${linkNamespaceURI}requestedURI`), this.rdfFactory.literal(doc.value), meta).map(st => st.subject)
-    for (var r = 0; r < requests.length; r++) {
-      const request = requests[r]
-      if (request != null) { // null or undefined
-        const response = this.any(request, this.sym(`${linkNamespaceURI}response`), null, meta) as Quad_Subject
-        // console.log('REQUEST ' + request.value)
-        removeBySubject(request)
-        if (response != null) { // null or undefined
-          // console.log('RESPONSE ' + response.value)
-          removeBySubject(response)
-        }
-      }
-    }
-    // console.log('DOCTYPE ' + doc.value)
-    removeBySubject(doc)
-    return this
-  }
-
-  /**
    * Removes all statements in a doc, along with the related metadata including request/response
    * @param doc - The document / graph
    */
   removeDocument(doc: Quad_Graph): IndexedFormula {
+    const meta = this.sym('chrome://TheCurrentSession') // or this.rdfFactory.namedNode('chrome://TheCurrentSession')
+    const linkNamespaceURI = 'http://www.w3.org/2007/ont/link#' // alain
     // remove request/response and metadata
-    this.removeMetadata(doc)
+    const requests = this.statementsMatching(undefined, this.sym(`${linkNamespaceURI}requestedURI`), this.rdfFactory.literal(doc.value), meta).map(st => st.subject)
+    for (var r = 0; r < requests.length; r++) {
+      const request = requests[r]
+      if (request !== undefined) {
+        this.removeMatches(request, null, null, meta)
+        const response = this.any(request, this.sym(`${linkNamespaceURI}response`), null, meta) as Quad_Subject
+        if (response !== undefined) { // ts
+          this.removeMatches(response, null, null, meta)
+        }
+      }
+    }
+    this.removeMatches(this.sym(doc.value), null, null, meta) // content-type
 
     // remove document
     var sts: Quad[] = this.statementsMatching(undefined, undefined, undefined, doc).slice() // Take a copy as this is the actual index

--- a/tests/unit/update-manager-test.js
+++ b/tests/unit/update-manager-test.js
@@ -223,17 +223,6 @@ describe('UpdateManager', () => {
       expect(updater.editable(doc1)).to.equal(undefined)
     })
 
-    it('Should not detect a document is editable from metadata after removeMetadata', () => {
-      loadMeta(updater.store)
-      updater.store.removeMetadata(doc1)
-      expect(updater.editable(doc1)).to.equal(undefined)
-    })
-
-    it('Should not detect a document is editable from metadata after removeDocument', () => {
-      loadMeta(updater.store)
-      updater.store.removeDocument(doc1)
-      expect(updater.editable(doc1)).to.equal(undefined)
-    })
 
     it('Async version should detect a document is editable from metadata', async () => {
       loadMeta(updater.store)
@@ -244,9 +233,13 @@ describe('UpdateManager', () => {
 
     it('Async version should not detect a document is editable from metadata after flush', async () => {
       loadMeta(updater.store)
+
       expect(updater.editable(doc1)).to.equal('SPARQL')
+
       updater.flagAuthorizationMetadata()
+
       const result = await updater.checkEditable(doc1)
+
       expect(result).to.equal(undefined)
     })
 


### PR DESCRIPTION
Reverts linkeddata/rdflib.js#633
This had issues not resolved. All metadata triples where not deleted.
A replacement removed the collection issue by removing the use of Collection in status message