### PR TITLE
This patch makes Collection identity stable across in-place list mutations/removals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rdflib",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rdflib",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdflib",
   "description": "an RDF library for node.js. Suitable for client and server side.",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "private": false,
   "browserslist": [
     "> 0.5%"

--- a/src/factories/canonical-data-factory.ts
+++ b/src/factories/canonical-data-factory.ts
@@ -106,6 +106,10 @@ const CanonicalDataFactory: DataFactory = {
     switch (term.termType) {
       case DefaultGraphTermType:
         return 'defaultGraph'
+      case CollectionTermType:
+        // Collections are mutable (elements can change), so ID must be stable.
+        // Use the collection's blank-node-like identifier, not element content.
+        return Collection.toNT(term as Collection)
       case VariableTermType:
         return Variable.toString(term)
       default:

--- a/src/factories/extended-term-factory.ts
+++ b/src/factories/extended-term-factory.ts
@@ -38,8 +38,7 @@ const ExtendedTermFactory: CollectionFactory = {
 
   id (term: Term | DefaultFactoryTypes): Indexable {
     if (isCollection(term)) {
-      return `( ${term.elements.map((e) => {
-        return this.id(e) }).join(', ')} )`
+      return Collection.toNT(term)
     }
 
     if (isVariable(term)) {

--- a/tests/unit/indexed-formula-test.js
+++ b/tests/unit/indexed-formula-test.js
@@ -8,6 +8,7 @@ import { RDFArrayRemove } from '../../src/utils-js'
 import DataFactory from '../../src/factories/rdflib-data-factory'
 import parse from '../../src/parse'
 import serialize from '../../src/serialize'
+import Collection from '../../src/collection'
 
 describe('IndexedFormula', () => {
   const g0 = NamedNode.fromValue('https://example.com/graph0')
@@ -274,6 +275,18 @@ describe('IndexedFormula', () => {
       expect(store.statements.length).to.eq(0)
       expect(store.holds(s1, p1, o1)).to.equal(false)
       expect(store.holds(s2, p2, o2)).to.equal(false)
+    })
+
+    it('removes statement after mutating Collection object', () => {
+      const store = new IndexedFormula()
+      const list = new Collection([o1, o2])
+      store.add(s1, p1, list)
+
+      // Mutating the list must not invalidate index lookups for removal.
+      list.append(o3)
+
+      expect(() => store.remove(store.statements[0])).not.to.throw()
+      expect(store.statements.length).to.eq(0)
     })
   })
 


### PR DESCRIPTION
Should close https://github.com/SolidOS/solid-ui/issues/737

This patch makes Collection identity stable across in-place list mutations/removals in rdflib, preventing stale/duplicate references in IndexedFormula indexes.

It also adds a regression test that exercises the mutate-then-remove path to lock in the expected store behavior.