### PR TITLE
fix: Turtle serializer abbreviates typed literals without validating lexical forms (#772)

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -577,7 +577,7 @@ export class Serializer {
             }
 
             case 'http://www.w3.org/2001/XMLSchema#boolean':
-              return expr.value === '1' ? 'true' : 'false'
+              return expr.value === '1' || expr.value === 'true' ? 'true' : 'false'
           }
         }
         var str = this.stringToN3(expr.value, this.flags)

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -546,6 +546,11 @@ export class Serializer {
   }
   // //////////////////////////////////////////// Atomic Terms
 
+  // Valid lexical forms that can be abbreviated to native Turtle tokens
+  validInteger = new RegExp(/^[+-]?[0-9]+$/)
+  validDecimal = new RegExp(/^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)$/)
+  validDouble = new RegExp(/^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/)
+
   //  Deal with term level things and nesting with no bnode structure
   atomicTermToN3 (expr, stats) {
     switch (expr.termType) {
@@ -558,17 +563,25 @@ export class Serializer {
           throw new TypeError('Value of RDF literal node must be a string')
         }
         // var val = expr.value.toString() // should be a string already
+        // Only abbreviate to native Turtle syntax when the lexical form is valid
+        // for the datatype AND expressible as a Turtle token; otherwise fall
+        // through to the verbose "value"^^datatype form so no data is lost.
         if (expr.datatype && this.flags.indexOf('x') < 0) { // Supress native numbers
           switch (expr.datatype.uri) {
 
             case 'http://www.w3.org/2001/XMLSchema#integer':
+              if (!this.validInteger.test(val)) break // Invalid lexical form: serialize verbosely
               return val
 
             case 'http://www.w3.org/2001/XMLSchema#decimal': // In Turtle, must have dot
+              if (!this.validDecimal.test(val)) break // Invalid lexical form: serialize verbosely
               if (val.indexOf('.') < 0) val += '.0'
+              else if (val.charAt(val.length - 1) === '.') val += '0' // Turtle needs a digit after the dot
               return val
 
             case 'http://www.w3.org/2001/XMLSchema#double': {
+              // INF, -INF and NaN are valid xsd:double but have no native Turtle form
+              if (!this.validDouble.test(val)) break // Invalid lexical form: serialize verbosely
               // Must force use of 'e'
               const eNotation = val.toLowerCase().indexOf('e') > 0
               if (val.indexOf('.') < 0 && !eNotation) val += '.0'
@@ -577,7 +590,9 @@ export class Serializer {
             }
 
             case 'http://www.w3.org/2001/XMLSchema#boolean':
-              return expr.value === '1' || expr.value === 'true' ? 'true' : 'false'
+              if (val === 'true' || val === '1') return 'true'
+              if (val === 'false' || val === '0') return 'false'
+              break // Invalid lexical form: serialize verbosely
           }
         }
         var str = this.stringToN3(expr.value, this.flags)

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -240,6 +240,42 @@ example:subject schema2:predicate 123e-2 .
 
     })
 
+    describe('booleans', () => {
+        const serializeBoolean = (lexicalForm) => {
+            const doc = sym("https://example.net/doc")
+            const statement = st(
+                sym('https://subject.example'),
+                sym('https://predicate.example'),
+                lit(lexicalForm, undefined, sym("http://www.w3.org/2001/XMLSchema#boolean")),
+                doc
+            )
+            const kb = graph()
+            kb.add(statement)
+            return serialize(doc, kb, null, 'text/turtle')
+        }
+        const expected = (token) => `@prefix : </doc#>.
+
+<https://subject.example> <https://predicate.example> ${token}.
+
+`
+
+        it('lexical form "true" serializes to true', () => {
+            expect(serializeBoolean('true')).to.equal(expected('true'))
+        })
+
+        it('lexical form "false" serializes to false', () => {
+            expect(serializeBoolean('false')).to.equal(expected('false'))
+        })
+
+        it('lexical form "1" serializes to true', () => {
+            expect(serializeBoolean('1')).to.equal(expected('true'))
+        })
+
+        it('lexical form "0" serializes to false', () => {
+            expect(serializeBoolean('0')).to.equal(expected('false'))
+        })
+    })
+
   describe('namespaces', () => {
     it('producing [prefix][colon] [dot]', () => {
       // when a symbol has a trailing slash, the automatic prefix production results in a prefixed symbol with no local name

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -274,6 +274,137 @@ example:subject schema2:predicate 123e-2 .
         it('lexical form "0" serializes to false', () => {
             expect(serializeBoolean('0')).to.equal(expected('false'))
         })
+
+        // Invalid lexical forms must fall through to the verbose form so no data is lost
+        const expectedVerbose = (token) => `@prefix : </doc#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://subject.example> <https://predicate.example> ${token}.
+
+`
+
+        it('invalid lexical form "yes" serializes verbosely', () => {
+            expect(serializeBoolean('yes')).to.equal(expectedVerbose('"yes"^^xsd:boolean'))
+        })
+
+        it('invalid lexical form "TRUE" serializes verbosely', () => {
+            expect(serializeBoolean('TRUE')).to.equal(expectedVerbose('"TRUE"^^xsd:boolean'))
+        })
+
+        it('invalid lexical form "2" serializes verbosely', () => {
+            expect(serializeBoolean('2')).to.equal(expectedVerbose('"2"^^xsd:boolean'))
+        })
+
+        it('invalid empty lexical form serializes verbosely', () => {
+            expect(serializeBoolean('')).to.equal(expectedVerbose('""^^xsd:boolean'))
+        })
+
+        it('invalid lexical form "01" serializes verbosely', () => {
+            expect(serializeBoolean('01')).to.equal(expectedVerbose('"01"^^xsd:boolean'))
+        })
+    })
+
+    describe('typed literals with valid and invalid lexical forms', () => {
+        const serializeTyped = (lexicalForm, datatype) => {
+            const doc = sym("https://example.net/doc")
+            const statement = st(
+                sym('https://subject.example'),
+                sym('https://predicate.example'),
+                lit(lexicalForm, undefined, sym(`http://www.w3.org/2001/XMLSchema#${datatype}`)),
+                doc
+            )
+            const kb = graph()
+            kb.add(statement)
+            return serialize(doc, kb, null, 'text/turtle')
+        }
+        const expectedNative = (token) => `@prefix : </doc#>.
+
+<https://subject.example> <https://predicate.example> ${token} .
+
+`
+        const expectedVerbose = (token) => `@prefix : </doc#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://subject.example> <https://predicate.example> ${token}.
+
+`
+
+        describe('integers', () => {
+            it('valid lexical forms serialize natively', () => {
+                expect(serializeTyped('42', 'integer')).to.equal(expectedNative('42'))
+                expect(serializeTyped('-7', 'integer')).to.equal(expectedNative('-7'))
+                expect(serializeTyped('+3', 'integer')).to.equal(expectedNative('+3'))
+            })
+
+            it('invalid lexical forms serialize verbosely', () => {
+                expect(serializeTyped('abc', 'integer')).to.equal(expectedVerbose('"abc"^^xsd:integer'))
+                expect(serializeTyped('1.5', 'integer')).to.equal(expectedVerbose('"1.5"^^xsd:integer'))
+                expect(serializeTyped('', 'integer')).to.equal(expectedVerbose('""^^xsd:integer'))
+                expect(serializeTyped('0x10', 'integer')).to.equal(expectedVerbose('"0x10"^^xsd:integer'))
+            })
+        })
+
+        describe('decimals', () => {
+            it('valid lexical forms serialize natively', () => {
+                expect(serializeTyped('3.14', 'decimal')).to.equal(expectedNative('3.14'))
+                expect(serializeTyped('-0.5', 'decimal')).to.equal(expectedNative('-0.5'))
+                expect(serializeTyped('.5', 'decimal')).to.equal(expectedNative('.5'))
+                expect(serializeTyped('5', 'decimal')).to.equal(expectedNative('5.0'))
+                expect(serializeTyped('2.', 'decimal')).to.equal(expectedNative('2.0'))
+            })
+
+            it('invalid lexical forms serialize verbosely', () => {
+                expect(serializeTyped('1.2.3', 'decimal')).to.equal(expectedVerbose('"1.2.3"^^xsd:decimal'))
+                expect(serializeTyped('abc', 'decimal')).to.equal(expectedVerbose('"abc"^^xsd:decimal'))
+                expect(serializeTyped('.', 'decimal')).to.equal(expectedVerbose('"."^^xsd:decimal'))
+                expect(serializeTyped('1e5', 'decimal')).to.equal(expectedVerbose('"1e5"^^xsd:decimal'))
+            })
+        })
+
+        describe('doubles', () => {
+            it('valid lexical forms serialize natively', () => {
+                expect(serializeTyped('1.0e10', 'double')).to.equal(expectedNative('1.0e10'))
+                expect(serializeTyped('1E5', 'double')).to.equal(expectedNative('1E5'))
+                expect(serializeTyped('-3.14e-2', 'double')).to.equal(expectedNative('-3.14e-2'))
+            })
+
+            it('valid xsd:double lexical forms without a native Turtle form serialize verbosely', () => {
+                // INF, -INF and NaN are valid xsd:double values but not valid Turtle DOUBLE tokens
+                expect(serializeTyped('NaN', 'double')).to.equal(expectedVerbose('"NaN"^^xsd:double'))
+                expect(serializeTyped('INF', 'double')).to.equal(expectedVerbose('"INF"^^xsd:double'))
+                expect(serializeTyped('-INF', 'double')).to.equal(expectedVerbose('"-INF"^^xsd:double'))
+            })
+
+            it('invalid lexical forms serialize verbosely', () => {
+                expect(serializeTyped('abc', 'double')).to.equal(expectedVerbose('"abc"^^xsd:double'))
+                expect(serializeTyped('1.2.3', 'double')).to.equal(expectedVerbose('"1.2.3"^^xsd:double'))
+            })
+        })
+
+        describe('invalid lexical forms round-trip without data loss', () => {
+            const roundTrip = (lexicalForm, datatype) => {
+                const doc = sym("https://example.net/doc")
+                const ttl = serializeTyped(lexicalForm, datatype)
+                const kb = graph()
+                parse(ttl, kb, doc.uri, 'text/turtle')
+                return kb.any(sym('https://subject.example'), sym('https://predicate.example'))
+            }
+            const cases = {
+                boolean: ['yes', 'TRUE', '2', '', '01'],
+                integer: ['abc', '1.5', '', '0x10'],
+                decimal: ['1.2.3', 'abc', '.', '1e5'],
+                double: ['NaN', 'INF', '-INF', 'abc', '1.2.3'],
+            }
+            Object.entries(cases).forEach(([datatype, lexicalForms]) => {
+                lexicalForms.forEach(lexicalForm => {
+                    it(`preserves "${lexicalForm}"^^xsd:${datatype}`, () => {
+                        const recovered = roundTrip(lexicalForm, datatype)
+                        expect(recovered.value).to.equal(lexicalForm)
+                        expect(recovered.datatype.uri).to.equal(`http://www.w3.org/2001/XMLSchema#${datatype}`)
+                    })
+                })
+            })
+        })
     })
 
   describe('namespaces', () => {


### PR DESCRIPTION
> **🚧 DRAFT — Note: this is an agent-generated draft PR** (part of the agent-assisted triage announced in #823). It is for @jeswr to review — please do not merge or mark ready-for-review until he has signed off.

Fixes #772. Part of the triage programme tracked in #824.

## Problem

`atomicTermToN3` (`src/serializer.js`) abbreviates `xsd:integer` / `xsd:decimal` / `xsd:double` / `xsd:boolean` literals to native Turtle tokens based only on the datatype URI, without checking that the lexical form is valid for that datatype. Originally reported for booleans in #772, generalized to the whole class after review:

| Input literal | Before | After |
|---|---|---|
| `"true"^^xsd:boolean` | `false` — **value flipped** (the #772 report) | `true` |
| `"false"` / `"1"` / `"0"` `^^xsd:boolean` | `false` / `true` / `false` | unchanged |
| `"yes"^^xsd:boolean` (invalid) | `false` — value lost | `"yes"^^xsd:boolean` |
| `"abc"^^xsd:integer` (invalid) | bare `abc` — invalid Turtle, datatype lost | `"abc"^^xsd:integer` |
| `"1.2.3"^^xsd:decimal` (invalid) | `1.2.3` — invalid Turtle | `"1.2.3"^^xsd:decimal` |
| `"2."^^xsd:decimal` (valid XSD; Turtle needs a digit after the dot) | `2.` — invalid Turtle | `2.0` |
| `"NaN"` / `"INF"` / `"-INF"` `^^xsd:double` (valid XSD; no Turtle DOUBLE form) | `NaN.0e0` etc. — mangled | `"NaN"^^xsd:double` etc. |
| `"abc"^^xsd:double` (invalid) | `abc.0e0` — mangled | `"abc"^^xsd:double` |

## Fix

Each of the four abbreviation cases now abbreviates only when the lexical form is valid for the datatype **and** expressible as a Turtle token:

- `xsd:integer` — `/^[+-]?[0-9]+$/`
- `xsd:decimal` — `/^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)$/`, then normalized so the token has a digit after the dot (`5` → `5.0`, `2.` → `2.0`)
- `xsd:double` — `/^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/` (excludes `INF`/`-INF`/`NaN`), then the existing `.`/`e` normalization
- `xsd:boolean` — `true`/`1` → `true`, `false`/`0` → `false`

Anything else falls through to the existing verbose `"value"^^datatype` path, so serialization is lossless and always emits valid Turtle. Diff: `src/serializer.js` +17/−1; everything else is tests.

## Ecosystem backward-compatibility assessment

- **Serializer-only** — parsing is untouched (read lenient, write strict).
- **Valid, correctly-serialized forms are byte-identical.** No `tests/serialize/*-ref.*` golden fixture changes; the full fixture corpus serializes identically (CI `test:serialize` green on this head).
- **Output changes only where the previous output was wrong** — the table rows above: a flipped value, lost data, or non-conformant Turtle. Every changed output is valid Turtle and round-trips with value and datatype preserved.
- **Who the #772 flip actually hit:** booleans stored with the standard lexical form `true` — e.g. minted by applications via `lit('true', undefined, XSD.boolean)`, or imported from RDF/JS-ecosystem libraries (N3.js et al.) that keep the canonical lexical form. Booleans from rdflib's own Turtle parser or `Literal.fromBoolean` are stored as `'1'`/`'0'` and always serialized correctly, so SolidOS/NSS round-trips through rdflib's own parser are unaffected.
- Related: #147 (the parser normalizes `true`/`false` to `'1'`/`'0'` on parse) is untouched here — but both lexical conventions now serialize to correct tokens.
- **Semver:** no API change; suggest `release-patch` (pure bug fix), though `release-minor` is defensible if any serializer-output delta is treated as behavioural.

## Tests

Extends the existing `tests/unit/serialize-test.js` (no new file):

- booleans: valid forms (`true`/`false`/`1`/`0`) unchanged; invalid forms (`yes`, `TRUE`, `2`, `""`, `01`) serialize verbosely
- new integer/decimal/double blocks: valid forms abbreviate exactly as before; invalid forms serialize verbosely
- serialize→parse round-trip tests asserting value + datatype are preserved for every invalid lexical form (no data loss)

CI is green on this head (Node 22.x / 24.x: unit + serialize golden fixtures + type tests + typedoc).

## Relationship to #830

#830 (term-level serialization rework) supersedes this PR and subsumes this fix at its term layer. This PR stands as the minimal, self-contained alternative if the larger rework is not taken — whichever lands, the other should be closed or rebased accordingly.

---
@jeswr — over to you for review; leaving as draft.
