### PR TITLE
fix: UpdateManager correctness quick-fix wave (QF-4/5)

### DIFF
--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -476,8 +476,8 @@ export default class UpdateManager {
         query += 'DELETE DATA { ' + this.statementNT + ' } ;\n'
         const statement = this.statement as [Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph]
         query += 'INSERT DATA { ' +
-          // `this` is the object literal returned by update_statement, which has no
-          // anonymize method (issue #231) — use the captured UpdateManager instead.
+          // `this` here has no anonymize method; use the captured
+          // UpdateManager (issue #231)
           updater.anonymize(statement[0]) + ' ' +
           updater.anonymize(statement[1]) + ' ' +
           updater.anonymize(obj) + ' ' + ' . }\n'
@@ -941,7 +941,7 @@ _:patch
         if (secondTry) {
           throw new Error('Update: Loaded ' + doc + " but still can't figure out what editing protocol it supports.")
         }
-        // No metadata about the document: load it (once) and try the update again (issue #250)
+        // Load the document (once) and try the update again (issue #250)
         // console.log(`Update: have not loaded ${doc} before: loading now...`);
         (this.store.fetcher.load(doc as NamedNode) as Promise<Response>).then(response => {
           this.update(deletions, insertions, callback, true, options)
@@ -949,8 +949,7 @@ _:patch
           if (err.status === 404 || (err.response && err.response.status === 404)) { // nonexistent files are fine
             this.update(deletions, insertions, callback, true, options)
           } else {
-            // Route the failure through the callback so the returned promise
-            // rejects instead of hanging forever (issue #479)
+            // Fail via the callback so the returned promise settles (issue #479)
             callback(doc.value, false,
               `Update: Can't get updatability status ${doc} before patching: ${err}`, err)
           }
@@ -1045,7 +1044,7 @@ _:patch
     } // should not happen
     var response = kb.any(request as NamedNode, this.ns.link('response')) as Quad_Subject
     if (!response) {
-      // Returning null silently here left update() callers hanging forever (issue #479)
+      // Throw rather than return null, which left update() hanging (issue #479)
       throw new Error('No record of HTTP GET response for document: ' + doc)
     }
     var contentType = (kb.the(response, this.ns.httph('content-type')) as Term).value
@@ -1139,7 +1138,7 @@ _:patch
       }
       callbackFunction(doc.value, true, '')  // success!
     }).catch((err) => {
-      // Without this the returned promise never settled on write failure (issue #479)
+      // Report write failures so the returned promise settles (issue #479)
       callbackFunction(doc.value, false, err.message, err)
     })
   }

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -1044,7 +1044,7 @@ _:patch
     } // should not happen
     var response = kb.any(request as NamedNode, this.ns.link('response')) as Quad_Subject
     if (!response) {
-      // Throw rather than return null, which left update() hanging (issue #479)
+      // Caught by update(), which reports the failure via the callback (issue #479)
       throw new Error('No record of HTTP GET response for document: ' + doc)
     }
     var contentType = (kb.the(response, this.ns.httph('content-type')) as Term).value

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -474,15 +474,15 @@ export default class UpdateManager {
       set_object: function (obj, callbackFunction) {
         var query = this.where
         query += 'DELETE DATA { ' + this.statementNT + ' } ;\n'
+        const statement = this.statement as [Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph]
         query += 'INSERT DATA { ' +
-          // @ts-ignore `this` might refer to the wrong scope. Does this work?
-          this.anonymize(this.statement[0]) + ' ' +
-          // @ts-ignore
-          this.anonymize(this.statement[1]) + ' ' +
-          // @ts-ignore
-          this.anonymize(obj) + ' ' + ' . }\n'
+          // `this` is the object literal returned by update_statement, which has no
+          // anonymize method (issue #231) — use the captured UpdateManager instead.
+          updater.anonymize(statement[0]) + ' ' +
+          updater.anonymize(statement[1]) + ' ' +
+          updater.anonymize(obj) + ' ' + ' . }\n'
 
-        updater.fire((this.statement as [Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph])[3].value, query, callbackFunction)
+        updater.fire(statement[3].value, query, callbackFunction)
       }
     }
   }
@@ -939,16 +939,20 @@ _:patch
       }
       if (protocol === undefined) { // Not enough metadata
         if (secondTry) {
-          throw new Error('Update: Loaded ' + doc + "but still can't figure out what editing protocol it supports.")
+          throw new Error('Update: Loaded ' + doc + " but still can't figure out what editing protocol it supports.")
         }
+        // No metadata about the document: load it (once) and try the update again (issue #250)
         // console.log(`Update: have not loaded ${doc} before: loading now...`);
         (this.store.fetcher.load(doc as NamedNode) as Promise<Response>).then(response => {
           this.update(deletions, insertions, callback, true, options)
         }, err => {
-          if (err.response.status === 404) { // nonexistent files are fine
+          if (err.status === 404 || (err.response && err.response.status === 404)) { // nonexistent files are fine
             this.update(deletions, insertions, callback, true, options)
           } else {
-            throw new Error(`Update: Can't get updatability status ${doc} before patching: ${err}`)
+            // Route the failure through the callback so the returned promise
+            // rejects instead of hanging forever (issue #479)
+            callback(doc.value, false,
+              `Update: Can't get updatability status ${doc} before patching: ${err}`, err)
           }
         })
         return
@@ -1041,7 +1045,8 @@ _:patch
     } // should not happen
     var response = kb.any(request as NamedNode, this.ns.link('response')) as Quad_Subject
     if (!response) {
-      return null // throw "No record HTTP GET response for document: "+doc
+      // Returning null silently here left update() callers hanging forever (issue #479)
+      throw new Error('No record of HTTP GET response for document: ' + doc)
     }
     var contentType = (kb.the(response, this.ns.httph('content-type')) as Term).value
 
@@ -1133,6 +1138,9 @@ _:patch
         kb.add(is[i].subject, is[i].predicate, is[i].object, doc);
       }
       callbackFunction(doc.value, true, '')  // success!
+    }).catch((err) => {
+      // Without this the returned promise never settled on write failure (issue #479)
+      callbackFunction(doc.value, false, err.message, err)
     })
   }
 

--- a/tests/unit/update-manager-test.js
+++ b/tests/unit/update-manager-test.js
@@ -247,4 +247,126 @@ describe('UpdateManager', () => {
       expect(result).to.equal(undefined)
     })
   })
+
+  describe('update_statement', () => {
+    it('set_object should use the anonymize method of the UpdateManager (issue #231)', done => {
+      const updater = new UpdateManager()
+      updater.store.fetcher.webOperation = sinon.stub().resolves({ ok: true, status: 200, statusText: 'Dummy stub' })
+      loadMeta(updater.store)
+      updater.store.add(st1)
+
+      const handle = updater.update_statement(st1)
+      // Before the fix this threw synchronously: `this.anonymize is not a function`
+      handle.set_object($rdf.literal('999'), (uri, ok, text) => {
+        try {
+          expect(ok).to.equal(true)
+          expect(updater.store.fetcher.webOperation).to.have.been.calledOnce
+          const [method, patchUri, options] = updater.store.fetcher.webOperation.firstCall.args
+          expect(method).to.equal('PATCH')
+          expect(patchUri).to.equal(doc.uri)
+          expect(options.body).to.include('DELETE DATA')
+          expect(options.body).to.include('INSERT DATA')
+          expect(options.body).to.include('"999"')
+          done()
+        } catch (e) { done(e) }
+      })
+    })
+  })
+
+  describe('update() error propagation (issue #479)', () => {
+    let updater
+
+    beforeEach(() => {
+      updater = new UpdateManager()
+      updater.store.fetcher.webOperation = sinon.stub().resolves({ ok: true, status: 200, statusText: 'Dummy stub' })
+    })
+
+    it('promise form should reject when the metadata load fails (e.g. unauthorized)', async () => {
+      const err = new Error('Fetcher: unauthorized')
+      err.status = 401
+      err.response = { status: 401 }
+      sinon.stub(updater.store.fetcher, 'load').rejects(err)
+
+      let rejection
+      try {
+        await updater.update([], [st1])
+      } catch (e) {
+        rejection = e
+      }
+      expect(rejection).to.be.instanceOf(Error)
+      expect(rejection.message).to.include("Can't get updatability status")
+    })
+
+    it('callback form should report failure when the load error carries no response object', done => {
+      // Network-level failures have no `.response`; this used to crash inside the
+      // rejection handler and swallow the error, so update() never settled.
+      const err = new Error('Fetcher: network failure')
+      err.status = 999
+      sinon.stub(updater.store.fetcher, 'load').rejects(err)
+
+      updater.update([], [st1], (uri, ok, body) => {
+        try {
+          expect(ok).to.equal(false)
+          expect(body).to.include("Can't get updatability status")
+          done()
+        } catch (e) { done(e) }
+      })
+    })
+  })
+
+  describe('update() loads metadata then retries once (issue #250)', () => {
+    let updater
+
+    beforeEach(() => {
+      updater = new UpdateManager()
+      updater.store.fetcher.webOperation = sinon.stub().resolves({ ok: true, status: 200, statusText: 'Dummy stub' })
+    })
+
+    it('should retry after a 404 rejection from load (nonexistent resources are creatable)', done => {
+      const err404 = new Error('Fetcher: not found')
+      err404.status = 404
+      const loadStub = sinon.stub(updater.store.fetcher, 'load').callsFake(() => {
+        loadMeta(updater.store) // headers of the failed request still supply editability metadata
+        return Promise.reject(err404)
+      })
+
+      updater.update([], [st1], (uri, ok, body) => {
+        try {
+          expect(ok).to.equal(true)
+          expect(loadStub).to.have.been.calledOnce
+          expect(updater.store.fetcher.webOperation).to.have.been.calledOnce
+          done()
+        } catch (e) { done(e) }
+      })
+    })
+
+    it('should load only once and fail helpfully if metadata is still missing', done => {
+      // load succeeds but yields no editability metadata: no retry loop, helpful error
+      const loadStub = sinon.stub(updater.store.fetcher, 'load')
+        .resolves({ ok: true, status: 200, statusText: 'Dummy stub' })
+
+      updater.update([], [st1], (uri, ok, body) => {
+        try {
+          expect(ok).to.equal(false)
+          expect(loadStub).to.have.been.calledOnce
+          expect(body).to.include("still can't figure out what editing protocol")
+          done()
+        } catch (e) { done(e) }
+      })
+    })
+
+    it('promise form should reject helpfully if metadata is still missing after the load', async () => {
+      sinon.stub(updater.store.fetcher, 'load')
+        .resolves({ ok: true, status: 200, statusText: 'Dummy stub' })
+
+      let rejection
+      try {
+        await updater.update([], [st1])
+      } catch (e) {
+        rejection = e
+      }
+      expect(rejection).to.be.instanceOf(Error)
+      expect(rejection.message).to.include("still can't figure out what editing protocol")
+    })
+  })
 })

--- a/tests/unit/update-manager-test.js
+++ b/tests/unit/update-manager-test.js
@@ -256,7 +256,6 @@ describe('UpdateManager', () => {
       updater.store.add(st1)
 
       const handle = updater.update_statement(st1)
-      // Before the fix this threw synchronously: `this.anonymize is not a function`
       handle.set_object($rdf.literal('999'), (uri, ok, text) => {
         try {
           expect(ok).to.equal(true)
@@ -298,8 +297,7 @@ describe('UpdateManager', () => {
     })
 
     it('callback form should report failure when the load error carries no response object', done => {
-      // Network-level failures have no `.response`; this used to crash inside the
-      // rejection handler and swallow the error, so update() never settled.
+      // Network-level failures carry no `.response`
       const err = new Error('Fetcher: network failure')
       err.status = 999
       sinon.stub(updater.store.fetcher, 'load').rejects(err)


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review before it progresses.

Consolidated quick-fix wave **4/5 (UpdateManager correctness)** from the rdflib.js backlog triage (#823 / #824); consolidated into one PR to keep PR volume low. Sibling waves: #832, #834, #835, #836.

This wave covers UpdateManager correctness: a broken method binding, promise paths that never settle, and the load-then-retry behaviour for missing fetch metadata. All changes are confined to `src/update-manager.ts` plus regression tests in `tests/unit/update-manager-test.js` (deliberately steering clear of the in-flight #830/#831 rework surfaces).

## Issues covered

| Issue | Fix |
| --- | --- |
| #231 | `update_statement().set_object()` called `this.anonymize` on the returned object literal, which has no such method (`TypeError: this.anonymize is not a function`); it now uses the captured UpdateManager instance, and the stale `@ts-ignore`s are gone. |
| #479 | `update()`'s returned promise could hang forever: the metadata-load rejection handler threw into an unhandled promise (and crashed outright on errors without a `.response`, e.g. network/CORS failures), `updateDav()` silently returned `null` when response metadata was missing, and `updateLocalFile()` never settled when the PUT rejected. All three paths now route the failure through the callback so the promise rejects with a useful error. |
| #250 | Auto-load metadata before PATCH: the load-then-retry skeleton already landed on main (via the `secondTry` flag), but its error paths were the swallowed ones above, the 404 detection crashed on `FetchError`s without a `.response`, and the give-up message was garbled ("Loaded &lt;doc&gt;but still..."). This PR makes the single retry actually work end-to-end, fails helpfully when metadata is still missing after one load (no retry loop), and pins the behaviour with regression tests. |

Closes #231
Closes #479
Closes #250

## Regression tests

Six new mocha tests in `tests/unit/update-manager-test.js`: `set_object` no longer throws and emits the expected PATCH; the promise form rejects on load failure (with and without a `.response` on the error); a 404 rejection from the metadata load still retries once and succeeds; a metadata-less load fails helpfully after exactly one load attempt (callback and promise forms). Against unfixed `src/update-manager.ts` these fail as 1 `TypeError` + 3 mocha timeouts (the old forever-pending behaviour).

## Behaviour & ecosystem impact

All deltas are confined to **error paths**; success paths are unchanged. No parser or serializer file is touched and there are no `tests/serialize` reference-file changes.

- `update()`'s returned promise now settles (rejects with a useful error) where it previously hung forever. Code that `await`s `updater.update(...)` may newly observe rejections on requests that never completed before; the callback form receives the same `(uri, false, message)` failure shape it already had to handle.
- `updateDav()` throws instead of silently returning `null` when no HTTP response metadata is recorded. Inside `update()` the throw is caught and reported via the callback; the change is visible only to direct callers of that (likely deprecated) method. A GitHub code search finds no `updateDav` callers in solid-ui, solid-panes, mashlib, or node-solid-server.

## Notes, deviations, and cross-wave coordination

- #278 is deliberately excluded — it belongs to the sparqljs UpdateManager rework (#837); merge this wave before #837 and that PR will rebase.
- Deviation note on #250: classified as an M-effort implementation item in the triage, but the retry mechanism itself already existed on main; the remaining (and now fixed) defects were the dead error paths and missing tests, so the diff is smaller than planned.
- No changes to `src/patch-parser.js`, `src/n3parser.js`, or `src/serializer.js`, so no structural conflict expected with #831 or #830. No `package.json` changes, so no conflict with sibling waves there either.

## Gates (all exit 0)

`npm run lint` (0 errors, 5 pre-existing no-console warnings in untouched files) · `npm test` fully green (unit: 314 passing / 0 failing · serialize: pass · types: pass).
