### PR TITLE
fix: correct `this.keyords` typo breaking the 'k' serializer flag (#742)

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -679,7 +679,7 @@ export class Serializer {
         if (this.defaultNamespace && this.defaultNamespace === namesp &&
             this.flags.indexOf('d') < 0) { // d -> suppress default
           if (this.flags.indexOf('k') >= 0 &&
-            this.keyords.indexOf(localid) < 0) {
+            this.keywords.indexOf(localid) < 0) {
             return localid
           }
           return ':' + localid

--- a/tests/unit/serializer-test.ts
+++ b/tests/unit/serializer-test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { graph, Serializer } from "../../src/index";
+import { graph, Serializer, sym } from "../../src/index";
 
 describe("Serializer", () => {
 	describe("can make up prefixes", () => {
@@ -48,6 +48,27 @@ describe("Serializer", () => {
 		it("with a URI starting with 'a'", () => {
 			const prefix = serializer.makeUpPrefix("http://aschema.org");
 			expect(prefix).to.equal("asc");
+		});
+	});
+
+	describe("with the 'k' (keywords) flag", () => {
+		let serializer;
+		beforeEach(() => {
+			serializer = Serializer(graph());
+			serializer.setFlags("k");
+			serializer.defaultNamespace = "http://example.org/ns#";
+		});
+
+		it("serializes a default-namespace symbol as a bare word", () => {
+			const term = serializer.symbolToN3(
+				sym("http://example.org/ns#foo")
+			);
+			expect(term).to.equal("foo");
+		});
+
+		it("keeps the colon for keywords such as 'a'", () => {
+			const term = serializer.symbolToN3(sym("http://example.org/ns#a"));
+			expect(term).to.equal(":a");
 		});
 	});
 });


### PR DESCRIPTION
> **Note:** This PR is agent-generated as part of the agent-assisted triage described in #823, and is awaiting review by @jeswr. Please don't merge until he has signed off — it will stay a draft until then.

Fixes #742

## The bug

`Serializer#symbolToN3` referenced `this.keyords` (typo) instead of `this.keywords` (defined in the constructor at `src/serializer.js:39`). This is the code path for the `'k'` (keywords) serializer flag, so any serialization using that flag together with a default namespace crashed.

## Reproduction

```js
const { graph, sym, Serializer } = require('rdflib')

const serializer = Serializer(graph())
serializer.setFlags('k')
serializer.defaultNamespace = 'http://example.org/ns#'
serializer.symbolToN3(sym('http://example.org/ns#foo'))
// TypeError: Cannot read properties of undefined (reading 'indexOf')
```

## The fix

One word in `src/serializer.js`: `this.keyords` → `this.keywords`. With the fix, the snippet above returns `"foo"` (bare word, as the `'k'` flag intends), and keywords such as `a` keep their colon (`:a`) so they can't be confused with the `a` keyword.

## Tests

Added two regression tests to `tests/unit/serializer-test.ts` covering the `'k'` flag path (bare word for non-keywords, `:a` for keywords). Verified they fail with the exact `TypeError` on the unfixed code and pass with the fix.

Local run: `npm run lint` (0 errors; 5 pre-existing warnings unchanged), `npm run build`, and the full `npm test` (306 unit tests + 18 serialize round-trips + type checks) all pass.

---

@jeswr — over to you when you have a moment; no rush.
