### PR TITLE
refactor: correct term-level serialization while preserving pretty output (supersedes #827)

### DIFF
--- a/src/serialize-term.js
+++ b/src/serialize-term.js
@@ -1,25 +1,10 @@
 /* Term-level serialization for Turtle / N3
 **
-** This module is the *correctness* layer that sits UNDER the pretty-printer in
-** src/serializer.js. It contains pure, side-effect-free helpers that turn a
-** single RDF term's lexical value into a valid Turtle/N3 token:
+** Pure helpers used by the pretty-printer in src/serializer.js to turn a
+** single RDF term's lexical value into a valid Turtle/N3 token.
 **
-**   - abbreviateTypedLiteral() : native numeric/boolean abbreviation, but only
-**                                when the lexical form is actually valid for the
-**                                datatype AND expressible as a Turtle token.
-**                                Otherwise returns null so the caller falls back
-**                                to a lossless "value"^^<datatype> form.
-**   - escapeStringBody()       : correct Turtle string escaping (valid ECHARs,
-**                                control characters, optional \\uXXXX for non-ASCII).
-**
-** Keeping these pure means the pretty-printing logic (subject grouping, prefix
-** use, RDF-list syntax, indentation) in serializer.js is unchanged: only the
-** term-level writing it delegates to is corrected. See
-** ~/css/upstream/rdflib-serializer-architecture.md for the full design.
-**
-** Inspired by the term-writing layers of @jeswr/pretty-turtle (lib/escape.ts,
-** validated numeric/boolean regexes) and @rdfjs/serializer-turtle
-** (lib/TermSerializer.js). Licence: MIT
+** Inspired by the term-writing layers of @jeswr/pretty-turtle and
+** @rdfjs/serializer-turtle. Licence: MIT
 */
 
 const XSD = 'http://www.w3.org/2001/XMLSchema#'
@@ -28,28 +13,18 @@ export const XSD_DECIMAL = XSD + 'decimal'
 export const XSD_DOUBLE = XSD + 'double'
 export const XSD_BOOLEAN = XSD + 'boolean'
 
-// Valid lexical spaces (subset expressible as a Turtle numeric token).
-// Mirrors the shapes used by @jeswr/pretty-turtle and rdflib PR #827.
+// Valid lexical spaces (the subset expressible as a Turtle numeric token)
 const INTEGER_RE = /^[+-]?[0-9]+$/
-// xsd:decimal lexical space; Turtle DECIMAL additionally needs a fraction, which
-// we complete below. We accept a trailing-dot form ("2.") as valid XSD and fix it.
+// xsd:decimal; a trailing-dot form ("2.") is valid XSD and completed below
 const DECIMAL_RE = /^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)$/
-// xsd:double: the numeric part optionally followed by an exponent. Deliberately
-// excludes the special values INF, -INF and NaN, which are valid xsd:double
-// values but have NO Turtle DOUBLE production, so they must fall back to quoted.
+// xsd:double, excluding INF/-INF/NaN which have no Turtle DOUBLE production
 const DOUBLE_RE = /^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/
 
 /**
  * Return a bare Turtle numeric/boolean token for `value` when it is a valid
  * lexical form of `datatypeUri` that Turtle can express natively; otherwise
- * return null so the caller emits a lossless quoted `"value"^^<datatype>` form.
- *
- * This is the single fix for the whole datatype-abbreviation bug family
- * (#147 / #619 / #772): abbreviation now happens only for values that are both
- * valid for their datatype and round-trippable, so the serializer never flips a
- * value ("true" stays true), never silently coerces an invalid value ("yes" is
- * preserved verbatim), and never emits an invalid Turtle token ("abc", "1.2.3",
- * "NaN").
+ * return null so the caller emits a lossless quoted `"value"^^<datatype>`
+ * form (#147/#619/#772).
  *
  * @param {string} value        the literal's lexical value
  * @param {string} datatypeUri  the literal's datatype IRI
@@ -73,8 +48,7 @@ export function abbreviateTypedLiteral(value, datatypeUri) {
 
     case XSD_DOUBLE: {
       if (!DOUBLE_RE.test(value)) return null
-      // Turtle DOUBLE requires an exponent; ensure one is present (mirrors the
-      // pre-existing normalisation so valid inputs serialise exactly as before).
+      // Turtle DOUBLE requires an exponent; ensure one is present
       let out = value
       const hasExponent = out.indexOf('e') >= 0 || out.indexOf('E') >= 0
       if (out.indexOf('.') < 0 && !hasExponent) out += '.0'
@@ -92,9 +66,8 @@ export function abbreviateTypedLiteral(value, datatypeUri) {
   }
 }
 
-// Characters that have a dedicated Turtle ECHAR escape. Note there is NO \\v:
-// U+000B (vertical tab) is *not* a valid Turtle escape, so it (and every other
-// control character without a named escape) goes through \\uXXXX below.
+// Characters with a dedicated Turtle ECHAR escape. There is no \v ECHAR:
+// U+000B, like other unnamed control characters, goes through \uXXXX below.
 const SHORT_ESCAPES = {
   '\t': '\\t',
   '\b': '\\b',
@@ -111,12 +84,6 @@ function unicodeEscapeChar(code) {
 
 /**
  * Escape the inner body of a Turtle/N3 string literal (delimiters not included).
- *
- * Fixes two escaping bugs in the previous inline implementation:
- *   - U+000B was emitted as the invalid escape `\\v` (Turtle has no \\v ECHAR).
- *   - Control characters U+0000–U+001F (and U+007F) outside the named set were
- *     passed through raw, producing invalid Turtle.
- * Both are now emitted as `\\uXXXX`.
  *
  * @param {string} str        the raw string value
  * @param {object} [opts]
@@ -136,15 +103,14 @@ export function escapeStringBody(str, { longString = false, unicodeEscape = true
     if (ch === '\\') {
       res += '\\\\'
     } else if (ch === '"') {
-      // In a long string a lone quote is legal; only escape a quote that would
-      // start a `"""` run and thus prematurely close the literal.
+      // In a long string only a quote starting a `"""` run needs escaping
       res += (longString && str.slice(i, i + 3) !== '"""') ? '"' : '\\"'
     } else if (longString && (ch === '\n' || ch === '\t')) {
       res += ch // newlines and tabs may stay raw inside a long string
     } else if (SHORT_ESCAPES[ch] !== undefined) {
       res += SHORT_ESCAPES[ch]
     } else if (code <= 0x1f || code === 0x7f) {
-      res += unicodeEscapeChar(code) // control chars incl. U+000B -> \uXXXX (never \v)
+      res += unicodeEscapeChar(code) // control chars incl. U+000B; Turtle has no \v
     } else if (unicodeEscape && code > 0x7e) {
       res += unicodeEscapeChar(code)
     } else {

--- a/src/serialize-term.js
+++ b/src/serialize-term.js
@@ -1,0 +1,155 @@
+/* Term-level serialization for Turtle / N3
+**
+** This module is the *correctness* layer that sits UNDER the pretty-printer in
+** src/serializer.js. It contains pure, side-effect-free helpers that turn a
+** single RDF term's lexical value into a valid Turtle/N3 token:
+**
+**   - abbreviateTypedLiteral() : native numeric/boolean abbreviation, but only
+**                                when the lexical form is actually valid for the
+**                                datatype AND expressible as a Turtle token.
+**                                Otherwise returns null so the caller falls back
+**                                to a lossless "value"^^<datatype> form.
+**   - escapeStringBody()       : correct Turtle string escaping (valid ECHARs,
+**                                control characters, optional \\uXXXX for non-ASCII).
+**
+** Keeping these pure means the pretty-printing logic (subject grouping, prefix
+** use, RDF-list syntax, indentation) in serializer.js is unchanged: only the
+** term-level writing it delegates to is corrected. See
+** ~/css/upstream/rdflib-serializer-architecture.md for the full design.
+**
+** Inspired by the term-writing layers of @jeswr/pretty-turtle (lib/escape.ts,
+** validated numeric/boolean regexes) and @rdfjs/serializer-turtle
+** (lib/TermSerializer.js). Licence: MIT
+*/
+
+const XSD = 'http://www.w3.org/2001/XMLSchema#'
+export const XSD_INTEGER = XSD + 'integer'
+export const XSD_DECIMAL = XSD + 'decimal'
+export const XSD_DOUBLE = XSD + 'double'
+export const XSD_BOOLEAN = XSD + 'boolean'
+
+// Valid lexical spaces (subset expressible as a Turtle numeric token).
+// Mirrors the shapes used by @jeswr/pretty-turtle and rdflib PR #827.
+const INTEGER_RE = /^[+-]?[0-9]+$/
+// xsd:decimal lexical space; Turtle DECIMAL additionally needs a fraction, which
+// we complete below. We accept a trailing-dot form ("2.") as valid XSD and fix it.
+const DECIMAL_RE = /^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)$/
+// xsd:double: the numeric part optionally followed by an exponent. Deliberately
+// excludes the special values INF, -INF and NaN, which are valid xsd:double
+// values but have NO Turtle DOUBLE production, so they must fall back to quoted.
+const DOUBLE_RE = /^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$/
+
+/**
+ * Return a bare Turtle numeric/boolean token for `value` when it is a valid
+ * lexical form of `datatypeUri` that Turtle can express natively; otherwise
+ * return null so the caller emits a lossless quoted `"value"^^<datatype>` form.
+ *
+ * This is the single fix for the whole datatype-abbreviation bug family
+ * (#147 / #619 / #772): abbreviation now happens only for values that are both
+ * valid for their datatype and round-trippable, so the serializer never flips a
+ * value ("true" stays true), never silently coerces an invalid value ("yes" is
+ * preserved verbatim), and never emits an invalid Turtle token ("abc", "1.2.3",
+ * "NaN").
+ *
+ * @param {string} value        the literal's lexical value
+ * @param {string} datatypeUri  the literal's datatype IRI
+ * @returns {string|null}
+ */
+export function abbreviateTypedLiteral(value, datatypeUri) {
+  switch (datatypeUri) {
+    case XSD_INTEGER:
+      return INTEGER_RE.test(value) ? value : null
+
+    case XSD_DECIMAL: {
+      if (!DECIMAL_RE.test(value)) return null
+      // Turtle DECIMAL needs a digit after the dot. Normalise:
+      //   "5"  -> "5.0"   (no dot at all)
+      //   "5." -> "5.0"   (trailing dot)
+      //   ".5", "5.5" are already valid Turtle DECIMALs.
+      if (value.indexOf('.') < 0) return value + '.0'
+      if (value.charAt(value.length - 1) === '.') return value + '0'
+      return value
+    }
+
+    case XSD_DOUBLE: {
+      if (!DOUBLE_RE.test(value)) return null
+      // Turtle DOUBLE requires an exponent; ensure one is present (mirrors the
+      // pre-existing normalisation so valid inputs serialise exactly as before).
+      let out = value
+      const hasExponent = out.indexOf('e') >= 0 || out.indexOf('E') >= 0
+      if (out.indexOf('.') < 0 && !hasExponent) out += '.0'
+      if (!hasExponent) out += 'e0'
+      return out
+    }
+
+    case XSD_BOOLEAN:
+      if (value === 'true' || value === '1') return 'true'
+      if (value === 'false' || value === '0') return 'false'
+      return null
+
+    default:
+      return null
+  }
+}
+
+// Characters that have a dedicated Turtle ECHAR escape. Note there is NO \\v:
+// U+000B (vertical tab) is *not* a valid Turtle escape, so it (and every other
+// control character without a named escape) goes through \\uXXXX below.
+const SHORT_ESCAPES = {
+  '\t': '\\t',
+  '\b': '\\b',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\f': '\\f',
+  '"': '\\"',
+  '\\': '\\\\',
+}
+
+function unicodeEscapeChar(code) {
+  return '\\u' + ('000' + code.toString(16).toLowerCase()).slice(-4)
+}
+
+/**
+ * Escape the inner body of a Turtle/N3 string literal (delimiters not included).
+ *
+ * Fixes two escaping bugs in the previous inline implementation:
+ *   - U+000B was emitted as the invalid escape `\\v` (Turtle has no \\v ECHAR).
+ *   - Control characters U+0000–U+001F (and U+007F) outside the named set were
+ *     passed through raw, producing invalid Turtle.
+ * Both are now emitted as `\\uXXXX`.
+ *
+ * @param {string} str        the raw string value
+ * @param {object} [opts]
+ * @param {boolean} [opts.longString]     true for a """triple-quoted""" literal,
+ *                                        where raw newlines and tabs are allowed
+ *                                        and a lone `"` may stay unescaped.
+ * @param {boolean} [opts.unicodeEscape]  true to \\uXXXX-escape non-ASCII (the
+ *                                        historic default; disabled by omitting
+ *                                        the 'e' flag).
+ * @returns {string}
+ */
+export function escapeStringBody(str, { longString = false, unicodeEscape = true } = {}) {
+  let res = ''
+  for (let i = 0; i < str.length; i++) {
+    const ch = str[i]
+    const code = str.charCodeAt(i)
+    if (ch === '\\') {
+      res += '\\\\'
+    } else if (ch === '"') {
+      // In a long string a lone quote is legal; only escape a quote that would
+      // start a `"""` run and thus prematurely close the literal.
+      res += (longString && str.slice(i, i + 3) !== '"""') ? '"' : '\\"'
+    } else if (longString && (ch === '\n' || ch === '\t')) {
+      res += ch // newlines and tabs may stay raw inside a long string
+    } else if (SHORT_ESCAPES[ch] !== undefined) {
+      res += SHORT_ESCAPES[ch]
+    } else if (code <= 0x1f || code === 0x7f) {
+      res += unicodeEscapeChar(code) // control chars incl. U+000B -> \uXXXX (never \v)
+    } else if (unicodeEscape && code > 0x7e) {
+      res += unicodeEscapeChar(code)
+    } else {
+      res += ch
+    }
+  }
+  return res
+}

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -11,6 +11,7 @@ import CanonicalDataFactory from './factories/canonical-data-factory'
 import * as Uri from './uri'
 import * as Util from './utils-js'
 import { createXSD } from './xsd'
+import { abbreviateTypedLiteral, escapeStringBody } from './serialize-term'
 
 
 export default function createSerializer(store) {
@@ -558,27 +559,14 @@ export class Serializer {
           throw new TypeError('Value of RDF literal node must be a string')
         }
         // var val = expr.value.toString() // should be a string already
-        if (expr.datatype && this.flags.indexOf('x') < 0) { // Supress native numbers
-          switch (expr.datatype.uri) {
-
-            case 'http://www.w3.org/2001/XMLSchema#integer':
-              return val
-
-            case 'http://www.w3.org/2001/XMLSchema#decimal': // In Turtle, must have dot
-              if (val.indexOf('.') < 0) val += '.0'
-              return val
-
-            case 'http://www.w3.org/2001/XMLSchema#double': {
-              // Must force use of 'e'
-              const eNotation = val.toLowerCase().indexOf('e') > 0
-              if (val.indexOf('.') < 0 && !eNotation) val += '.0'
-              if (!eNotation) val += 'e0'
-              return val
-            }
-
-            case 'http://www.w3.org/2001/XMLSchema#boolean':
-              return expr.value === '1' ? 'true' : 'false'
-          }
+        // Abbreviate numeric/boolean literals to native Turtle tokens, but ONLY
+        // when the lexical form is valid for the datatype and expressible as a
+        // Turtle token; otherwise fall through to the lossless quoted form below.
+        // This fixes the datatype-abbreviation bug family (#147/#619/#772):
+        // no value flips, no silent coercion of invalid values, no invalid tokens.
+        if (expr.datatype && this.flags.indexOf('x') < 0) { // Supress native numbers with 'x'
+          var abbreviated = abbreviateTypedLiteral(val, expr.datatype.uri)
+          if (abbreviated !== null) return abbreviated
         }
         var str = this.stringToN3(expr.value, this.flags)
         if (expr.language) {
@@ -600,49 +588,23 @@ export class Serializer {
 
   validPrefix = new RegExp(/^[a-zA-Z][a-zA-Z0-9]*$/)
 
-  forbidden1 = new RegExp(/[\\"\b\f\r\v\t\n\u0080-\uffff]/gm)
-  forbidden3 = new RegExp(/[\\"\b\f\r\v\u0080-\uffff]/gm)
+  // Choose the delimiter (this pretty-printing decision is unchanged); the
+  // character-level escaping is delegated to the correctness layer in
+  // ./serialize-term so control characters and U+000B are handled per the
+  // Turtle grammar (previously U+000B produced the invalid escape "\v").
   stringToN3(str, flags) {
     if (!flags) flags = 'e'
-    var res = ''
-    var i, j, k
-    var delim
-    var forbidden
-    if (str.length > 20 && // Long enough to make sense
-        str.slice(-1) !== '"' && // corner case'
-        flags.indexOf('n') < 0 && // Force single line
-        (str.indexOf('\n') > 0 || str.indexOf('"') > 0)) {
-      delim = '"""'
-      forbidden = this.forbidden3
-    } else {
-      delim = '"'
-      forbidden = this.forbidden1
-    }
-    for (i = 0; i < str.length;) {
-      forbidden.lastIndex = 0
-      var m = forbidden.exec(str.slice(i))
-      if (m == null) break
-      j = i + forbidden.lastIndex - 1
-      res += str.slice(i, j)
-      var ch = str[j]
-      if (ch === '"' && delim === '"""' && str.slice(j, j + 3) !== '"""') {
-        res += ch
-      } else {
-        k = '\b\f\r\t\v\n\\"'.indexOf(ch) // No escaping of bell (7)?
-        if (k >= 0) {
-          res += '\\' + 'bfrtvn\\"'[k]
-        } else {
-          if (flags.indexOf('e') >= 0) { // Unicode escaping in strings not unix style
-            res += '\\u' + ('000' +
-              ch.charCodeAt(0).toString(16).toLowerCase()).slice(-4)
-          } else { // no 'e' flag
-            res += ch
-          }
-        }
-      }
-      i = j + 1
-    }
-    return delim + res + str.slice(i) + delim
+    var longString =
+      str.length > 20 && // Long enough to make sense
+      str.slice(-1) !== '"' && // corner case'
+      flags.indexOf('n') < 0 && // Force single line
+      (str.indexOf('\n') > 0 || str.indexOf('"') > 0)
+    var delim = longString ? '"""' : '"'
+    var body = escapeStringBody(str, {
+      longString: longString,
+      unicodeEscape: flags.indexOf('e') >= 0, // Unicode escaping in strings not unix style
+    })
+    return delim + body + delim
   }
   //  A single symbol, either in  <> or namespace notation
 

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -559,11 +559,9 @@ export class Serializer {
           throw new TypeError('Value of RDF literal node must be a string')
         }
         // var val = expr.value.toString() // should be a string already
-        // Abbreviate numeric/boolean literals to native Turtle tokens, but ONLY
-        // when the lexical form is valid for the datatype and expressible as a
-        // Turtle token; otherwise fall through to the lossless quoted form below.
-        // This fixes the datatype-abbreviation bug family (#147/#619/#772):
-        // no value flips, no silent coercion of invalid values, no invalid tokens.
+        // Abbreviate to a native Turtle token only when the lexical form is
+        // valid for the datatype; otherwise fall through to the lossless
+        // quoted form below (#147/#619/#772)
         if (expr.datatype && this.flags.indexOf('x') < 0) { // Supress native numbers with 'x'
           var abbreviated = abbreviateTypedLiteral(val, expr.datatype.uri)
           if (abbreviated !== null) return abbreviated
@@ -588,10 +586,8 @@ export class Serializer {
 
   validPrefix = new RegExp(/^[a-zA-Z][a-zA-Z0-9]*$/)
 
-  // Choose the delimiter (this pretty-printing decision is unchanged); the
-  // character-level escaping is delegated to the correctness layer in
-  // ./serialize-term so control characters and U+000B are handled per the
-  // Turtle grammar (previously U+000B produced the invalid escape "\v").
+  // Chooses the delimiter; character-level escaping per the Turtle grammar
+  // is delegated to ./serialize-term
   stringToN3(str, flags) {
     if (!flags) flags = 'e'
     var longString =

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -631,10 +631,8 @@ const jsonldCollection1 = `{
   })
 })
 
-// Term-level correctness of the Turtle serializer: abbreviate numeric/boolean
-// literals only when the lexical form is valid for the datatype, and escape
-// strings per the Turtle grammar. Covers the datatype-abbreviation bug family
-// (#147 / #619 / #772) plus the \v / control-character escaping bugs.
+// Term-level correctness of the Turtle serializer: datatype abbreviation
+// (#147/#619/#772) and string escaping per the Turtle grammar
 describe('serialize text/turtle - term-level correctness', () => {
   const XSD = (local) => sym('http://www.w3.org/2001/XMLSchema#' + local)
   const S = sym('http://example.org/s')
@@ -755,8 +753,7 @@ describe('serialize text/turtle - term-level correctness', () => {
   })
 })
 
-// JSON-LD serialization routes through the Turtle serializer, so the boolean
-// fix also resolves the value flip reported for JSON-LD in #619.
+// JSON-LD serialization routes through the Turtle serializer (#619)
 describe('serialize application/ld+json - boolean value (#619)', () => {
   const XSD = (local) => sym('http://www.w3.org/2001/XMLSchema#' + local)
   it('keeps xsd:boolean "true" as true (not false)', async () => {

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -630,3 +630,139 @@ const jsonldCollection1 = `{
     })
   })
 })
+
+// Term-level correctness of the Turtle serializer: abbreviate numeric/boolean
+// literals only when the lexical form is valid for the datatype, and escape
+// strings per the Turtle grammar. Covers the datatype-abbreviation bug family
+// (#147 / #619 / #772) plus the \v / control-character escaping bugs.
+describe('serialize text/turtle - term-level correctness', () => {
+  const XSD = (local) => sym('http://www.w3.org/2001/XMLSchema#' + local)
+  const S = sym('http://example.org/s')
+  const P = sym('http://example.org/p')
+  const base = 'http://example.org/'
+  const doc = sym(base + 'doc')
+
+  // Serialize a single `s p object` statement and return the Turtle string.
+  const ttlOf = (object) => {
+    const kb = graph()
+    kb.add(st(S, P, object, doc))
+    return serialize(doc, kb, base, 'text/turtle')
+  }
+  // Serialize then re-parse; returns the parsed-back object term (round-trip).
+  const roundTrip = (object) => {
+    const ttl = ttlOf(object)
+    const kb2 = graph()
+    parse(ttl, kb2, base, 'text/turtle') // throws if the output is invalid Turtle
+    const back = kb2.statementsMatching(S, P, null)
+    return { ttl, obj: back.length === 1 ? back[0].object : null }
+  }
+  const truth = (v) => v === 'true' || v === '1'
+
+  describe('xsd:boolean (#147/#619/#772)', () => {
+    it('serializes canonical "true" as true, not false (#772)', () => {
+      const ttl = ttlOf(lit('true', null, XSD('boolean')))
+      expect(ttl).to.match(/\btrue\b/)
+      expect(ttl).to.not.match(/\bfalse\b/)
+    })
+
+    it('serializes "false", "1", "0" to the correct native token', () => {
+      expect(ttlOf(lit('false', null, XSD('boolean')))).to.match(/\bfalse\b/)
+      expect(ttlOf(lit('1', null, XSD('boolean')))).to.match(/\btrue\b/)
+      expect(ttlOf(lit('0', null, XSD('boolean')))).to.match(/\bfalse\b/)
+    })
+
+    it('preserves the truth value through a round-trip for every valid form', () => {
+      for (const form of ['true', 'false', '1', '0']) {
+        const { obj } = roundTrip(lit(form, null, XSD('boolean')))
+        expect(obj.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#boolean')
+        expect(truth(obj.value)).to.equal(truth(form))
+      }
+    })
+
+    it('preserves invalid boolean forms verbatim instead of coercing to false', () => {
+      for (const bad of ['yes', 'TRUE', '2', '']) {
+        const { ttl, obj } = roundTrip(lit(bad, null, XSD('boolean')))
+        expect(ttl).to.contain('^^xsd:boolean')
+        expect(obj.value).to.equal(bad)
+        expect(obj.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#boolean')
+      }
+    })
+  })
+
+  describe('xsd:integer / xsd:decimal / xsd:double', () => {
+    it('abbreviates valid numeric forms exactly as before', () => {
+      expect(ttlOf(lit('42', null, XSD('integer')))).to.match(/\s42\s/)
+      expect(ttlOf(lit('12.0', null, XSD('decimal')))).to.match(/\s12\.0\s/)
+      expect(ttlOf(lit('0.123', null, XSD('double')))).to.match(/\s0\.123e0\s/)
+    })
+
+    it('completes the Turtle DECIMAL fraction ("5" -> 5.0, "2." -> 2.0)', () => {
+      expect(ttlOf(lit('5', null, XSD('decimal')))).to.match(/\s5\.0\s/)
+      expect(ttlOf(lit('2.', null, XSD('decimal')))).to.match(/\s2\.0\s/)
+    })
+
+    it('never emits an invalid Turtle token for invalid lexical forms', () => {
+      const cases = [
+        ['abc', 'integer'],
+        ['1.2.3', 'decimal'],
+        ['NaN', 'double'],
+        ['INF', 'double'],
+        ['-INF', 'double'],
+      ]
+      for (const [value, dt] of cases) {
+        const { ttl, obj } = roundTrip(lit(value, null, XSD(dt)))
+        expect(ttl, `${value}^^xsd:${dt}`).to.contain('"' + value + '"^^xsd:' + dt)
+        expect(obj.value).to.equal(value)
+        expect(obj.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#' + dt)
+      }
+    })
+  })
+
+  describe('string escaping', () => {
+    it('escapes U+000B as \\u000b, never the invalid \\v escape', () => {
+      const { ttl, obj } = roundTrip(lit('a' + String.fromCharCode(0x0b) + 'b', null, XSD('string')))
+      expect(ttl).to.contain('\\u000b')
+      expect(ttl).to.not.contain('\\v')
+      expect(obj.value).to.equal('a' + String.fromCharCode(0x0b) + 'b')
+    })
+
+    it('escapes control characters that have no named Turtle escape', () => {
+      const raw = 'x' + String.fromCharCode(0x01) + String.fromCharCode(0x1f) + 'y'
+      const { ttl, obj } = roundTrip(lit(raw, null, XSD('string')))
+      expect(ttl).to.contain('\\u0001')
+      expect(ttl).to.contain('\\u001f')
+      expect(obj.value).to.equal(raw)
+    })
+  })
+
+  describe('a graph of invalid-and-valid literals', () => {
+    it('always serializes to valid, re-parseable Turtle with no value loss', () => {
+      const kb = graph()
+      const objects = [
+        lit('true', null, XSD('boolean')),
+        lit('yes', null, XSD('boolean')),
+        lit('abc', null, XSD('integer')),
+        lit('1.2.3', null, XSD('decimal')),
+        lit('NaN', null, XSD('double')),
+        lit('42', null, XSD('integer')),
+      ]
+      objects.forEach((o, i) => kb.add(st(S, sym(base + 'p' + i), o, doc)))
+      const ttl = serialize(doc, kb, base, 'text/turtle')
+      const kb2 = graph()
+      expect(() => parse(ttl, kb2, base, 'text/turtle')).to.not.throw()
+      expect(kb2.statements).to.have.length(objects.length)
+    })
+  })
+})
+
+// JSON-LD serialization routes through the Turtle serializer, so the boolean
+// fix also resolves the value flip reported for JSON-LD in #619.
+describe('serialize application/ld+json - boolean value (#619)', () => {
+  const XSD = (local) => sym('http://www.w3.org/2001/XMLSchema#' + local)
+  it('keeps xsd:boolean "true" as true (not false)', async () => {
+    const kb = graph()
+    kb.add(st(sym('http://ex/s'), sym('http://ex/p'), lit('true', null, XSD('boolean')), sym('http://ex/doc')))
+    const jsonld = await serialize(sym('http://ex/doc'), kb, 'http://ex/', 'application/ld+json')
+    expect(JSON.parse(jsonld)['http://ex/p']).to.equal(true)
+  })
+})


### PR DESCRIPTION
> **Agent-generated PR** (for @jeswr to review) — part of the agent-assisted
> serializer work following #823/#824. Marked **ready for review** on 2026-07-05
> as part of the v3.0.0 release-train prep, per your steer to push this work
> forward; review and merge remain entirely yours.
>
> **Train note:** #831 (N3.js parser migration) is the v3.0.0 anchor and lands
> first. Its branch carries a small 5-line fix to the same boolean leaf in
> `serializer.js` that this PR's term layer subsumes — expect a trivial rebase
> of this branch over #831, resolving toward this PR's `serialize-term.js` layer.

## Summary

rdflib's Turtle/N3 serializer produces **pretty** output (subject grouping,
prefix use, RDF-list `( … )` and blank-node `[ … ]` syntax, 80-column wrapping) —
a deliberate goal that migrating to n3.js would lose. The correctness bugs,
though, are not in that pretty layer; they are in the **term-level writing** at
the leaves (`atomicTermToN3` / `stringToN3`). This PR introduces a small **pure
term-level correctness layer underneath the pretty-printer** and routes the leaf
writers through it, fixing the bugs while leaving pretty output byte-for-byte
unchanged for valid data.

## The bugs (verified against `main`, `eb1e18d`)

`atomicTermToN3` abbreviated typed literals from the **datatype URI alone**, never
checking the lexical form, and `stringToN3` emitted an invalid `\v` escape:

| input literal (`s p <object>`) | before (`main`)         | after (this PR)          |
|--------------------------------|-------------------------|--------------------------|
| `"true"^^xsd:boolean`          | `false` — value flip    | `true`                   |
| `"yes"^^xsd:boolean` (invalid) | `false` — value lost    | `"yes"^^xsd:boolean`     |
| `"abc"^^xsd:integer`           | `abc` — invalid ttl     | `"abc"^^xsd:integer`     |
| `"1.2.3"^^xsd:decimal`         | `1.2.3` — invalid       | `"1.2.3"^^xsd:decimal`   |
| `"NaN"^^xsd:double`            | `NaN.0e0` — invalid     | `"NaN"^^xsd:double`      |
| string containing U+000B       | `\v` — invalid ttl      | `\u000b`                 |
| **serialize → parse the above**| **throws "Bad syntax"** | **re-parses cleanly**    |
| JSON-LD `"true"^^xsd:boolean`  | `false` (#619)          | `true`                   |

The boolean case actually **changed the data** (`"true"` → `false`), and the
JSON-LD path routes through `statementsToN3`, so it flipped there too (#619).

## The fix — a term-level correctness layer

New pure module `src/serialize-term.js` (no side effects, independently
unit-tested), consumed via the single existing seam in `serializer.js`:

- **`abbreviateTypedLiteral(value, datatypeUri)`** — returns a native Turtle
  numeric/boolean token **only** when the lexical form is valid for the datatype
  *and* expressible in Turtle; otherwise returns `null` and the caller emits the
  lossless `"value"^^<datatype>` form. Validation shapes:
  - integer `^[+-]?[0-9]+$`
  - decimal `^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)$`, fraction completed so the
    Turtle token has a digit after the dot (`5`→`5.0`, `2.`→`2.0`)
  - double `^[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$` (excludes
    `INF`/`-INF`/`NaN`, which have no Turtle DOUBLE form), then `.`/`e0`
    normalization
  - boolean `true`/`1`→`true`, `false`/`0`→`false`
- **`escapeStringBody(str, {longString, unicodeEscape})`** — Turtle-correct
  escaping. The escape map omits `\v`, so U+000B and every other unnamed control
  char (U+0000–U+001F, U+007F) go through `\uXXXX`. `stringToN3` keeps its
  pretty delimiter choice (single vs `"""`) and just delegates the character
  escaping.

**Principle:** a serializer must be total and lossless — abbreviation is only a
display optimization valid on a subset of lexical forms, so abbreviate on that
subset and fall back to the always-valid quoted form otherwise. Everything else
in the serializer (pretty layer + public API) is untouched.

## Breaking-change / ecosystem assessment

For SolidOS/NSS/solid-panes/mashlib and other consumers, the output deltas are
exactly these three classes — nothing else changes:

1. **Previously-invalid tokens become valid** (bare `abc`, `1.2.3`, `NaN.0e0`,
   the `\v` escape, `2.` without a fraction digit). A conformant Turtle parser —
   including rdflib's own — rejected these before, so no consumer round-trip can
   have depended on them; files already written with them were unreadable.
2. **The boolean value flip is undone**: `"true"^^xsd:boolean` now serializes as
   `true` instead of `false`. This is the one output change for a *valid* lexical
   form (`"false"`/`"1"`/`"0"` already serialized correctly); anything reading
   the old output was reading a corrupted truth value.
3. **Cosmetic escaping**: control characters without a named ECHAR (e.g. U+0001)
   are now written as `\uXXXX` instead of raw bytes. Both forms are valid Turtle
   and parse back to the identical string — a robustness change only.

Everything outside those classes is byte-identical: the golden serialize suite
(t1–t18) passes with **no `*-ref.*` fixture modified** in this PR. No public API
changes: `serialize-term.js` is internal (not re-exported from `src/index.ts`),
and `stringToN3`'s signature and the `x`/`n`/`e` flag semantics are preserved.

## Inspiration

- **[`@jeswr/pretty-turtle`](https://github.com/jeswr/pretty-turtle)** — borrowed
  the "validate the lexical form with a regex, else fall back to quoted" numeric/
  boolean approach and the `escape.ts` escape-map style (notably: no `\v`).
- **[`@rdfjs/serializer-turtle`](https://github.com/rdfjs-base/serializer-turtle)**
  (bergi) — borrowed the architectural boundary: a standalone `TermSerializer`
  that the pretty/structural code calls through one `toNT`-style seam, rather than
  interleaving term formatting with layout.

## Relationship to #827

#827 (`fix/issue-772-boolean-true-serialization`) is the **minimal inline** form
of the same datatype fix (patches the four `switch` cases in place). This PR
**supersedes** it by (1) extracting that logic into the pure, tested
`serialize-term.js` seam and (2) **additionally** fixing the string-escaping bugs
(`\v`, raw control chars) that #827 doesn't touch. Datatype semantics are
intentionally identical to #827, so they're consistent.

**Decision needed:** land #827 as the small targeted fix, **or** this as the
layered version (datatype fix + escaping fix + TermWriter seam) — not both. Happy
to go whichever way you prefer.

## Scope note

The prefix/base issues (`#251`: stray `@prefix : </#>`, missing `@base`) live in
the **pretty** layer and *change output for currently-"working" graphs*, so they
are intentionally **out of scope** here to keep this a safe, mechanical
correctness fix. Same for IRI-validation-at-construction (#168/#271) and the
parser-side half of #147.

## Covered issues

| Issue | Fix |
| --- | --- |
| #772 | `"true"^^xsd:boolean` no longer mis-serialized as `false` — booleans abbreviate from the validated lexical form, not `value === '1'`. |
| #619 | JSON-LD serialization routes through the same seam, so the boolean flip is fixed there too; regression test added. |
| #147 (serializer half) | Invalid boolean lexical forms (`"yes"`, `"TRUE"`, `"2"`) are no longer silently coerced to `false`; they serialize losslessly as `"…"^^xsd:boolean`. The parser-normalization half stays open. |
| #824 §3 (escaping) | Invalid `\v` escape replaced by `\u000b`; control characters without a named ECHAR are `\uXXXX`-escaped. |

Closes #772
Closes #619

## Tests

- `tests/unit/serialize-test.js` — new term-level-correctness block: booleans
  (incl. round-trip truth-value preservation), integer/decimal/double valid +
  invalid, decimal fraction completion, U+000B + control-char escaping, a mixed
  invalid-and-valid graph asserted to re-parse; plus a JSON-LD boolean test
  for #619.
- CI is green on this branch (Node 22.x + 24.x: `npm test` = unit + golden
  serialize suite + `test:types`, plus `npm run doc` and all builds).
