### PR TITLE
Pass this.flags to `stringToN3`, fixes #650.

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -553,7 +553,7 @@ export class Serializer {
               return expr.value === '1' ? 'true' : 'false'
           }
         }
-        var str = this.stringToN3(expr.value)
+        var str = this.stringToN3(expr.value, this.flags)
         if (expr.language) {
           str += '@' + expr.language
         } else if (!expr.datatype.equals(this.xsd.string)) {


### PR DESCRIPTION
Passing this.flags to `stringToN3` to ensure that format flags are properly used. Fixes #650

The `stringToN3` function resets to default flag 'e` if `flags` has no value. This fix ensures that any flags that were set prior to calling `stringToN3` are properly taken into account.