### PR TITLE
Fix/script textcontent parsing

### DIFF
--- a/reference/fetcher-classes.js
+++ b/reference/fetcher-classes.js
@@ -113,7 +113,7 @@ class XHTMLHandler {
       var scripts = this.dom.getElementsByTagName('script')
       for (var i = 0; i < scripts.length; i++) {
         var contentType = scripts[i].getAttribute('type')
-        if (Parsable[contentType]) {
+        if (Parsable[contentType] && scripts[i].textContent.trim().length) {
           rdfParse(scripts[i].textContent, kb, xhr.original.uri, contentType)
         }
       }


### PR DESCRIPTION
Migrates the fix from https://github.com/linkeddata/rdflib.js/pull/693 (csarven's fork) into the main repository to resolve https://github.com/linkeddata/rdflib.js/issues/692.

Change
Prevents parsing empty script tags in RDFa documents by checking content length before invoking the parser:

// reference/fetcher-classes.js, line 116
- if (Parsable[contentType]) {
+ if (Parsable[contentType] && scripts[i].textContent.trim().length) {
    rdfParse(scripts[i].textContent, kb, xhr.original.uri, contentType)
  }
Fixes errors when encountering <script type="text/turtle" src="..."></script> tags with no body content.