### PR TITLE
fix: accept undefined target in serialize() typings (#450)

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -20,7 +20,7 @@ import { BlankNode, NamedNode } from './tf-types'
  */
 export default function serialize (
   /** The graph or nodes that should be serialized */
-  target: Formula | NamedNode | BlankNode | null,
+  target: Formula | NamedNode | BlankNode | null | undefined,
   /** The store */
   kb: Formula,
   base?: unknown,

--- a/tests/types/serialize.ts
+++ b/tests/types/serialize.ts
@@ -1,0 +1,16 @@
+import { graph, serialize, st, sym, lit } from '../../src/index';
+
+// https://github.com/linkeddata/rdflib.js/issues/450
+// serialize() handles an absent target at runtime, so the typings must
+// accept `undefined` (and `null`) for the first argument.
+const kb = graph();
+kb.add(st(
+  sym('https://subject.example'),
+  sym('https://predicate.example'),
+  lit('value'),
+  sym('https://example.net/doc')
+));
+
+const withUndefined: string | undefined = serialize(undefined, kb, 'https://example.net/doc', 'text/turtle');
+const withNull: string | undefined = serialize(null, kb, 'https://example.net/doc', 'text/turtle');
+const withTarget: string | undefined = serialize(sym('https://example.net/doc'), kb, null, 'text/turtle');

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -270,6 +270,28 @@ example:subject schema:predicate obj: .
 `)
     })
   })
+
+  describe('target', () => {
+    // https://github.com/linkeddata/rdflib.js/issues/450
+    it('serializes all statements when target is undefined and a base is given', () => {
+      const statement = st(
+        sym('https://subject.example'),
+        sym('https://predicate.example'),
+        lit('value'),
+        sym('https://example.net/doc')
+      )
+      const kb = graph()
+      kb.add(statement)
+
+      const result = serialize(undefined, kb, 'https://example.net/doc', 'text/turtle')
+
+      expect(result).to.equal(`@prefix : </doc#>.
+
+<https://subject.example> <https://predicate.example> "value".
+
+`)
+    })
+  })
 })
 
 describe('parse --> serialize', () => {


### PR DESCRIPTION
> **Note: this is an agent-generated draft PR** (part of the agent-assisted triage announced in #823). It was prepared for @jeswr to review — please don't merge or mark ready until @jeswr has signed off. No rush on this, whenever someone has a moment.

Fixes #450

## Problem

`serialize()` handles an absent target just fine at runtime — `base = base || target?.value`, and `statementsMatching` accepts `undefined` — but the TypeScript signature only allows `null`:

```ts
target: Formula | NamedNode | BlankNode | null,
```

So strict-mode TypeScript consumers calling `serialize(undefined, kb, base, contentType)` get:

```
error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'NamedNode | BlankNode | Formula | null'.
```

Reproduced against the current `master` with `tsc --strict` (the project's own `tsconfig.json` is `strict: true`, so the published `.d.ts` promises non-`undefined` to strict consumers).

## Fix

Relax the first parameter to `Formula | NamedNode | BlankNode | null | undefined` (`src/serialize.ts`). It can't be made optional with `?` because the required `kb` parameter follows it, so widening the union is the minimal correct change. **Typing-only — zero runtime impact.**

This also supersedes the typings half of the (now stale) #237 by @rubensworks — the runtime falsy-target handling from that effort is already on `master`; this completes the picture on the type level. Credit to @rubensworks for the original runtime fix.

## Tests

- New runtime unit test in `tests/unit/serialize-test.js`: `serialize(undefined, kb, base, 'text/turtle')` serializes all statements — locks in the runtime contract the typing now promises.
- New compile-time contract test `tests/types/serialize.ts` (picked up by the existing `npm run test:types`) exercising `undefined`, `null`, and a `NamedNode` target. Note: `test:types` runs tsc without `--strict`, so this file documents the contract but only fails pre-fix under `--strict`; the strict repro above was verified manually.

## Verification

- `npm run test:unit` — 305 passing (304 pre-existing + 1 new)
- `npm run test:types` — clean
- `npm run build` + `npm run build:types` — clean; emitted `lib/serialize.d.ts` now has `target: Formula | NamedNode | BlankNode | null | undefined`
- `npm run lint` — 0 errors (5 pre-existing `no-console` warnings in untouched files)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — for @jeswr to review before this is marked ready.
