### PR TITLE
fix: store & terms correctness quick-fix wave (QF-2/5)

### DIFF
--- a/src/formula.ts
+++ b/src/formula.ts
@@ -115,9 +115,8 @@ export default class Formula extends Node {
     graph?: Quad_Graph
   ): Statement | null | this | number {
     if (arguments.length === 1) {
-      // Don't fall through to the 4-argument case below: it would construct a
-      // corrupt statement out of the array/statement itself, with an undefined
-      // predicate and object. See issue #362.
+      // A lone array or statement must not fall through to the 4-argument
+      // case, which would build a corrupt statement from it (issue #362)
       if (subject instanceof Array) {
         subject.forEach(st => this.add(st.subject, st.predicate, st.object, st.graph))
       } else {

--- a/src/formula.ts
+++ b/src/formula.ts
@@ -115,7 +115,16 @@ export default class Formula extends Node {
     graph?: Quad_Graph
   ): Statement | null | this | number {
     if (arguments.length === 1) {
-      (subject as Quad[]).forEach(st => this.add(st.subject, st.predicate, st.object, st.graph))
+      // Don't fall through to the 4-argument case below: it would construct a
+      // corrupt statement out of the array/statement itself, with an undefined
+      // predicate and object. See issue #362.
+      if (subject instanceof Array) {
+        subject.forEach(st => this.add(st.subject, st.predicate, st.object, st.graph))
+      } else {
+        const st = subject as Quad
+        this.add(st.subject, st.predicate, st.object, st.graph)
+      }
+      return this
     }
     return this.statements.push(this.rdfFactory.quad(subject, predicate, object, graph))
   }

--- a/src/query.js
+++ b/src/query.js
@@ -51,6 +51,24 @@ export class Query {
  * @param onDone -  callback when query finished
  */
 export function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
+  // When the query selects specific variables (query.vars, as set by e.g.
+  // SPARQLToQuery from a SELECT clause), only report bindings for those
+  // variables — not for every variable that happened to be used in the
+  // pattern. See issue #393. Queries built without vars are unaffected.
+  if (myQuery.vars && myQuery.vars.length > 0) {
+    const userCallback = callback
+    const selected = myQuery.vars.map(function (v) { return String(v) })
+    callback = function (bindings) {
+      const projected = {}
+      for (let i = 0; i < selected.length; i++) {
+        if (bindings[selected[i]] !== undefined) {
+          projected[selected[i]] = bindings[selected[i]]
+        }
+      }
+      return userCallback(projected)
+    }
+  }
+
   /** Debug strings
   */
   function bindingDebug (b) {

--- a/src/query.js
+++ b/src/query.js
@@ -51,10 +51,8 @@ export class Query {
  * @param onDone -  callback when query finished
  */
 export function indexedFormulaQuery (myQuery, callback, fetcher, onDone) {
-  // When the query selects specific variables (query.vars, as set by e.g.
-  // SPARQLToQuery from a SELECT clause), only report bindings for those
-  // variables — not for every variable that happened to be used in the
-  // pattern. See issue #393. Queries built without vars are unaffected.
+  // Project reported bindings onto the selected variables (query.vars),
+  // if the query set any (issue #393)
   if (myQuery.vars && myQuery.vars.length > 0) {
     const userCallback = callback
     const selected = myQuery.vars.map(function (v) { return String(v) })

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -59,6 +59,15 @@ export default class Statement<
     object: O,
     graph?: G | DefaultGraph,
   ) {
+    if (subject === null || subject === undefined) {
+      throw new Error('Statement: the subject of a statement can not be ' + subject + ' (see https://github.com/linkeddata/rdflib.js/issues/362)')
+    }
+    if (predicate === null || predicate === undefined) {
+      throw new Error('Statement: the predicate of a statement can not be ' + predicate + ' (see https://github.com/linkeddata/rdflib.js/issues/362)')
+    }
+    if (object === null || object === undefined) {
+      throw new Error('Statement: the object of a statement can not be ' + object + ' (see https://github.com/linkeddata/rdflib.js/issues/362)')
+    }
     this.subject = Node.fromValue(subject)
     this.predicate = Node.fromValue(predicate)
     this.object = Node.fromValue(object)

--- a/src/store.ts
+++ b/src/store.ts
@@ -857,8 +857,11 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
    */
   remove(st: Quad | Quad[]): IndexedFormula {
     if (st instanceof Array) {
-      for (var i = 0; i < st.length; i++) {
-        this.remove(st[i])
+      // The array may be an index of this store (e.g. the result of statementsMatching),
+      // which removal mutates while we iterate — take a copy first. See issue #145.
+      const statements = st.slice()
+      for (var i = 0; i < statements.length; i++) {
+        this.remove(statements[i])
       }
       return this
     }
@@ -1001,8 +1004,11 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
    * @param sts The statements to remove
    */
   removeStatements(sts: ReadonlyArray<Quad>): IndexedFormula {
-    for (var i = 0; i < sts.length; i++) {
-      this.remove(sts[i])
+    // Copy the array first: it may be an index of this store, which removal
+    // mutates while we iterate. See issue #145.
+    const statements = sts.slice()
+    for (var i = 0; i < statements.length; i++) {
+      this.remove(statements[i])
     }
     return this
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -857,8 +857,8 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
    */
   remove(st: Quad | Quad[]): IndexedFormula {
     if (st instanceof Array) {
-      // The array may be an index of this store (e.g. the result of statementsMatching),
-      // which removal mutates while we iterate — take a copy first. See issue #145.
+      // Copy first: the array may be an index of this store, which removal
+      // mutates while we iterate (issue #145)
       const statements = st.slice()
       for (var i = 0; i < statements.length; i++) {
         this.remove(statements[i])
@@ -1004,8 +1004,8 @@ export default class IndexedFormula extends Formula { // IN future - allow pass 
    * @param sts The statements to remove
    */
   removeStatements(sts: ReadonlyArray<Quad>): IndexedFormula {
-    // Copy the array first: it may be an index of this store, which removal
-    // mutates while we iterate. See issue #145.
+    // Copy first: the array may be an index of this store, which removal
+    // mutates while we iterate (issue #145)
     const statements = sts.slice()
     for (var i = 0; i < statements.length; i++) {
       this.remove(statements[i])

--- a/src/utils/terms.ts
+++ b/src/utils/terms.ts
@@ -35,7 +35,10 @@ export function isCollection(obj: any): obj is Collection<any> {
 
 /** TypeGuard for valid RDFlib Object types, also allows Collections, Graphs */
 export function isRDFlibObject(obj: any): obj is ObjectType {
-  return obj && Object.prototype.hasOwnProperty.call(obj, 'termType') && (
+  // Duck-type on termType instead of checking for an own property: terms from
+  // other RDF/JS factories may expose termType as a getter or prototype
+  // property (e.g. es6 class getters), which hasOwnProperty misses. See issue #480.
+  return isTerm(obj) && (
     obj.termType === NamedNodeTermType ||
     obj.termType === VariableTermType ||
     obj.termType === BlankNodeTermType ||
@@ -48,7 +51,8 @@ export function isRDFlibObject(obj: any): obj is ObjectType {
 /** TypeGuard for valid RDFlib Subject types, same as Object as RDFLib symmetrical.
 */
 export function isRDFlibSubject(obj: any): obj is ObjectType {
-  return obj && Object.prototype.hasOwnProperty.call(obj, 'termType') && (
+  // Duck-type on termType — see isRDFlibObject above and issue #480.
+  return isTerm(obj) && (
     obj.termType === NamedNodeTermType ||
     obj.termType === VariableTermType ||
     obj.termType === BlankNodeTermType ||

--- a/src/utils/terms.ts
+++ b/src/utils/terms.ts
@@ -35,9 +35,8 @@ export function isCollection(obj: any): obj is Collection<any> {
 
 /** TypeGuard for valid RDFlib Object types, also allows Collections, Graphs */
 export function isRDFlibObject(obj: any): obj is ObjectType {
-  // Duck-type on termType instead of checking for an own property: terms from
-  // other RDF/JS factories may expose termType as a getter or prototype
-  // property (e.g. es6 class getters), which hasOwnProperty misses. See issue #480.
+  // Terms from other RDF/JS factories may expose termType as a getter,
+  // which hasOwnProperty misses (issue #480)
   return isTerm(obj) && (
     obj.termType === NamedNodeTermType ||
     obj.termType === VariableTermType ||
@@ -51,7 +50,7 @@ export function isRDFlibObject(obj: any): obj is ObjectType {
 /** TypeGuard for valid RDFlib Subject types, same as Object as RDFLib symmetrical.
 */
 export function isRDFlibSubject(obj: any): obj is ObjectType {
-  // Duck-type on termType — see isRDFlibObject above and issue #480.
+  // See isRDFlibObject above (issue #480)
   return isTerm(obj) && (
     obj.termType === NamedNodeTermType ||
     obj.termType === VariableTermType ||

--- a/tests/unit/formula-test.js
+++ b/tests/unit/formula-test.js
@@ -5,6 +5,7 @@ import Literal from '../../src/literal'
 import NamedNode from '../../src/named-node'
 import Namespace from '../../src/namespace'
 import Formula from '../../src/formula'
+import Statement from '../../src/statement'
 
 const alice = new NamedNode('https://alice.example.com/profile#alice')
 const doc = alice.doc()
@@ -120,6 +121,30 @@ describe('Formula', () => {
       let d = kb.anyJS(alice, age)
       expect(d instanceof Date).to.equal(true)
       expect(d.toISOString()).to.equal('2000-10-10T00:00:00.000Z')
+    })
+  })
+
+  describe('add', () => {
+    it('does not append a corrupt statement when given an array (issue #362)', () => {
+      const kb = new Formula()
+      kb.add([
+        new Statement(alice, knows, bob, doc),
+        new Statement(alice, knows, charlie, doc)
+      ])
+
+      expect(kb.statements).to.have.length(2)
+      for (const st of kb.statements) {
+        expect(st.subject.equals(alice)).to.equal(true)
+        expect(st.predicate.equals(knows)).to.equal(true)
+      }
+    })
+
+    it('adds a single statement object via addStatement', () => {
+      const kb = new Formula()
+      kb.addStatement(new Statement(alice, knows, bob, doc))
+
+      expect(kb.statements).to.have.length(1)
+      expect(kb.statements[0].object.equals(bob)).to.equal(true)
     })
   })
 

--- a/tests/unit/indexed-formula-test.js
+++ b/tests/unit/indexed-formula-test.js
@@ -288,6 +288,62 @@ describe('IndexedFormula', () => {
       expect(() => store.remove(store.statements[0])).not.to.throw()
       expect(store.statements.length).to.eq(0)
     })
+
+    it('removes every statement when passed an index of the store itself (issue #145)', () => {
+      const store = new IndexedFormula()
+      store.add([triple1, triple2, triple4])
+
+      // statementsMatching returns the store's own index array, which each
+      // removal mutates. remove() must not skip elements because of that.
+      const matches = store.statementsMatching(s1, null, null)
+      expect(matches.length).to.eq(2)
+
+      store.remove(matches)
+
+      expect(store.statementsMatching(s1, null, null)).to.have.length(0)
+      expect(store.holds(s1, p1, o1)).to.equal(false)
+      expect(store.holds(s1, p2, o3)).to.equal(false)
+    })
+  })
+
+  describe('removeStatements', () => {
+    it('removes all given statements, even from the store\'s own statements array (issue #145)', () => {
+      const store = new IndexedFormula()
+      store.add([triple1, triple2, triple3])
+
+      store.removeStatements(store.statements)
+
+      expect(store.statements).to.have.length(0)
+    })
+  })
+
+  describe('add with terms from a foreign RDF/JS factory (issue #480)', () => {
+    // Simulates terms produced by other RDF/JS-compliant libraries (e.g.
+    // Comunica), which may expose termType as an es6 class getter rather
+    // than an own property.
+    class ForeignNamedNode {
+      constructor (value) {
+        this._value = value
+      }
+      get termType () { return 'NamedNode' }
+      get value () { return this._value }
+      equals (other) {
+        return !!other && other.termType === this.termType && other.value === this.value
+      }
+    }
+
+    it('imports quads whose terms have termType getters', () => {
+      const store = new IndexedFormula()
+      const s = new ForeignNamedNode('https://example.com/subject1')
+      const p = new ForeignNamedNode('https://example.com/predicate1')
+      const o = new ForeignNamedNode('https://example.com/object1')
+
+      store.add(s, p, o)
+
+      expect(store.statements).to.have.length(1)
+      // The imported quad is interoperable with rdflib's own terms
+      expect(store.holds(s1, p1, o1)).to.equal(true)
+    })
   })
 
   describe('removeStatement', () => {

--- a/tests/unit/indexed-formula-test.js
+++ b/tests/unit/indexed-formula-test.js
@@ -293,8 +293,7 @@ describe('IndexedFormula', () => {
       const store = new IndexedFormula()
       store.add([triple1, triple2, triple4])
 
-      // statementsMatching returns the store's own index array, which each
-      // removal mutates. remove() must not skip elements because of that.
+      // statementsMatching returns the store's own index array, which removal mutates
       const matches = store.statementsMatching(s1, null, null)
       expect(matches.length).to.eq(2)
 
@@ -318,9 +317,8 @@ describe('IndexedFormula', () => {
   })
 
   describe('add with terms from a foreign RDF/JS factory (issue #480)', () => {
-    // Simulates terms produced by other RDF/JS-compliant libraries (e.g.
-    // Comunica), which may expose termType as an es6 class getter rather
-    // than an own property.
+    // Other RDF/JS libraries may expose termType as a class getter
+    // rather than an own property
     class ForeignNamedNode {
       constructor (value) {
         this._value = value

--- a/tests/unit/query-test.js
+++ b/tests/unit/query-test.js
@@ -194,6 +194,62 @@ describe('Query', () => {
 
   })
 })
+
+describe('Query variable projection (issue #393)', () => {
+  after(() => {
+    BlankNode.nextId = 0
+  })
+
+  const a = rdf.sym('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+  const person = rdf.sym('http://xmlns.com/foaf/0.1/Person')
+  const doc = rdf.sym('https://example.com/data')
+
+  const kb = rdf.graph()
+  kb.add(rdf.sym('https://example.com/alice#i'), a, person, doc)
+  kb.add(rdf.sym('https://example.com/bob#me'), a, person, doc)
+
+  it('only reports bindings for the variables the query selects', done => {
+    const query = rdf.SPARQLToQuery('SELECT ?type WHERE { ?subject a ?type. }', true, kb)
+    const results = []
+    kb.query(query, (bindings) => {
+      results.push(bindings)
+    }, null, () => {
+      expect(results).to.have.length(2)
+      for (const bindings of results) {
+        expect(Object.keys(bindings)).to.eql(['?type'])
+        expect(bindings['?type'].value).to.equal(person.value)
+      }
+      done()
+    })
+  })
+
+  it('projects querySync results to the selected variables too', () => {
+    const query = rdf.SPARQLToQuery('SELECT ?type WHERE { ?subject a ?type. }', true, kb)
+    const results = kb.querySync(query)
+    expect(results).to.have.length(2)
+    for (const bindings of results) {
+      expect(Object.keys(bindings)).to.eql(['?type'])
+      expect(bindings['?type'].value).to.equal(person.value)
+    }
+  })
+
+  it('keeps all bindings for queries that do not select specific variables', done => {
+    const s = new Variable('s')
+    const t = new Variable('t')
+    const query = new rdf.Query()
+    query.pat.add(rdf.st(s, a, t, doc))
+    const results = []
+    kb.query(query, (bindings) => {
+      results.push(bindings)
+    }, null, () => {
+      expect(results).to.have.length(2)
+      for (const bindings of results) {
+        expect(Object.keys(bindings).sort()).to.eql(['?s', '?t'])
+      }
+      done()
+    })
+  })
+})
 /////////////////////////////////////////////////
 
 describe('Synchronous Query', () => {

--- a/tests/unit/statement-test.js
+++ b/tests/unit/statement-test.js
@@ -13,4 +13,34 @@ describe('Statement', () => {
     )
     expect(statement.toString()).to.equal(serialized)
   })
+
+  describe('constructor validation (issue #362)', () => {
+    const s = new NamedNode('http://example.com/subject')
+    const p = new NamedNode('http://example.com/predicate')
+    const o = new NamedNode('http://example.com/object')
+
+    it('throws when constructed without any terms', () => {
+      expect(() => new Statement()).to.throw(Error, /subject/)
+    })
+
+    it('throws on a null or undefined subject', () => {
+      expect(() => new Statement(null, p, o)).to.throw(Error, /subject/)
+      expect(() => new Statement(undefined, p, o)).to.throw(Error, /subject/)
+    })
+
+    it('throws on a null or undefined predicate', () => {
+      expect(() => new Statement(s, null, o)).to.throw(Error, /predicate/)
+      expect(() => new Statement(s, undefined, o)).to.throw(Error, /predicate/)
+    })
+
+    it('throws on a null or undefined object', () => {
+      expect(() => new Statement(s, p, null)).to.throw(Error, /object/)
+      expect(() => new Statement(s, p, undefined)).to.throw(Error, /object/)
+    })
+
+    it('still defaults an omitted graph to the default graph', () => {
+      const statement = new Statement(s, p, o)
+      expect(statement.graph.termType).to.equal('DefaultGraph')
+    })
+  })
 })


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review — he will look at this personally before it progresses. Part of the backlog-triage programme agreed in #823 (full plan: #824).

Consolidated quick-fix **wave 2/5 ("store & terms correctness")** from the rdflib.js backlog triage; consolidated into one PR to keep PR volume low. Smallest-possible behavioral fixes, each with a regression test verified to fail on unmodified `main`.

## Fixes

| Issue | Fix | Rationale |
|---|---|---|
| #145 | `IndexedFormula.remove()` / `removeStatements()` iterate over a copy of the given array | The array is often one of the store's own indexes (e.g. from `statementsMatching`), which each removal splices, so iteration skipped every other statement |
| #393 | `indexedFormulaQuery` projects reported bindings down to `query.vars` (when non-empty) | `store.query()` returned bindings for every variable in the pattern, not just the ones the SPARQL SELECT asked for; queries built without `vars` are unaffected |
| #480 | `isRDFlibObject` / `isRDFlibSubject` now duck-type on `termType` (via `isTerm`) instead of `hasOwnProperty` | `hasOwnProperty` misses ES6 class getters, so spec-compliant terms from foreign RDF/JS factories (e.g. Comunica) were rejected by `store.add`; the other guards in `utils/terms.ts` already duck-type this way |
| #362 | `new Statement(...)` throws a clear error when subject, predicate or object is `null`/`undefined` (behavior agreed in the issue thread). Corollaries: `Formula.add`'s 1-argument branch no longer falls through and appends a corrupt statement (`predicate: undefined`), and `Formula.addStatement` now works on plain formulae | Corrupt statements were created silently and only blew up later (e.g. `toNT()` on `undefined`) |

Closes #145
Closes #393
Closes #480
Closes #362

## Breaking-change / ecosystem assessment

Per-fix impact on downstream consumers (SolidOS / NSS / solid-panes / mashlib and anything else on `store.query` / `store.add`):

- **Serializer and parsers untouched.** No change to `src/serializer.js` or the Turtle/N3 parser files, and `test:serialize` passes against the unchanged `*-ref.*` fixtures — byte-level output is identical.
- **#362 is the one behavioral tightening**: constructing a statement with a `null`/`undefined` subject, predicate or object (directly or via any factory `quad()` route) now throws a clear error at the construction site instead of silently building a corrupt statement that crashed later. Code that relied on getting away with this will surface immediately — flagging explicitly for review. Wildcard matching is unaffected: `match()` / `statementsMatching(null, …)` still accept `null` (see notes).
- **#393 narrows what `store.query()` reports**: callbacks now receive only the variables the SELECT clause asked for. A caller that read a non-selected pattern variable out of the bindings would stop seeing it — that leakage is the reported bug, but it is observable. Queries built without `vars` (e.g. hand-constructed `Query` objects) behave exactly as before.
- **#480 moves in the lenient direction**: spec-compliant terms from foreign RDF/JS factories that were previously rejected by `store.add` are now accepted; the same `termType` whitelist still applies.
- **#145 has no observable change** beyond `remove()` actually removing every statement it was given.

## Deviations / notes for review

- **#567 (formula subjects) — deliberately dropped, no change.** On close reading and empirical re-verification against current `main`, the reported failure no longer exists: both `parse()` of a `text/n3` document with a formula subject (`{ :a :b :c } :accordingTo :alice .`) and a direct `store.add(formula, pred, obj)` already succeed — the store's guard is now `isRDFlibSubject`, which accepts `Graph` terms (the strict RDF/JS `isSubject` the issue names is no longer used on this path). #831 additionally carries a fetcher-level regression test for the original repro shape, so coverage lands there; recommend closing #567 manually once either lands.
- **#362 scope:** the shared `Node.fromValue` still passes `null`/`undefined` through, because wildcard matching (`match()`/`statementsMatching`) and `Literal`'s optional datatype depend on that; the agreed "nonsensical statements must throw" behavior is enforced at `Statement` construction, which every factory `quad()` goes through. The issue thread (2019) also floated a console warning when the graph argument is defaulted; omitted deliberately — defaulting to `DefaultGraph` is the RDF/JS-aligned, clearly intentional behavior, and a per-statement warning would spam every `st(s, p, o)` caller.

## Expected conflicts with sibling waves

- None structural: this wave does not touch `src/serializer.js` or the Turtle/N3 parser files (#830/#831 own those). Possible trivial test-file merge conflicts with other waves extending the same `tests/unit/*-test.js` files.

## Local gates (all exit 0 at push time)

`npm run lint` (0 errors, 5 pre-existing `no-console` warnings) · `npm run test:unit` (321 passing, 0 failing) · `npm run test:serialize` (all 17, unchanged ref fixtures) · `npm run test:types`.
