### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      minor:
+        update-types:
+        - "minor"
+        - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This is the standard dependant configuration that I use (e.g. in https://github.com/eyereasoner/eye-js/blob/main/.github/dependabot.yml).

This will create PRs weekly to update npm dependencies and GitHub packages. These PRs *will not* be merged automatically - to enable auto merging we would need to:
 - Add an auto merge action like [this one](https://github.com/eyereasoner/eye-js/blob/main/.github/workflows/automerge.yml), and
  - enable the auto merge setting in https://github.com/linkeddata/rdflib.js/settings, and
  - enable branch protections in https://github.com/linkeddata/rdflib.js/branches that make the CI / tests "required" workflows. My default branch protections are:
    - Require a pull request before merging (all sub options are disabled)
    - Require status checks to pass before merging (once this is selected, you will be able to choose the required workflows)
    - Require branches to be up to date before merging
    - Require linear history
    - Do not allow bypassing the above settings