### PR TITLE
fix: NTriples serializer emitted misspelled rdf:nill instead of rdf:nil (#750)

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -306,7 +306,7 @@ export class Serializer {
         return self.atomicTermToN3(x)
       }
       var list = x.elements
-      var rest = kb.sym(rdfns + 'nill')
+      var rest = kb.sym(rdfns + 'nil')
       for (var i = list.length - 1; i >= 0; i--) {
         var bnode = factory.blankNode()
         str += termToNT(bnode) + ' ' + termToNT(kb.sym(rdfns + 'first')) + ' ' + termToNT(list[i]) + '.\n'

--- a/tests/serialize/t13-ref.ttl
+++ b/tests/serialize/t13-ref.ttl
@@ -1,5 +1,4 @@
 @prefix : </,structures.nt#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 @prefix str: </structures.n3#>.
 
@@ -46,23 +45,6 @@ _:_g_L4C88 str:name "Coretta Scott King".
 
 [
     a str:Marriage;
-    str:offspring
-            [
-                rdf:first str:MLK3;
-                rdf:rest
-                        [
-                            rdf:first str:DSK;
-                            rdf:rest
-                                    [
-                                        rdf:first str:YK;
-                                        rdf:rest
-                                                [
-                                                    rdf:first
-                                                    [ str:name "Bernice King" ];
-                                                    rdf:rest rdf:nill
-                                                ]
-                                    ]
-                        ]
-            ];
+    str:offspring ( str:MLK3 str:DSK str:YK [ str:name "Bernice King" ] );
     str:spouse str:MLK, _:_g_L4C88
 ].

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -552,6 +552,12 @@ const jsonldCollection1 = `{
         // console.log(await serialize(null, store, base, 'application/ld+json'))
         expect(await serialize(null, store, base, 'application/ld+json')).to.eql(jsonldCollection0)
       })
+      it('serialize to n-triples terminates the list with rdf:nil', () => {
+        // https://github.com/linkeddata/rdflib.js/issues/750
+        const result = serialize(null, store, base, 'application/n-triples')
+        expect(result).to.contain('<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>')
+        expect(result).not.to.contain('<http://www.w3.org/1999/02/22-rdf-syntax-ns#nill>')
+      })
     })
 
     describe('collections - source jsonld', () => {


### PR DESCRIPTION
> **Note: this is an agent-generated draft PR** (part of the agent-assisted triage announced in #823). It is for @jeswr to review — please don't merge until he has signed off. It will stay a draft until then.

Fixes #750

## Problem

The N-Triples/N-Quads serializer terminated RDF collections with a misspelled IRI — `rdf:nill` instead of [`rdf:nil`](https://www.w3.org/TR/rdf-schema/#ch_nil) — in `Serializer#statementsToNTriples` (`src/serializer.js:309`). Lists serialized to `application/n-triples` / `application/n-quads` ended in a nonexistent term, so no conforming consumer could recognise them as well-formed RDF collections. Credit to @DJ1TJOO for reporting this and fixing it in his serializer rewrite (see #750 / #740).

## Reproduction

Serializing a store containing a Collection to `application/n-triples` produced:

```
_:n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nill>.
```

The new unit test in `tests/unit/serialize-test.js` fails on `main` and passes with this fix.

## Fix

- **`src/serializer.js`** — one-word change: `kb.sym(rdfns + 'nill')` → `kb.sym(rdfns + 'nil')`.
- **`tests/unit/serialize-test.js`** — new test: serializing a collection to `application/n-triples` terminates the list with `rdf:nil` and never emits `rdf:nill`.
- **`tests/serialize/t13-ref.ttl`** — regenerated. This reference file had captured the buggy output: t13 round-trips `structures.n3` → n-triples → turtle, and because the list ended in the bogus `rdf:nill`, the turtle serializer could not recollapse it and the reference froze the degraded `rdf:first`/`rdf:rest` blank-node chain (including the `rdf:nill` literal text). With the fix, the round trip now correctly reproduces the `( str:MLK3 str:DSK str:YK [ str:name "Bernice King" ] )` collection syntax of the original input — a strict improvement, and the reason this file changes.

## Test results

- `npm run test:unit` — 305 passing (includes the new test)
- `npm run test:serialize` — all round-trip diffs pass (t13 verified failing before the ref update, passing after)
- `npm run test:types` — passes
- `npm run lint` — 0 errors (only pre-existing warnings, none in touched lines)
- `npm run build` — compiles cleanly

@jeswr — over to you to review and mark ready when you're happy (no rush!).
