### PR TITLE
Skip rdfParse if script content is empty

### DIFF
--- a/reference/fetcher-classes.js
+++ b/reference/fetcher-classes.js
@@ -113,7 +113,7 @@ class XHTMLHandler {
       var scripts = this.dom.getElementsByTagName('script')
       for (var i = 0; i < scripts.length; i++) {
         var contentType = scripts[i].getAttribute('type')
-        if (Parsable[contentType]) {
+        if (Parsable[contentType] && scripts[i].textContent.trim().length) {
           rdfParse(scripts[i].textContent, kb, xhr.original.uri, contentType)
         }
       }


### PR DESCRIPTION
May be sufficient to resolve https://github.com/linkeddata/rdflib.js/issues/692 . There should be better checks before committing to parse<del>, e.g., type=text/html and application/xhtml+xml in a script block is not particularly common</del>.