### PR TITLE
fix: accept application/n-triples in parse() (#110)

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,7 +8,7 @@ import RDFParser from './rdfxmlparser'
 import sparqlUpdateParser from './patch-parser'
 import * as Util from './utils-js'
 import Formula from './formula'
-import { ContentType, TurtleContentType, N3ContentType, RDFXMLContentType, XHTMLContentType, HTMLContentType, SPARQLUpdateContentType, SPARQLUpdateSingleMatchContentType, JSONLDContentType, NQuadsContentType, NQuadsAltContentType } from './types'
+import { ContentType, TurtleContentType, N3ContentType, NTriplesContentType, RDFXMLContentType, XHTMLContentType, HTMLContentType, SPARQLUpdateContentType, SPARQLUpdateSingleMatchContentType, JSONLDContentType, NQuadsContentType, NQuadsAltContentType } from './types'
 import { Quad } from './tf-types'
 import type { Document as XmldomDocument } from '@xmldom/xmldom'
 
@@ -35,7 +35,7 @@ export default function parse (
   contentType = contentType || TurtleContentType
   contentType = contentType.split(';')[0] as ContentType
   try {
-    if (contentType === N3ContentType || contentType === TurtleContentType) {
+    if (contentType === N3ContentType || contentType === TurtleContentType || contentType === NTriplesContentType) {
       var p = N3Parser(kb, kb, base, base, null, null, '', null)
       p.loadBuf(str)
       executeCallback()
@@ -83,7 +83,8 @@ export default function parse (
     'application/sparql-update-single-match': true,
     'application/ld+json': true,
     'application/nquads' : true,
-    'application/n-quads' : true
+    'application/n-quads' : true,
+    'application/n-triples' : true
   }
 
   function executeCallback () {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type ContentType = typeof RDFXMLContentType
   | typeof N3LegacyContentType
   | typeof NQuadsAltContentType
   | typeof NQuadsContentType
+  | typeof NTriplesContentType
   | typeof SPARQLUpdateContentType
   | typeof SPARQLUpdateSingleMatchContentType
   | typeof TurtleContentType

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -216,6 +216,30 @@ ex:myid ex:prop1 [ ex:prop2 [ ex:prop3 "value" ] ].
   })
 }) // ttl
 
+  describe('n-triples', () => {
+    it('parses application/n-triples', () => {
+      let base = 'https://www.example.org/abc/def'
+      let mimeType = 'application/n-triples'
+      let store = DataFactory.graph()
+      let content = '<http://www.wikidata.org/entity/Q328> <http://www.w3.org/2000/01/rdf-schema#label> "English Wikipedia"@en .'
+      parse(content, store, base, mimeType)
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].subject.value).to.eql('http://www.wikidata.org/entity/Q328')
+      expect(store.statements[0].object.value).to.eql('English Wikipedia')
+      expect(store.statements[0].object.lang).to.eql('en')
+    })
+
+    it('parses application/n-triples with charset', () => {
+      let base = 'https://www.example.org/abc/def'
+      let mimeType = 'application/n-triples;charset=UTF-8'
+      let store = DataFactory.graph()
+      let content = '<http://www.wikidata.org/entity/Q328> <http://www.w3.org/2000/01/rdf-schema#label> "ангельская Вікіпэдыя"@be-x-old .'
+      parse(content, store, base, mimeType)
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].object.lang).to.eql('be-x-old')
+    })
+  }) // n-triples
+
   describe('a JSON-LD document', () => {
     describe('with a base IRI', () => {
       let store


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review — part of the agent-assisted triage announced in #823 (full plan: #824). Please don't merge or mark ready until he has signed off.

Fixes #110. Supersedes #220 — credit to @retog, who proposed the equivalent one-line change before the TypeScript migration; this PR re-applies it to the current `src/parse.ts` and adds test coverage.

## Problem

`serialize()` has long supported `application/n-triples`, but `parse()` rejects it:

```js
const store = $rdf.graph()
$rdf.parse('<http://example.com/s> <http://example.com/p> "o" .',
           store, 'http://example.com/', 'application/n-triples')
// => Error: Don't know how to parse application/n-triples yet
//    while trying to parse <http://example.com/> as application/n-triples
```

Reproduced against current `main` (v2.4.0). `src/parse.ts` handles `application/n-quads` but not `application/n-triples`, and the `NTriplesContentType` constant in `src/types.ts` was never added to the `ContentType` union nor wired into `parse()`.

## Fix

| File | Change |
|---|---|
| `src/parse.ts` | route `application/n-triples` into the same synchronous N3 parser branch as `text/turtle`/`text/n3` (N-Triples is a syntactic subset of Turtle), and add it to the `parse.handled` map |
| `src/types.ts` | add the already-existing `NTriplesContentType` constant to the `ContentType` union, so the new branch type-checks and the type accepted by `parse`/`serialize` matches reality |
| `tests/unit/parse-test.js` | two new cases: `application/n-triples` and `application/n-triples;charset=UTF-8` (mirroring the existing turtle-with-charset test) |

Why the Turtle branch rather than the n-quads branch: the n-quads path requires a callback, so routing through the Turtle branch keeps `parse()` synchronous for this content type — the same calling convention turtle users rely on today.

## Breaking-change / ecosystem assessment

Additive only — no ripple expected into SolidOS / NSS / solid-panes / mashlib:

- `parse()` with `application/n-triples` previously **threw**; it now parses. Every other content type takes exactly the code path it took before, and the serializer is untouched (zero output change — no `tests/serialize` ref-file diffs in this PR).
- Read-lenient by construction: the shared Turtle parser will accept full Turtle syntax under the `application/n-triples` label — the same tolerance `text/n3` already gets from this branch. Nothing that parsed before now parses differently or fails.
- Type-level: `ContentType` gains `'application/n-triples'`, which widens what TypeScript consumers may pass; nothing that compiled before is rejected.
- Suggested semver label: `release-patch`.

## Tests

Local results on Node 22.14.0:

- `npm run test:unit` — 306 passing (includes the 2 new tests; fails on `main` without the fix)
- `npm run lint` — 0 errors (5 pre-existing warnings)
- `npm run test:types`, `npm run build`, `npm run build:types` — all pass
