### PR TITLE
chore: token cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,16 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      pages: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: build
       - uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: .
 
   npm-publish-build:


### PR DESCRIPTION
Uses a [workflow token](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication) rather than requiring a PAT.

@bourgeoa this means that you can remove the PAT from the secrets in this repo and also decommission the PAT if it is yours.

I'm basing this on https://github.com/eyereasoner/eye-js/blob/e5ffb6028ed064e21a948c273a7a78d00b05d5a3/.github/workflows/nodejs.yml#L52-L94 - there is a chance we may need to increase the permission of this token to include some of the additional permissions listed in eye-js but I'm fairly confident that I've gotten the subset of required permissions correct here.