### PR TITLE
chore: skip prebuilds for non owners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,9 @@ jobs:
   npm-publish-build:
     needs: [build, prerelease-check]
     runs-on: ubuntu-latest
-    if: needs.prerelease-check.outputs.should_publish == 'true'
+    if: |
+      needs.prerelease-check.outputs.should_publish == 'true' &&
+      (github.event_name != 'pull_request' || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
> **Agent-revised description** — @jeswr's agent rewrote this description for reviewer clarity; the workflow change itself is @jeswr's original (March 2025), freshly rebased onto current `main`. The agent touched no code.

`ci.yml` runs the `npm-publish-build` job (the prerelease `npm publish --tag dev`) on `pull_request` events as well as pushes to `main`. Whenever `package.json` carries a not-yet-published prerelease version, every PR build therefore attempts a publish — and a PR whose author has no publish rights can never authenticate that step (then: repo secrets such as `NPM_TOKEN` are not exposed to fork PR runs; now, under the workflow's npm OIDC trusted publishing: fork PR runs are not granted the `id-token` it needs). The result is a red check unrelated to the PR's content, as seen on #667 #668 #669 #670.

**Fix** — one condition in one file (`.github/workflows/ci.yml`, +3/−1): gate the job's `if:` so the publish only runs outside `pull_request` events, or when the PR author's `author_association` is `OWNER` / `MEMBER` / `COLLABORATOR`.

| run | before | after |
|---|---|---|
| push to `main` | publish attempted | unchanged |
| PR authored by an owner / member / collaborator | publish attempted | unchanged |
| PR from any other author (fork / first-time contributor) | publish attempted → fails red | **skipped** |

**Backward-compat assessment:** CI-only — no library code, no serializer output, nothing about published artefacts changes. `npm-publish-latest` and `gh-pages` (both gated to `main`) are untouched. The change strictly removes publish attempts that could never succeed; no event newly publishes. With the current stable `2.4.0` version, `should_publish` is `false` and the job already skips for everyone; the gate takes effect whenever `main` carries an unpublished prerelease version — the state in which #667–#670 failed.

**Status:** rebased onto current `main`, per the ask on this PR's entry in the #824 open-PR triage ("re-check against the rewritten CI, then rebase"). CI is green on the rebase, the gated `if:` line is unchanged upstream, and the diff applies clean.
