### PR TITLE
feat: replace hand-rolled SPARQL handling (patch-parser, UpdateManager generation, SPARQLToQuery) with sparqljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Javascript RDF library for browsers and Node.js.
 - Real-Time Collaborative editing with web sockets and PATCHes
 - Local API for querying a store
 - Compatible with [RDFJS task force spec](https://github.com/rdfjs/representation-task-force/blob/master/interface-spec.md)
-- SPARQL queries (not full SPARQL - just graph match and optional)
+- SPARQL queries (not full SPARQL — a documented subset, see [SPARQL support](#sparql-support))
 - Smushing of nodes from `owl:sameAs`, and `owl:{f,inverseF}unctionProperty`
 - Tracks provenance of triples keeps metadata (in RDF) from HTTP accesses
 
@@ -92,6 +92,62 @@ Notes:
 
 - For Turtle and JSON‑LD, user‑provided flags are merged with the defaults so your flags (like `o`) are honored.
 - By contrast, passing `'p'` disables prefix abbreviations entirely (all terms are written as `<...>` IRIs).
+
+## SPARQL support
+
+rdflib is not a SPARQL engine, but it accepts a well-defined subset of SPARQL
+in two places. Both are parsed with [sparqljs](https://github.com/RubenVerborgh/SPARQL.js),
+so anything accepted is real SPARQL 1.1 syntax and syntax errors are reported
+with clear messages.
+
+#### Queries: `SPARQLToQuery(sparql, testMode, kb)`
+
+`SPARQLToQuery` translates a SPARQL string onto rdflib's pattern-matching
+`Query` object, which you can run against a store with `kb.query(query,
+onResult, fetcher?, onDone?)` or `kb.querySync(query)`:
+
+```js
+const query = $rdf.SPARQLToQuery(`
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  SELECT ?name WHERE {
+    ?person a foaf:Person ;
+            foaf:name ?name .
+    OPTIONAL { ?person foaf:nick ?nick . }
+    FILTER regex(?name, "^A")
+  }`, false, kb)
+
+kb.query(query, bindings => console.log(bindings['?name'].value))
+```
+
+The supported subset is:
+
+- `SELECT ?x ?y WHERE { ... }` and `SELECT * WHERE { ... }` (a `CONSTRUCT`
+  query is executed as a `SELECT` over its `WHERE` clause: the API returns
+  variable bindings, not graphs)
+- basic graph patterns: triple patterns with `;`/`,` abbreviations, `a`,
+  prefixed names, IRIs, literals and blank nodes (`rdf:` and `rdfs:` are
+  predeclared)
+- `OPTIONAL { ... }` groups, which may nest and may contain `FILTER`s
+- `FILTER` constraints of the forms `FILTER (?x = constant)`,
+  `FILTER (?x > constant)`, `FILTER (?x < constant)` and
+  `FILTER regex(?x, "pattern"[, "flags"])`
+
+Everything else — `ASK`/`DESCRIBE`, property paths, `UNION`, `GRAPH`, `FROM`,
+`BIND`, `VALUES`, subqueries, aggregates and solution modifiers such as
+`ORDER BY`/`LIMIT`/`DISTINCT`, other `FILTER` operators — throws an
+informative error naming the unsupported construct. If you need full SPARQL
+1.1, run a real engine (e.g. [Comunica](https://comunica.dev/)) over the
+store instead.
+
+#### Updates
+
+`UpdateManager.update(deletions, insertions, callback?)` writes changes back
+to the web by generating spec-conformant SPARQL 1.1 Update (or N3 Patch)
+requests — you never write SPARQL yourself. The patch parser used for
+`text/n3`-less servers (`application/sparql-update` documents fed to
+`parse()`) accepts `INSERT DATA`, `DELETE DATA`, and `DELETE/INSERT/WHERE`
+operations built from basic graph patterns, with `PREFIX` (or legacy
+`@prefix ... .`) declarations, in any clause order.
 
 ## Contribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "cross-fetch": "^4.1.0",
         "jsonld": "^9.0.0",
         "n3": "^2.0.3",
-        "solid-namespace": "^0.5.4"
+        "solid-namespace": "^0.5.4",
+        "sparqljs": "^3.7.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.28.6",
@@ -33,6 +34,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.1",
         "@types/sinon-chai": "^4.0.0",
+        "@types/sparqljs": "^3.1.12",
         "babel-loader": "^10.1.1",
         "chai": "^6.2.2",
         "colors": "^1.4.0",
@@ -2678,6 +2680,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.12.tgz",
+      "integrity": "sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
       }
     },
     "node_modules/@types/unist": {
@@ -7211,6 +7223,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.3.0",
       "license": "MIT",
@@ -8011,6 +8041,22 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.4.tgz",
+      "integrity": "sha512-hb4C84gf7KM7vz+iG595mPwvqxOvBJCm9L3dCxtV2zZDht6ZMmMG0tHeeqFeqwb9875yU9U4lhYe4LYRvWj0BQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.2"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/spdy": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "cross-fetch": "^4.1.0",
     "jsonld": "^9.0.0",
     "n3": "^2.0.3",
-    "solid-namespace": "^0.5.4"
+    "solid-namespace": "^0.5.4",
+    "sparqljs": "^3.7.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",
@@ -68,6 +69,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.1",
     "@types/sinon-chai": "^4.0.0",
+    "@types/sparqljs": "^3.1.12",
     "babel-loader": "^10.1.1",
     "chai": "^6.2.2",
     "colors": "^1.4.0",

--- a/src/patch-parser.js
+++ b/src/patch-parser.js
@@ -1,94 +1,217 @@
-// Parse a simple SPARL-Update subset syntax for patches.
+// Parse a SPARQL-Update subset syntax for patches, using the SPARQL 1.1
+// Update grammar implemented by sparqljs.
 //
 //  This parses
-//   WHERE {xxx} DELETE {yyy} INSERT DATA {zzz}
-// (not necessarily in that order)
+//   DELETE {yyy} INSERT {zzz} WHERE {xxx}
+// (for backward compatibility, the clauses may arrive in any order, e.g.
+// legacy WHERE-first patches, and `INSERT DATA`/`DELETE DATA` and N3-style
+// `@prefix` directives are also accepted)
 // as though it were the n3
 //   <#query> patch:where {xxx}; patch:delete {yyy}; patch:insert {zzz}.
-import N3Parser from './n3parser'
+import { Parser as SparqlParser } from 'sparqljs'
 import Namespace from './namespace'
+import { docpart } from './uri'
+
+// Skip whitespace and #-comments. Returns the next index (may be str.length).
+function skipSpace (str, i) {
+  while (i < str.length) {
+    var ch = str[i]
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n' || ch === '\f') {
+      i += 1
+    } else if (ch === '#') { // comment runs to end of line
+      while (i < str.length && str[i] !== '\n') i += 1
+    } else {
+      break
+    }
+  }
+  return i
+}
+
+// Scan a single- or triple-quoted string starting at i (str[i] is the quote).
+// Returns the index just after the closing quote(s).
+function skipString (str, i, base) {
+  var quote = str[i]
+  var long = str.slice(i, i + 3) === quote + quote + quote
+  var terminator = long ? quote + quote + quote : quote
+  i += terminator.length
+  while (i < str.length) {
+    if (str[i] === '\\') {
+      i += 2
+    } else if (str.slice(i, i + terminator.length) === terminator) {
+      return i + terminator.length
+    } else if (!long && str[i] === '\n') {
+      return i // unterminated single-line string; let sparqljs report it
+    } else {
+      i += 1
+    }
+  }
+  throw badPatchSyntax(base, str, i, 'unterminated string literal in patch')
+}
+
+// Given str[i] === '{', return the index just after the matching '}',
+// respecting nested groups, strings, IRIs and comments.
+function skipGroup (str, i, base) {
+  var depth = 0
+  var start = i
+  while (i < str.length) {
+    var ch = str[i]
+    if (ch === '{') {
+      depth += 1
+      i += 1
+    } else if (ch === '}') {
+      depth -= 1
+      i += 1
+      if (depth === 0) return i
+    } else if (ch === '"' || ch === "'") {
+      i = skipString(str, i, base)
+    } else if (ch === '<') { // probably an IRIREF: scan to '>' unless it is a comparison
+      var j = i + 1
+      while (j < str.length && str[j] !== '>' &&
+             !/[\s<"{}]/.test(str[j])) j += 1
+      i = (str[j] === '>') ? j + 1 : i + 1
+    } else if (ch === '#') { // comment runs to end of line
+      while (i < str.length && str[i] !== '\n') i += 1
+    } else {
+      i += 1
+    }
+  }
+  throw badPatchSyntax(base, str, start, "no matching '}' for clause group")
+}
+
+function badPatchSyntax (base, str, i, why) {
+  return new Error('Patch syntax failure in <' + base + '>: ' + why +
+    '\n   at: "' + str.slice(i, i + 30) + '"')
+}
+
+// Split the patch into prefix/base directives and top-level clauses,
+// without interpreting the clause bodies.
+function scanTopLevel (str, base) {
+  var directives = []
+  var clauses = [] // { kind: 'insert'|'delete'|'where', body: string }
+  var i = 0
+  var m
+  for (;;) {
+    i = skipSpace(str, i)
+    if (i >= str.length) return { directives: directives, clauses: clauses }
+    if (str[i] === ';') { // clause separator, as in legacy patches
+      i += 1
+      continue
+    }
+    var rest = str.slice(i)
+    if ((m = rest.match(/^@?prefix\s+([^\s<>]*:)\s*(<[^<>"{}|^`\\\s]*>)\s*\.?/i))) {
+      // N3-style `@prefix foo: <x> .` is normalized to SPARQL `PREFIX foo: <x>`
+      directives.push('PREFIX ' + m[1] + ' ' + m[2])
+      i += m[0].length
+    } else if ((m = rest.match(/^@?base\s+(<[^<>"{}|^`\\\s]*>)\s*\.?/i))) {
+      directives.push('BASE ' + m[1])
+      i += m[0].length
+    } else if ((m = rest.match(/^(INSERT|DELETE|WHERE)\b/i))) {
+      var kind = m[1].toLowerCase()
+      var j = skipSpace(str, i + m[1].length)
+      if (kind !== 'where' && /^DATA\b/i.test(str.slice(j, j + 5))) {
+        j = skipSpace(str, j + 4) // `INSERT DATA`/`DELETE DATA`; also tolerated alongside WHERE, like the old parser
+      }
+      if (str[j] !== '{') {
+        throw badPatchSyntax(base, str, j, 'expected {...} after ' + m[1].toUpperCase())
+      }
+      var end = skipGroup(str, j, base)
+      clauses.push({ kind: kind, body: str.slice(j + 1, end - 1) })
+      i = end
+    } else {
+      throw badPatchSyntax(base, str, i,
+        "Unknown syntax at start of statement: '" + str.slice(i, i + 20) + "'")
+    }
+  }
+}
+
+// Reassemble the scanned clauses as a spec-conformant SPARQL 1.1 Update
+// string: `DELETE {} INSERT {} WHERE {}` when a WHERE clause is present
+// (whatever the input clause order), `DELETE DATA`/`INSERT DATA` otherwise.
+function normalizePatch (directives, clauses, base) {
+  var parts = directives.slice()
+  var byKind = { insert: [], delete: [], where: [] }
+  clauses.forEach(function (clause) { byKind[clause.kind].push(clause) })
+  if (byKind.where.length) {
+    ;['insert', 'delete', 'where'].forEach(function (kind) {
+      if (byKind[kind].length > 1) {
+        throw new Error('Patch syntax failure in <' + base + '>: multiple ' +
+          kind.toUpperCase() + ' clauses in one DELETE/INSERT/WHERE patch are not supported')
+      }
+    })
+    if (byKind.delete.length) {
+      parts.push('DELETE { ' + byKind.delete[0].body + ' }')
+    } else if (!byKind.insert.length) {
+      parts.push('DELETE { }') // a patch of just WHERE needs some template clause
+    }
+    if (byKind.insert.length) parts.push('INSERT { ' + byKind.insert[0].body + ' }')
+    parts.push('WHERE { ' + byKind.where[0].body + ' }')
+    return parts.join('\n')
+  }
+  // No WHERE: each clause is an independent DATA operation, in input order
+  var ops = clauses.map(function (clause) {
+    return (clause.kind === 'delete' ? 'DELETE DATA' : 'INSERT DATA') +
+      ' { ' + clause.body + ' }'
+  })
+  parts.push(ops.join(' ;\n'))
+  return parts.join('\n')
+}
 
 export default function sparqlUpdateParser (str, kb, base) {
-  var i, j, k
-  var keywords = [ 'INSERT', 'DELETE', 'WHERE' ]
   var SQNS = Namespace('http://www.w3.org/ns/pim/patch#')
-  var p = N3Parser(kb, kb, base, base, null, null, '', null)
+  var doc = docpart(base) // the document part: a fragment on the base cannot take part in IRI resolution
+  var query = kb.sym(doc + '#query') // Invent a URI for the query
+  var source = kb.sym(doc)
   var clauses = {}
-
-  var badSyntax = function (uri, lines, str, i, why) {
-    return ('Line ' + (lines + 1) + ' of <' + uri + '>: Bad syntax:\n   ' +
-    why + '\n   at: "' + str.slice(i, (i + 30)) + '"')
-  }
-
-  // var check = function (next, last, message) {
-  //   if (next < 0) {
-  //     throw badSyntax(p._thisDoc, p.lines, str, j, last, message)
-  //   }
-  //   return next
-  // }
-  i = 0
-  var query = kb.sym(base + '#query') // Invent a URI for the query
   clauses['query'] = query // A way of accessing it in its N3 model.
 
-  while (true) {
-    // console.log("A Now at i = " + i)
-    j = p.skipSpace(str, i)
-    if (j < 0) {
-      return clauses
-    }
-    // console.log("B After space at j= " + j)
-    if (str[j] === ';') {
-      i = p.skipSpace(str, j + 1)
-      if (i < 0) {
-        return clauses // Allow end in a
-      }
-      j = i
-    }
-    var found = false
-    for (k = 0; k < keywords.length; k++) {
-      var key = keywords[k]
-      if (str.slice(j, j + key.length) === key) {
-        i = p.skipSpace(str, j + key.length)
-        if (i < 0) {
-          throw badSyntax(p._thisDoc, p.lines, str, j + key.length, 'found EOF, needed {...} after ' + key)
-        }
-        if (((key === 'INSERT') || (key === 'DELETE')) && str.slice(i, i + 4) === 'DATA') { // Some wanted 'DATA'. Whatever
-          j = p.skipSpace(str, i + 4)
-          if (j < 0) {
-            throw badSyntax(p._thisDoc, p.lines, str, i + 4, 'needed {...} after INSERT DATA ' + key)
-          }
-          i = j
-        }
-        var res2 = []
-        j = p.node(str, i, res2) // Parse all the complexity of the clause
+  var scanned = scanTopLevel(str, base)
+  if (scanned.clauses.length === 0) {
+    return clauses // An empty patch (or just directives): nothing to do
+  }
+  var inputHas = {}
+  scanned.clauses.forEach(function (clause) { inputHas[clause.kind] = true })
 
-        if (j < 0) {
-          throw badSyntax(p._thisDoc, p.lines, str, i,
-            'bad syntax or EOF in {...} after ' + key)
+  var normalized = normalizePatch(scanned.directives, scanned.clauses, base)
+
+  var parsed
+  try {
+    // The store's data factory makes sparqljs produce rdflib terms directly
+    parsed = new SparqlParser({ factory: kb.rdfFactory, baseIRI: doc }).parse(normalized)
+  } catch (e) {
+    throw new Error('Patch syntax failure in <' + base + '>: ' + (e && e.message ? e.message : e))
+  }
+
+  var addClause = function (kind, patterns) {
+    var formula = kb.formula()
+    patterns.forEach(function (pattern) {
+      if (pattern.type !== 'bgp') {
+        throw new Error('Patch parser, in <' + base + '>: only basic graph patterns are supported ' +
+          'in patch clauses, found a ' + pattern.type + ' pattern')
+      }
+      pattern.triples.forEach(function (t) {
+        if (!t.predicate.termType) { // a property path object, not a term
+          throw new Error('Patch parser, in <' + base + '>: property paths are not supported in patches')
         }
-        clauses[key.toLowerCase()] = res2[0]
-        kb.add(query, SQNS(key.toLowerCase()), res2[0]) // , kb.sym(base)
-        // key is the keyword and res2 has the contents
-        found = true
-        i = j
-      }
+        formula.add(t.subject, t.predicate, t.object, source)
+      })
+    })
+    clauses[kind] = formula.close()
+    kb.add(query, SQNS(kind), formula)
+  }
+
+  parsed.updates.forEach(function (op) {
+    if (op.updateType === 'insert') {
+      addClause('insert', op.insert)
+    } else if (op.updateType === 'delete') {
+      addClause('delete', op.delete)
+    } else if (op.updateType === 'insertdelete') {
+      if (inputHas.delete) addClause('delete', op.delete)
+      if (inputHas.insert) addClause('insert', op.insert)
+      addClause('where', op.where)
+    } else {
+      throw new Error('Patch parser, in <' + base + '>: unsupported update operation ' +
+        (op.updateType || op.type))
     }
-    if (!found && str.slice(j, j + 7) === '@prefix') {
-      i = p.directive(str, j)
-      if (i < 0) {
-        throw badSyntax(p._thisDoc, p.lines, str, i,
-          'bad syntax or EOF after @prefix ')
-      }
-      // console.log("P before dot i= " + i)
-      i = p.checkDot(str, i)
-      // console.log("Q after dot i= " + i)
-      found = true
-    }
-    if (!found) {
-      // console.log("Bad syntax " + j)
-      throw badSyntax(p._thisDoc, p.lines, str, j,
-        "Unknown syntax at start of statememt: '" + str.slice(j).slice(0, 20) + "'")
-    }
-  } // while
-// return clauses
+  })
+  return clauses
 }

--- a/src/sparql-to-query.js
+++ b/src/sparql-to-query.js
@@ -5,8 +5,8 @@
 // existing Query object shape (`query.pat`, `query.vars`) that the matcher
 // and downstream UI code (e.g. solid-ui table panes) consume.
 //
-// SUPPORTED SUBSET — the rdflib matcher is a basic-graph-pattern engine, so
-// only the following SPARQL forms are accepted:
+// The rdflib matcher is a basic-graph-pattern engine, so only the
+// following SPARQL forms are accepted:
 //   - SELECT queries: `SELECT ?a ?b WHERE { ... }` and `SELECT * WHERE { ... }`
 //   - CONSTRUCT queries are executed as binding queries over their WHERE
 //     clause (the Query API returns variable bindings, not graphs)
@@ -18,8 +18,8 @@
 //       FILTER (?x < <constant>)   FILTER regex(?x, "pattern"[, "flags"])
 // Everything else (ASK/DESCRIBE, property paths, UNION, GRAPH, FROM, BIND,
 // VALUES, subqueries, aggregates, solution modifiers such as ORDER/LIMIT/
-// DISTINCT, other FILTER operators) throws an informative error rather than
-// silently misparsing, which is what the previous hand-rolled parser did.
+// DISTINCT, other FILTER operators) throws an informative error rather
+// than silently misparsing.
 
 import { Parser as SparqlParser } from 'sparqljs'
 import { Query } from './query'

--- a/src/sparql-to-query.js
+++ b/src/sparql-to-query.js
@@ -1,497 +1,240 @@
 // Converting between SPARQL queries and the $rdf query API
-/*
+//
+// A SPARQL front-end for the rdflib query engine (src/query.js), built on
+// the sparqljs SPARQL 1.1 parser. It maps the parsed algebra onto the
+// existing Query object shape (`query.pat`, `query.vars`) that the matcher
+// and downstream UI code (e.g. solid-ui table panes) consume.
+//
+// SUPPORTED SUBSET — the rdflib matcher is a basic-graph-pattern engine, so
+// only the following SPARQL forms are accepted:
+//   - SELECT queries: `SELECT ?a ?b WHERE { ... }` and `SELECT * WHERE { ... }`
+//   - CONSTRUCT queries are executed as binding queries over their WHERE
+//     clause (the Query API returns variable bindings, not graphs)
+//   - WHERE clauses made of basic graph patterns (triple patterns with
+//     `;`/`,` abbreviations, `a`, prefixed names, IRIs, literals, blank nodes)
+//   - OPTIONAL { ... } groups (may nest, and may contain FILTERs)
+//   - FILTER constraints of the forms:
+//       FILTER (?x = <constant>)   FILTER (?x > <constant>)
+//       FILTER (?x < <constant>)   FILTER regex(?x, "pattern"[, "flags"])
+// Everything else (ASK/DESCRIBE, property paths, UNION, GRAPH, FROM, BIND,
+// VALUES, subqueries, aggregates, solution modifiers such as ORDER/LIMIT/
+// DISTINCT, other FILTER operators) throws an informative error rather than
+// silently misparsing, which is what the previous hand-rolled parser did.
 
-function SQuery () {
-  this.terms = []
+import { Parser as SparqlParser } from 'sparqljs'
+import { Query } from './query'
+
+const SUPPORTED = 'The supported subset is: SELECT (or CONSTRUCT, run as a SELECT ' +
+  'over its WHERE clause) with basic graph patterns, OPTIONAL groups, and ' +
+  'FILTER (?x = / < / > constant) or FILTER regex(?x, "pattern").'
+
+// The constraint objects the matcher (query.js) applies to candidate
+// bindings: each has test(term), and describe(varStr) for query-to-sparql.
+function ConstraintEqualTo (value) {
+  this.describe = function (varstr) {
+    return varstr + ' = ' + value.toNT()
+  }
+  this.test = function (term) {
+    return value.equals(term)
+  }
   return this
 }
 
-STerm.prototype.toString = STerm.val
-SQuery.prototype.add = function (str) {this.terms.push()}*/
+function ConstraintGreaterThan (value) {
+  this.describe = function (varstr) {
+    return varstr + ' > ' + value.toNT()
+  }
+  this.test = function (term) {
+    if (term.value.match(/^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/)) {
+      return (parseFloat(term.value) > parseFloat(value.value))
+    } else {
+      return (term.toNT() > value.toNT())
+    }
+  }
+  return this
+}
 
-import log from './log'
-import { Query } from './query'
+function ConstraintLessThan (value) {
+  this.describe = function (varstr) {
+    return varstr + ' < ' + value.toNT()
+  }
+  this.test = function (term) {
+    if (term.value.match(/^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$/)) {
+      return (parseFloat(term.value) < parseFloat(value.value))
+    } else {
+      return (term.toNT() < value.toNT())
+    }
+  }
+  return this
+}
+
+// value is the pattern string, flags the optional regex flags
+function ConstraintRegexp (value, flags) {
+  this.describe = function (varstr) {
+    return "REGEXP( '" + value + "' , " + varstr + ' )'
+  }
+  this.test = function (term) {
+    var rg = new RegExp(value, flags)
+    if (term.value) {
+      return rg.test(term.value)
+    } else {
+      return false
+    }
+  }
+  return this
+}
+
+function unsupported (why) {
+  return new Error('SPARQLToQuery: ' + why + '\n' + SUPPORTED)
+}
 
 /**
  * @SPARQL: SPARQL text that is converted to a query object which is returned.
  * @testMode: testing flag. Prevents loading of sources.
  */
 export default function SPARQLToQuery (SPARQL, testMode, kb) {
-  // AJAR_ClearTable()
-  var variableHash = []
-  function makeVar (name) {
-    if (variableHash[name]) {
-      return variableHash[name]
-    }
-    var newVar = kb.variable(name)
-    variableHash[name] = newVar
-    return newVar
-  }
-
-  // term type functions
-  function isRealText (term) {
-    return (typeof term === 'string' && term.match(/[^ \n\t]/))
-  }
-  function isVar (term) {
-    return (typeof term === 'string' && term.match(/^[\?\$]/))
-  }
-  function fixSymbolBrackets (term) {
-    if (typeof term === 'string') {
-      return term.replace(/^&lt;/, '<').replace(/&gt;$/, '>')
-    } else {
-      return term
-    }
-  }
-  function isSymbol (term) {
-    return (typeof term === 'string' && term.match(/^<[^>]*>$/))
-  }
-  function isBnode (term) {
-    return (typeof term === 'string' && (term.match(/^_:/) || term.match(/^$/)))
-  }
-  function isPrefix (term) {
-    return (typeof term === 'string' && term.match(/:$/))
-  }
-  function isPrefixedSymbol (term) {
-    return (typeof term === 'string' && term.match(/^:|^[^_][^:]*:/))
-  }
-  function getPrefix (term) {
-    var a = term.split(':')
-    return a[0]
-  }
-  function getSuffix (term) {
-    var a = term.split(':')
-    return a[1]
-  }
-  function removeBrackets (term) {
-    if (isSymbol(term)) {
-      return term.slice(1, term.length - 1)
-    } else {
-      return term
-    }
-  }
-  // takes a string and returns an array of strings and Literals in the place of literals
-  function parseLiterals (str) {
-    // var sin = (str.indexOf(/[ \n]\'/)==-1)?null:str.indexOf(/[ \n]\'/), doub = (str.indexOf(/[ \n]\"/)==-1)?null:str.indexOf(/[ \n]\"/)
-    var sin = (str.indexOf("'") === -1)
-      ? null
-      : str.indexOf("'")
-    var doub = (str.indexOf('"') === -1)
-      ? null
-      : str.indexOf('"')
-    // alert("S: "+sin+" D: "+doub)
-    if (!sin && !doub) {
-      var a = new Array(1)
-      a[0] = str
-      return a
-    }
-    var res = new Array(2)
-    var br
-    var ind
-    if (!sin || (doub && doub < sin)) {
-      br = '"'
-      ind = doub
-    } else if (!doub || (sin && sin < doub)) {
-      br = "'"
-      ind = sin
-    } else {
-      log.error('SQARQL QUERY OOPS!')
-      return res
-    }
-    res[0] = str.slice(0, ind)
-    var end = str.slice(ind + 1).indexOf(br)
-    if (end === -1) {
-      log.error('SPARQL parsing error: no matching parentheses in literal ' + str)
-      return str
-    }
-    // alert(str.slice(end + ind + 2).match(/^\^\^/))
-    var end2
-    if (str.slice(end + ind + 2).match(/^\^\^/)) {
-      end2 = str.slice(end + ind + 2).indexOf(' ')
-      // alert(end2)
-      res[1] = kb.literal(
-        str.slice(ind + 1, ind + 1 + end),
-        kb.sym(removeBrackets(
-          str.slice(ind + 4 + end, ind + 2 + end + end2))
-        )
-      )
-      // alert(res[1].datatype.uri)
-      res = res.concat(parseLiterals(str.slice(end + ind + 3 + end2)))
-    } else if (str.slice(end + ind + 2).match(/^@/)) {
-      end2 = str.slice(end + ind + 2).indexOf(' ')
-      // alert(end2)
-      res[1] = kb.literal(
-        str.slice(ind + 1, ind + 1 + end),
-        str.slice(ind + 3 + end, ind + 2 + end + end2), null
-      )
-      // alert(res[1].datatype.uri)
-      res = res.concat(
-        parseLiterals(str.slice(end + ind + 2 + end2))
-      )
-    } else {
-      res[1] = kb.literal(str.slice(ind + 1, ind + 1 + end))
-      log.info('Literal found: ' + res[1])
-      res = res.concat(parseLiterals(str.slice(end + ind + 2))) // finds any other literals
-    }
-    return res
-  }
-
-  function spaceDelimit (str) {
-    str = str.replace(/\(/g, ' ( ')
-      .replace(/\)/g, ' ) ')
-      .replace(/</g, ' <')
-      .replace(/>/g, '> ')
-      .replace(/{/g, ' { ')
-      .replace(/}/g, ' } ')
-      .replace(/[\t\n\r]/g, ' ')
-      .replace(/; /g, ' ; ')
-      .replace(/\. /g, ' . ')
-      .replace(/, /g, ' , ')
-    log.info('New str into spaceDelimit: \n' + str)
-    var res = []
-    var br = str.split(' ')
-    for (var x in br) {
-      if (isRealText(br[x])) {
-        res = res.concat(br[x])
-      }
-    }
-    return res
-  }
-
-  function replaceKeywords (input) {
-    var strarr = input
-    for (var x = 0; x < strarr.length; x++) {
-      if (strarr[x] === 'a') {
-        strarr[x] = '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>'
-      }
-      if (strarr[x] === 'is' && strarr[x + 2] === 'of') {
-        strarr.splice(x, 1)
-        strarr.splice(x + 1, 1)
-        var s = strarr[x - 1]
-        strarr[x - 1] = strarr[x + 1]
-        strarr[x + 1] = s
-      }
-    }
-    return strarr
-  }
-
-  function toTerms (input) {
-    var res = []
-    for (var x = 0; x < input.length; x++) {
-      if (typeof input[x] !== 'string') {
-        res[x] = input[x]
-        continue
-      }
-      input[x] = fixSymbolBrackets(input[x])
-      if (isVar(input[x])) {
-        res[x] = makeVar(input[x].slice(1))
-      } else if (isBnode(input[x])) {
-        log.info(input[x] + ' was identified as a bnode.')
-        res[x] = kb.bnode()
-      } else if (isSymbol(input[x])) {
-        log.info(input[x] + ' was identified as a symbol.')
-        res[x] = kb.sym(removeBrackets(input[x]))
-      } else if (isPrefixedSymbol(input[x])) {
-        log.info(input[x] + ' was identified as a prefixed symbol')
-        if (prefixes[getPrefix(input[x])]) {
-          res[x] = kb.sym(input[x] = prefixes[getPrefix(input[x])] +
-            getSuffix(input[x]))
-        } else {
-          log.error('SPARQL error: ' + input[x] + ' with prefix ' +
-            getPrefix(input[x]) + ' does not have a correct prefix entry.')
-          res[x] = input[x]
-        }
-      } else {
-        res[x] = input[x]
-      }
-    }
-    return res
-  }
-
-  function tokenize (str) {
-    var token1 = parseLiterals(str)
-    var token2 = []
-    for (var x in token1) {
-      if (typeof token1[x] === 'string') {
-        token2 = token2.concat(spaceDelimit(token1[x]))
-      } else {
-        token2 = token2.concat(token1[x])
-      }
-    }
-    token2 = replaceKeywords(token2)
-    log.info('SPARQL Tokens: ' + token2)
-    return token2
-  }
-
-  // CASE-INSENSITIVE
-  function arrayIndexOf (str, arr) {
-    for (var i = 0; i < arr.length; i++) {
-      if (typeof arr[i] !== 'string') {
-        continue
-      }
-      if (arr[i].toLowerCase() === str.toLowerCase()) {
-        return i
-      }
-    }
-    // log.warn("No instance of "+str+" in array "+arr)
-    return null
-  }
-
-  // CASE-INSENSITIVE
-  function arrayIndicesOf (str, arr) {
-    var ind = []
-    for (var i = 0; i < arr.length; i++) {
-      if (typeof arr[i] !== 'string') {
-        continue
-      }
-      if (arr[i].toLowerCase() === str.toLowerCase()) {
-        ind.push(i)
-      }
-    }
-    return ind
-  }
-
-  function setVars (input, query) {
-    log.info('SPARQL vars: ' + input)
-    for (var x in input) {
-      if (isVar(input[x])) {
-        log.info('Added ' + input[x] + ' to query variables from SPARQL')
-        var v = makeVar(input[x].slice(1))
-        query.vars.push(v)
-        v.label = input[x].slice(1)
-      } else {
-        log.warn('Incorrect SPARQL variable in SELECT: ' + input[x])
-      }
-    }
-  }
-
-  function getPrefixDeclarations (input) {
-    var prefInd = arrayIndicesOf('PREFIX', input)
-    var res = []
-    for (var i in prefInd) {
-      var a = input[prefInd[i] + 1]
-      var b = input[prefInd[i] + 2]
-      if (!isPrefix(a)) {
-        log.error('Invalid SPARQL prefix: ' + a)
-      } else if (!isSymbol(b)) {
-        log.error('Invalid SPARQL symbol: ' + b)
-      } else {
-        log.info('Prefix found: ' + a + ' -> ' + b)
-        var pref = getPrefix(a)
-        var symbol = removeBrackets(b)
-        res[pref] = symbol
-      }
-    }
-    return res
-  }
-
-  function getMatchingBracket (arr, open, close) {
-    log.info('Looking for a close bracket of type ' + close + ' in ' + arr)
-    var index = 0
-    for (var i = 0; i < arr.length; i++) {
-      if (arr[i] === open) {
-        index++
-      }
-      if (arr[i] === close) {
-        index--
-      }
-      if (index < 0) {
-        return i
-      }
-    }
-    log.error('Statement had no close parenthesis in SPARQL query')
-    return 0
-  }
-
-  function constraintGreaterThan (value) {
-    this.describe = function (varstr) {
-      return varstr + ' > ' + value.toNT()
-    }
-    this.test = function (term) {
-      if (term.value.match(/[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/)) {
-        return (parseFloat(term.value) > parseFloat(value))
-      } else {
-        return (term.toNT() > value.toNT())
-      }
-    }
-    return this
-  }
-
-  function constraintLessThan (value) { // this is not the recommended usage. Should only work on literal, numeric, dateTime
-    this.describe = function (varstr) {
-      return varstr + ' < ' + value.toNT()
-    }
-    this.test = function (term) {
-      // this.describe = function (varstr) { return varstr + " < "+value }
-      if (term.value.match(/[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?/)) {
-        return (parseFloat(term.value) < parseFloat(value))
-      } else {
-        return (term.toNT() < value.toNT())
-      }
-    }
-    return this
-  }
-  // This should only work on literals but doesn't.
-  function ConstraintEqualTo (value) {
-    this.describe = function (varstr) {
-      return varstr + ' = ' + value.toNT()
-    }
-    this.test = function (term) {
-      return value.equals(term)
-    }
-    return this
-  }
-
-  // value must be a literal
-  function ConstraintRegexp (value) {
-    this.describe = function (varstr) {
-      return "REGEXP( '" + value + "' , " + varstr + ' )'
-    }
-    this.test = function (term) {
-      var str = value
-      // str = str.replace(/^//,"").replace(//$/,"")
-      var rg = new RegExp(str)
-      if (term.value) {
-        return rg.test(term.value)
-      } else {
-        return false
-      }
-    }
-  }
-
-  function setConstraint (input, pat) {
-    if (input.length === 3 && input[0].termType === 'Variable' &&
-      (input[2].termType === 'NamedNode' || input[2].termType === 'Literal')) {
-      if (input[1] === '=') {
-        log.debug('Constraint added: ' + input)
-        pat.constraints[input[0]] = new ConstraintEqualTo(input[2])
-      } else if (input[1] === '>') {
-        log.debug('Constraint added: ' + input)
-        pat.constraints[input[0]] = new ConstraintEqualTo(input[2])
-      } else if (input[1] === '<') {
-        log.debug('Constraint added: ' + input)
-        pat.constraints[input[0]] = new ConstraintEqualTo(input[2])
-      } else {
-        log.warn("I don't know how to handle the constraint: " + input)
-      }
-    } else if (input.length === 6 && typeof input[0] === 'string' &&
-      input[0].toLowerCase() === 'regexp' &&
-      input[1] === '(' && input[5] === ')' && input[3] === ',' &&
-      input[4].termType === 'Variable' && input[2].termType === 'Literal') {
-      log.debug('Constraint added: ' + input)
-      pat.constraints[input[4]] = new ConstraintRegexp(input[2].value)
-    }
-  // log.warn("I don't know how to handle the constraint: "+input)
-  // alert("length: "+input.length+" input 0 type: "+input[0].termType+" input 1: "+input[1]+" input[2] type: "+input[2].termType)
-  }
-
-  function setOptional (terms, pat) {
-    log.debug('Optional query: ' + terms + ' not yet implemented.')
-    var opt = kb.formula()
-    setWhere(terms, opt)
-    pat.optional.push(opt)
-  }
-
-  function setWhere (input, pat) {
-    var terms = toTerms(input)
-    var end
-    log.debug('WHERE: ' + terms)
-    var opt
-    // var opt = arrayIndicesOf("OPTIONAL",terms)
-    while (arrayIndexOf('OPTIONAL', terms)) {
-      opt = arrayIndexOf('OPTIONAL', terms)
-      log.debug('OPT: ' + opt + ' ' + terms[opt] + ' in ' + terms)
-      if (terms[opt + 1] !== '{') {
-        log.warn('Bad optional opening bracket in word ' + opt)
-      }
-      end = getMatchingBracket(terms.slice(opt + 2), '{', '}')
-      if (end === -1) {
-        log.error('No matching bracket in word ' + opt)
-      } else {
-        setOptional(terms.slice(opt + 2, opt + 2 + end), pat)
-        // alert(pat.statements[0].toNT())
-        opt = arrayIndexOf('OPTIONAL', terms)
-        end = getMatchingBracket(terms.slice(opt + 2), '{', '}')
-        terms.splice(opt, end + 3)
-      }
-    }
-    log.debug('WHERE after optionals: ' + terms)
-    while (arrayIndexOf('FILTER', terms)) {
-      var filt = arrayIndexOf('FILTER', terms)
-      if (terms[filt + 1] !== '(') {
-        log.warn('Bad filter opening bracket in word ' + filt)
-      }
-      end = getMatchingBracket(terms.slice(filt + 2), '(', ')')
-      if (end === -1) {
-        log.error('No matching bracket in word ' + filt)
-      } else {
-        setConstraint(terms.slice(filt + 2, filt + 2 + end), pat)
-        filt = arrayIndexOf('FILTER', terms)
-        end = getMatchingBracket(terms.slice(filt + 2), '(', ')')
-        terms.splice(filt, end + 3)
-      }
-    }
-    log.debug('WHERE after filters and optionals: ' + terms)
-    extractStatements(terms, pat)
-  }
-
-  function extractStatements (terms, formula) {
-    var arrayZero = new Array(1)
-    arrayZero[0] = -1 // this is just to add the beginning of the where to the periods index.
-    var per = arrayZero.concat(arrayIndicesOf('.', terms))
-    var stat = []
-    for (var x = 0; x < per.length - 1; x++) {
-      stat[x] = terms.slice(per[x] + 1, per[x + 1])
-    }
-    // Now it's in an array of statements
-    for (x in stat) { // THIS MUST BE CHANGED FOR COMMA, SEMICOLON
-      log.info('s+p+o ' + x + ' = ' + stat[x])
-      var subj = stat[x][0]
-      stat[x].splice(0, 1)
-      var sem = arrayZero.concat(arrayIndicesOf(';', stat[x]))
-      sem.push(stat[x].length)
-      var stat2 = []
-      for (var y = 0; y < sem.length - 1; y++) {
-        stat2[y] = stat[x].slice(sem[y] + 1, sem[y + 1])
-      }
-      for (x in stat2) {
-        log.info('p+o ' + x + ' = ' + stat[x])
-        var pred = stat2[x][0]
-        stat2[x].splice(0, 1)
-        var com = arrayZero.concat(arrayIndicesOf(',', stat2[x]))
-        com.push(stat2[x].length)
-        var stat3 = []
-        for (y = 0; y < com.length - 1; y++) {
-          stat3[y] = stat2[x].slice(com[y] + 1, com[y + 1])
-        }
-        for (x in stat3) {
-          var obj = stat3[x][0]
-          log.info('Subj=' + subj + ' Pred=' + pred + ' Obj=' + obj)
-          formula.add(subj, pred, obj)
-        }
-      }
-    }
-  }
-
-  // ******************************* Body of SPARQLToQuery ***************************//
-  log.info('SPARQL input: \n' + SPARQL)
   var q = new Query()
-  var sp = tokenize(SPARQL) // first tokenize everything
-  var prefixes = getPrefixDeclarations(sp)
-  if (!prefixes.rdf) {
-    prefixes.rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
-  }
-  if (!prefixes.rdfs) {
-    prefixes.rdfs = 'http://www.w3.org/2000/01/rdf-schema#'
-  }
-  var selectLoc = arrayIndexOf('SELECT', sp)
-  var whereLoc = arrayIndexOf('WHERE', sp)
-  if (selectLoc < 0 || whereLoc < 0 || selectLoc > whereLoc) {
-    log.error('Invalid or nonexistent SELECT and WHERE tags in SPARQL query')
-    return false
-  }
-  setVars(sp.slice(selectLoc + 1, whereLoc), q)
 
-  setWhere(sp.slice(whereLoc + 2, sp.length - 1), q.pat)
+  // One rdflib Variable instance per name, so identical names share a term
+  var variableHash = {}
+  function makeVar (name) {
+    if (!variableHash[name]) {
+      variableHash[name] = kb.variable(name)
+    }
+    return variableHash[name]
+  }
+
+  // Order of first occurrence of variables in the patterns, for SELECT *
+  var varsSeen = []
+  function noteTerm (term) {
+    if (term.termType === 'Variable' && varsSeen.indexOf(term) < 0) {
+      varsSeen.push(term)
+    }
+  }
+
+  // Have sparqljs build rdflib terms via the store's data factory, with
+  // variables funnelled through makeVar so instances are shared
+  var factory = {
+    namedNode: function (value) { return kb.rdfFactory.namedNode(value) },
+    blankNode: function (value) { return kb.rdfFactory.blankNode(value) },
+    literal: function (value, languageOrDatatype) { return kb.rdfFactory.literal(value, languageOrDatatype) },
+    variable: function (name) { return makeVar(name) },
+    defaultGraph: function () { return kb.rdfFactory.defaultGraph() },
+    quad: function (s, p, o, g) { return kb.rdfFactory.quad(s, p, o, g) }
+  }
+
+  var parsed
+  try {
+    // rdf: and rdfs: are predeclared, as they were in the old parser
+    parsed = new SparqlParser({
+      factory: factory,
+      prefixes: {
+        rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+      }
+    }).parse(SPARQL)
+  } catch (e) {
+    throw new Error('SPARQLToQuery: could not parse the query: ' +
+      (e && e.message ? e.message : e) + '\n' + SUPPORTED)
+  }
+
+  if (parsed.type !== 'query') {
+    throw unsupported('only SPARQL queries are supported, not ' + parsed.type + ' operations')
+  }
+  if (parsed.queryType !== 'SELECT' && parsed.queryType !== 'CONSTRUCT') {
+    throw unsupported(parsed.queryType + ' queries are not supported')
+  }
+  if (parsed.from) {
+    throw unsupported('FROM clauses are not supported: the query runs over the given knowledge base')
+  }
+  if (parsed.group || parsed.having || parsed.order ||
+      parsed.limit !== undefined || parsed.offset !== undefined || parsed.distinct) {
+    throw unsupported('aggregates and solution modifiers (GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, DISTINCT) are not supported')
+  }
+
+  // SELECT variables (a Wildcard for `SELECT *`); CONSTRUCT has none
+  var wildcard = parsed.queryType === 'CONSTRUCT'
+  var selectVars = []
+  ;(parsed.variables || []).forEach(function (v) {
+    if (v.termType === 'Wildcard' || v.value === '*') {
+      wildcard = true
+    } else if (v.termType === 'Variable') {
+      selectVars.push(makeVar(v.value))
+    } else {
+      throw unsupported('SELECT expressions (AS) are not supported')
+    }
+  })
+
+  function checkPatternTerm (term) {
+    if (!term.termType) { // e.g. a property path object
+      throw unsupported('property paths are not supported')
+    }
+    noteTerm(term)
+    return term
+  }
+
+  function addConstraint (formula, expression) {
+    if (expression.type !== 'operation') {
+      throw unsupported('only simple FILTER constraints are supported')
+    }
+    var op = expression.operator
+    var args = expression.args
+    if (op === 'regex') {
+      if (args.length < 2 || args[0].termType !== 'Variable' || args[1].termType !== 'Literal') {
+        throw unsupported('FILTER regex is only supported as regex(?variable, "pattern"[, "flags"])')
+      }
+      formula.constraints[args[0]] = new ConstraintRegexp(
+        args[1].value, args[2] && args[2].value)
+      return
+    }
+    if (op === '=' || op === '>' || op === '<') {
+      if (args.length !== 2 || args[0].termType !== 'Variable' ||
+          (args[1].termType !== 'Literal' && args[1].termType !== 'NamedNode')) {
+        throw unsupported("FILTER " + op + ' is only supported as (?variable ' + op + ' constant)')
+      }
+      var Constraint = op === '=' ? ConstraintEqualTo
+        : op === '>' ? ConstraintGreaterThan : ConstraintLessThan
+      formula.constraints[args[0]] = new Constraint(args[1])
+      return
+    }
+    throw unsupported("the FILTER operator '" + op + "' is not supported")
+  }
+
+  function addGroup (patterns, formula) {
+    patterns.forEach(function (pattern) {
+      switch (pattern.type) {
+        case 'bgp':
+          pattern.triples.forEach(function (t) {
+            formula.add(checkPatternTerm(t.subject),
+              checkPatternTerm(t.predicate),
+              checkPatternTerm(t.object))
+          })
+          break
+        case 'optional': {
+          var opt = kb.formula()
+          addGroup(pattern.patterns, opt)
+          formula.optional.push(opt)
+          break
+        }
+        case 'filter':
+          addConstraint(formula, pattern.expression)
+          break
+        case 'group':
+          addGroup(pattern.patterns, formula)
+          break
+        default:
+          throw unsupported("the '" + pattern.type.toUpperCase() + "' construct is not supported")
+      }
+    })
+  }
+
+  addGroup(parsed.where || [], q.pat)
+
+  var vars = wildcard ? varsSeen : selectVars
+  vars.forEach(function (v) {
+    q.vars.push(v)
+    v.label = v.value
+  })
 
   if (testMode) {
     return q
@@ -510,8 +253,5 @@ export default function SPARQLToQuery (SPARQL, testMode, kb) {
       }
     }
   }
-  // alert(q.pat)
   return q
-// checkVars()
-// *******************************************************************//
 }

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -4,6 +4,7 @@
 ** 2010-08-08 TimBL folded in Kenny's WEBDAV
 ** 2010-12-07 TimBL added local file write code
 */
+import { Generator as SparqlGenerator } from 'sparqljs'
 import IndexedFormula from './store'
 import { docpart, join as uriJoin } from './uri'
 import Fetcher, { Options } from './fetcher'
@@ -13,6 +14,7 @@ import { isBlankNode, isStore } from './utils/terms'
 import * as Util from './utils-js'
 import Statement from './statement'
 import RDFlibNamedNode from './named-node'
+import Variable from './variable'
 import { termValue } from './utils/termValue'
 import { BlankNode, NamedNode, Quad, Quad_Graph, Quad_Object, Quad_Predicate, Quad_Subject, Term, } from './tf-types'
 
@@ -754,9 +756,19 @@ export default class UpdateManager {
 
   /**
    * @private
-   * 
-   * This helper function constructs SPARQL Update query from resolved arguments.
-   * 
+   *
+   * This helper function constructs a SPARQL 1.1 Update query from resolved
+   * arguments, by building a sparqljs AST and serializing it with the
+   * sparqljs Generator (rather than concatenating strings).
+   *
+   * Blank nodes are illegal in DELETE templates and DELETE DATA, and a blank
+   * node in a WHERE pattern denotes a *fresh* variable rather than the node
+   * the caller meant. So every blank node that already exists in the store is
+   * consistently rewritten to one collision-free variable across the DELETE,
+   * INSERT and WHERE clauses (the WHERE clause built from `bnodes_context`
+   * grounds it), while genuinely fresh blank nodes are kept as blank nodes in
+   * insertions only.
+   *
    * @param ds: deletions array.
    * @param is: insertions array.
    * @param bnodes_context: Additional context to uniquely identify any blank nodes.
@@ -766,42 +778,111 @@ export default class UpdateManager {
     is: ReadonlyArray<Statement>,
     bnodes_context,
   ): string {
-    var whereClause = this.contextWhere(bnodes_context)
-    var query = ''
-    if (whereClause.length) { // Is there a WHERE clause?
-      if (ds.length) {
-        query += 'DELETE { '
-        for (let i = 0; i < ds.length; i++) {
-          query += this.anonymizeNT(ds[i]) + '\n'
+    const context: Quad[] = bnodes_context || []
+    const rdfNS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+
+    // One collision-free variable per blank node, consistent across clauses
+    const usedVarNames = new Set<string>()
+    const varByBnode = new Map<string, Variable>()
+    const variableForBnode = (bnode: Term): Variable => {
+      let variable = varByBnode.get(bnode.value)
+      if (!variable) {
+        const base = bnode.value.replace(/[^A-Za-z0-9_]/g, '_') || 'bnode'
+        let name = base
+        for (let n = 2; usedVarNames.has(name); n++) {
+          name = base + '_' + n
         }
-        query += ' }\n'
+        usedVarNames.add(name)
+        variable = new Variable(name)
+        varByBnode.set(bnode.value, variable)
       }
-      if (is.length) {
-        query += 'INSERT { '
-        for (let i = 0; i < is.length; i++) {
-          query += this.anonymizeNT(is[i]) + '\n'
+      return variable
+    }
+
+    // Rewrite one term for use in the given clause. `role` is 'delete',
+    // 'insert' or 'where'; `data` is true when generating a DATA operation
+    // (no WHERE clause available to ground variables).
+    let freshBnodeCount = 0
+    const termFor = (term: Term, role: string, data: boolean, triples: any[]): Term => {
+      const anyTerm = term as any
+      if (anyTerm.termType === 'Collection' || anyTerm.termType === 'Empty') {
+        // Desugar rdflib Collections into standard rdf:first/rest triples
+        if (role === 'delete') {
+          throw new Error('UpdateManager.update: cannot delete a statement containing a ' +
+            'Collection ' + anyTerm.toNT() + ': there is no SPARQL Update template for it. ' +
+            'Delete the underlying statements instead.')
         }
-        query += ' }\n'
+        const elements = anyTerm.elements || []
+        if (elements.length === 0) {
+          return this.store.rdfFactory.namedNode(rdfNS + 'nil') as Term
+        }
+        let head = this.store.rdfFactory.blankNode('l_' + freshBnodeCount++)
+        const first = head
+        for (let i = 0; i < elements.length; i++) {
+          triples.push({
+            subject: head,
+            predicate: this.store.rdfFactory.namedNode(rdfNS + 'first'),
+            object: termFor(elements[i], role, data, triples)
+          })
+          const rest = (i === elements.length - 1)
+            ? this.store.rdfFactory.namedNode(rdfNS + 'nil')
+            : this.store.rdfFactory.blankNode('l_' + freshBnodeCount++)
+          triples.push({
+            subject: head,
+            predicate: this.store.rdfFactory.namedNode(rdfNS + 'rest'),
+            object: rest
+          })
+          head = rest as any
+        }
+        return first as Term
       }
-      query += whereClause
+      if (isBlankNode(term)) {
+        if (this.mentioned(term)) {
+          if (data) {
+            throw new Error('UpdateManager.update: cannot patch the blank node ' +
+              (term as any).toNT() + ': no identifying WHERE context could be built for it ' +
+              'in its document, so a SPARQL Update cannot refer to it unambiguously.')
+          }
+          return variableForBnode(term) as unknown as Term
+        }
+        if (role === 'delete') {
+          throw new Error('UpdateManager.update: cannot delete a statement containing the ' +
+            'blank node ' + (term as any).toNT() + ' which is not in the store: there is nothing ' +
+            'to identify it by.')
+        }
+        return term // fresh blank node in an insertion: legal SPARQL
+      }
+      return term
+    }
+
+    const bgpFor = (sts: ReadonlyArray<Quad>, role: string, data: boolean): any[] => {
+      const triples: any[] = []
+      for (const st of sts) {
+        triples.push({
+          subject: termFor(st.subject, role, data, triples),
+          predicate: termFor(st.predicate, role, data, triples),
+          object: termFor(st.object, role, data, triples)
+        })
+      }
+      return [{ type: 'bgp', triples }]
+    }
+
+    const updates: any[] = []
+    if (context.length) { // Is there a WHERE clause?
+      const op: any = { updateType: 'insertdelete', delete: [], insert: [] }
+      if (ds.length) op.delete = bgpFor(ds, 'delete', false)
+      if (is.length) op.insert = bgpFor(is, 'insert', false)
+      op.where = bgpFor(context, 'where', false)
+      updates.push(op)
     } else { // no where clause
       if (ds.length) {
-        query += 'DELETE DATA { '
-        for (let i = 0; i < ds.length; i++) {
-          query += this.anonymizeNT(ds[i]) + '\n'
-        }
-        query += ' } \n'
+        updates.push({ updateType: 'delete', delete: bgpFor(ds, 'delete', true) })
       }
       if (is.length) {
-        if (ds.length) query += ' ; '
-        query += 'INSERT DATA { '
-        for (let i = 0; i < is.length; i++) {
-          query += this.nTriples(is[i]) + '\n'
-        }
-        query += ' }\n'
+        updates.push({ updateType: 'insert', insert: bgpFor(is, 'insert', true) })
       }
     }
-    return query;
+    return new SparqlGenerator().stringify({ type: 'update', prefixes: {}, updates } as any) + '\n'
   }
 
   /**
@@ -846,6 +927,62 @@ _:patch
     query += "   a solid:InsertDeletePatch .\n"
 
     return query;
+  }
+
+  /**
+   * @private
+   *
+   * Validates that every statement handed to update() is made of real RDF
+   * terms and targets the document being patched. Throws a clear TypeError
+   * naming the offending argument, rather than letting a plain string (or
+   * other non-term value) turn into garbage SPARQL that only fails
+   * server-side (#278).
+   */
+  validateUpdateStatements(sts: ReadonlyArray<Statement>, role: string, doc): void {
+    const expected = {
+      subject: 'a NamedNode or BlankNode',
+      predicate: 'a NamedNode',
+      object: 'a NamedNode, BlankNode, Literal or Collection',
+      graph: 'the NamedNode of the document to patch'
+    }
+    const allowedTermTypes = {
+      subject: ['NamedNode', 'BlankNode', 'Variable'],
+      predicate: ['NamedNode', 'Variable'],
+      object: ['NamedNode', 'BlankNode', 'Literal', 'Collection', 'Empty', 'Variable'],
+      graph: ['NamedNode']
+    }
+    sts.forEach((st, i) => {
+      if (!st || typeof st !== 'object' || typeof (st as any).subject === 'undefined') {
+        throw new TypeError(`UpdateManager.update: ${role}[${i}] is not a Statement: ${st}. ` +
+          'Expected a Statement as produced by st() or statementsMatching().')
+      }
+      for (const prop of ['subject', 'predicate', 'object', 'graph']) {
+        const term = st[prop]
+        if (term === undefined || term === null) {
+          throw new TypeError(`UpdateManager.update: the ${prop} of ${role}[${i}] is missing; ` +
+            `expected ${expected[prop]}.`)
+        }
+        if (typeof term === 'string') {
+          throw new TypeError(`UpdateManager.update: the ${prop} of ${role}[${i}] is the string ` +
+            `${JSON.stringify(term)}, not an RDF term; expected ${expected[prop]}. ` +
+            'Build terms with sym()/namedNode() or literal().')
+        }
+        if (typeof (term as any).termType !== 'string') {
+          throw new TypeError(`UpdateManager.update: the ${prop} of ${role}[${i}] is not an ` +
+            `RDF term (it has no termType); expected ${expected[prop]}.`)
+        }
+        const allowed = allowedTermTypes[prop]
+        if (allowed.indexOf((term as any).termType) < 0) {
+          throw new TypeError(`UpdateManager.update: the ${prop} of ${role}[${i}] is a ` +
+            `${(term as any).termType} ("${(term as any).value}"); expected ${expected[prop]}. ` +
+            '(Note that a plain string passed to st() becomes a Literal.)')
+        }
+      }
+      if (!doc.equals(st.graph)) {
+        throw new Error('update: destination ' + doc +
+          ' inconsistent with ' + role.slice(0, -1) + ' quad targeting ' + st.graph)
+      }
+    })
   }
 
   /**
@@ -915,22 +1052,11 @@ _:patch
 
       var startTime = Date.now()
 
-      var props = ['subject', 'predicate', 'object', 'why']
-      var verbs = ['insert', 'delete']
-      var clauses = { 'delete': ds, 'insert': is }
-      verbs.map(function (verb) {
-        clauses[verb].map(function (st: Quad) {
-          if (!doc.equals(st.graph)) {
-            throw new Error('update: destination ' + doc +
-              ' inconsistent with delete quad ' + st.graph)
-          }
-          props.map(function (prop) {
-            if (typeof st[prop] === 'undefined') {
-              throw new Error('update: undefined ' + prop + ' of statement.')
-            }
-          })
-        })
-      })
+      // Validate the statements before generating anything from them (#278):
+      // a plain string (or other non-term value) in a term position would
+      // otherwise produce garbage SPARQL that only fails server-side.
+      this.validateUpdateStatements(ds, 'deletions', doc)
+      this.validateUpdateStatements(is, 'insertions', doc)
 
       var protocol = this.editable(doc.value, kb);
 

--- a/src/update-manager.ts
+++ b/src/update-manager.ts
@@ -757,17 +757,14 @@ export default class UpdateManager {
   /**
    * @private
    *
-   * This helper function constructs a SPARQL 1.1 Update query from resolved
-   * arguments, by building a sparqljs AST and serializing it with the
-   * sparqljs Generator (rather than concatenating strings).
+   * Constructs a SPARQL 1.1 Update query from resolved arguments, via a
+   * sparqljs AST serialized with the sparqljs Generator.
    *
    * Blank nodes are illegal in DELETE templates and DELETE DATA, and a blank
-   * node in a WHERE pattern denotes a *fresh* variable rather than the node
-   * the caller meant. So every blank node that already exists in the store is
-   * consistently rewritten to one collision-free variable across the DELETE,
-   * INSERT and WHERE clauses (the WHERE clause built from `bnodes_context`
-   * grounds it), while genuinely fresh blank nodes are kept as blank nodes in
-   * insertions only.
+   * node in a WHERE pattern denotes a fresh variable rather than the node
+   * the caller meant, so every blank node already in the store is rewritten
+   * to one collision-free variable across the DELETE, INSERT and WHERE
+   * clauses; genuinely fresh blank nodes are kept in insertions only.
    *
    * @param ds: deletions array.
    * @param is: insertions array.
@@ -1052,9 +1049,7 @@ _:patch
 
       var startTime = Date.now()
 
-      // Validate the statements before generating anything from them (#278):
-      // a plain string (or other non-term value) in a term position would
-      // otherwise produce garbage SPARQL that only fails server-side.
+      // Validate before generating anything from the statements (#278)
       this.validateUpdateStatements(ds, 'deletions', doc)
       this.validateUpdateStatements(is, 'insertions', doc)
 

--- a/tests/unit/patch-parser-test.js
+++ b/tests/unit/patch-parser-test.js
@@ -3,6 +3,8 @@ import { expect } from 'chai'
 import sparqlUpdateParser from '../../src/patch-parser'
 import IndexedFormula from '../../src/store'
 
+const PATCH_NS = 'http://www.w3.org/ns/pim/patch#'
+
 describe('sparqlUpdateParser', () => {
   it('parses a basic SPARQL UPDATE query', () => {
     const query = `
@@ -41,6 +43,213 @@ describe('sparqlUpdateParser', () => {
         object: "Verborgh",
       },
     ])
+  })
+
+  // Characterization of the legacy output contract: server-side consumers
+  // (NSS, and code reading the patch model out of the kb) depend on these
+  // shapes, so the sparqljs-backed parser must keep producing them.
+  describe('output contract (characterization)', () => {
+    const query = `
+      DELETE { <#me> <http://xmlns.com/foaf/0.1/givenName> ?name. }
+      INSERT { <#me> <http://xmlns.com/foaf/0.1/givenName> "Ruben". }
+      WHERE { <#me> <http://xmlns.com/foaf/0.1/lastName> "Verborgh". }`
+    const baseUri = 'https://ruben.verborgh.org/profile/card'
+
+    it('invents a #query node on the document', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(query, store, baseUri)
+      expect(result.query.termType).to.equal('NamedNode')
+      expect(result.query.value).to.equal(baseUri + '#query')
+    })
+
+    it('returns formula subgraphs whose statements carry the document as graph', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(query, store, baseUri)
+      for (const kind of ['where', 'insert', 'delete']) {
+        expect(result[kind].termType).to.equal('Graph')
+        expect(result[kind].statements).to.have.length(1)
+        expect(result[kind].statements[0].why.value).to.equal(baseUri)
+      }
+    })
+
+    it('adds query patch:where|insert|delete statements to the kb', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(query, store, baseUri)
+      for (const kind of ['where', 'insert', 'delete']) {
+        const sts = store.statementsMatching(result.query, store.sym(PATCH_NS + kind))
+        expect(sts, kind).to.have.length(1)
+        expect(sts[0].object).to.equal(result[kind])
+      }
+    })
+
+    it('produces Variable terms for ?variables and shares them between clauses', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(query, store, baseUri)
+      const deleted = result.delete.statements[0].object
+      const where = result.where.statements[0].object
+      expect(deleted.termType).to.equal('Variable')
+      expect(deleted.value).to.equal('name')
+      expect(where.termType).to.equal('Literal')
+    })
+  })
+
+  describe('compatibility with legacy patch shapes', () => {
+    const baseUri = 'https://example.org/doc'
+
+    it('accepts clauses in any order, including legacy WHERE-first', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(`
+        WHERE { <#me> <http://xmlns.com/foaf/0.1/lastName> "Verborgh". }
+        DELETE { <#me> <http://xmlns.com/foaf/0.1/givenName> ?name. }
+        INSERT { <#me> <http://xmlns.com/foaf/0.1/givenName> "Ruben". }`,
+        store, baseUri)
+      expect(result.where.statements.map(termValues)).to.eql([{
+        subject: baseUri + '#me',
+        predicate: 'http://xmlns.com/foaf/0.1/lastName',
+        object: 'Verborgh',
+      }])
+      expect(result.delete.statements[0].object.termType).to.equal('Variable')
+      expect(result.insert.statements[0].object.value).to.equal('Ruben')
+    })
+
+    it('parses INSERT DATA and DELETE DATA operations separated by semicolons', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(
+        'DELETE DATA { <#s> <#p> "old" . } ; INSERT DATA { <#s> <#p> "new" . }',
+        store, baseUri)
+      expect(result.delete.statements.map(termValues)).to.eql([
+        { subject: baseUri + '#s', predicate: baseUri + '#p', object: 'old' }])
+      expect(result.insert.statements.map(termValues)).to.eql([
+        { subject: baseUri + '#s', predicate: baseUri + '#p', object: 'new' }])
+      expect(result.where).to.equal(undefined)
+      expect(store.statementsMatching(result.query, store.sym(PATCH_NS + 'where'))).to.have.length(0)
+    })
+
+    it('accepts N3-style @prefix directives (normalized to PREFIX)', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(`@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+        INSERT DATA { <#me> foaf:name "Tim" . }`, store, baseUri)
+      expect(result.insert.statements.map(termValues)).to.eql([
+        { subject: baseUri + '#me', predicate: 'http://xmlns.com/foaf/0.1/name', object: 'Tim' }])
+    })
+
+    it('accepts SPARQL PREFIX declarations (#651)', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(`PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        INSERT DATA { <#me> foaf:name "Tim" . }`, store, baseUri)
+      expect(result.insert.statements.map(termValues)).to.eql([
+        { subject: baseUri + '#me', predicate: 'http://xmlns.com/foaf/0.1/name', object: 'Tim' }])
+    })
+
+    it('accepts lowercase keywords', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(
+        'insert data { <#s> <#p> "v" . }', store, baseUri)
+      expect(result.insert.statements.map(termValues)).to.eql([
+        { subject: baseUri + '#s', predicate: baseUri + '#p', object: 'v' }])
+    })
+
+    it('returns just the query node for an empty patch', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser('  \n # nothing here\n', store, baseUri)
+      expect(Object.keys(result)).to.eql(['query'])
+      expect(store.statements).to.have.length(0)
+    })
+
+    it('accepts a patch of only a WHERE clause', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(
+        'WHERE { <#s> <#p> ?o . }', store, baseUri)
+      expect(result.where.statements).to.have.length(1)
+      expect(result.insert).to.equal(undefined)
+      expect(result.delete).to.equal(undefined)
+    })
+  })
+
+  describe('term handling', () => {
+    const baseUri = 'https://example.org/doc'
+
+    it('preserves blank node identity within a patch', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(
+        'INSERT DATA { <#s> <#p> _:b0 . _:b0 <#q> "v" . }', store, baseUri)
+      const sts = result.insert.statements
+      expect(sts).to.have.length(2)
+      expect(sts[0].object.termType).to.equal('BlankNode')
+      expect(sts[1].subject.termType).to.equal('BlankNode')
+      expect(sts[0].object.equals(sts[1].subject)).to.equal(true)
+    })
+
+    it('parses typed and language-tagged literals', () => {
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser(
+        `INSERT DATA { <#s> <#p> "5"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+                            <#q> "hi"@en . }`, store, baseUri)
+      const sts = result.insert.statements
+      expect(sts).to.have.length(2)
+      expect(sts[0].object.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#integer')
+      expect(sts[0].object.value).to.equal('5')
+      expect(sts[1].object.language).to.equal('en')
+      expect(sts[1].object.value).to.equal('hi')
+    })
+  })
+
+  describe('base IRI handling', () => {
+    it('resolves against the document part when the base has a fragment (U7 regression)', () => {
+      // A fragment must not take part in resolution: with base
+      // <https://example.org/doc#section>, <#s> is <https://example.org/doc#s>
+      // and the invented query node lives on the document, not the fragment.
+      const store = new IndexedFormula()
+      const result = sparqlUpdateParser('INSERT DATA { <#s> <#p> "v" . }',
+        store, 'https://example.org/doc#section')
+      expect(result.query.value).to.equal('https://example.org/doc#query')
+      expect(result.insert.statements.map(termValues)).to.eql([
+        { subject: 'https://example.org/doc#s', predicate: 'https://example.org/doc#p', object: 'v' }])
+      expect(result.insert.statements[0].why.value).to.equal('https://example.org/doc')
+    })
+  })
+
+  describe('error reporting', () => {
+    const baseUri = 'https://example.org/doc'
+
+    it('throws a clear error on unknown top-level syntax', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser('SELECT * WHERE { ?s ?p ?o }', store, baseUri))
+        .to.throw(/Patch syntax failure in <https:\/\/example\.org\/doc>.*Unknown syntax/s)
+    })
+
+    it('throws a clear error on an unterminated clause group', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser('INSERT DATA { <#s> <#p> "v" .', store, baseUri))
+        .to.throw(/no matching '}'/)
+    })
+
+    it('throws a clear error on invalid clause contents', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser('INSERT DATA { this is not rdf }', store, baseUri))
+        .to.throw(/Patch syntax failure/)
+    })
+
+    it('rejects blank nodes in DELETE templates, as SPARQL requires', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser(
+        'DELETE { <#s> <#p> _:b } WHERE { <#s> <#p> ?o }', store, baseUri))
+        .to.throw(/Patch syntax failure/)
+    })
+
+    it('rejects GRAPH blocks inside clauses', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser(
+        'INSERT DATA { GRAPH <#g> { <#s> <#p> "v" } }', store, baseUri))
+        .to.throw(/Patch syntax failure|basic graph patterns/)
+    })
+
+    it('rejects property paths in WHERE clauses', () => {
+      const store = new IndexedFormula()
+      expect(() => sparqlUpdateParser(
+        'DELETE { <#s> <#p> ?o } WHERE { <#s> <#p>/<#q> ?o }', store, baseUri))
+        .to.throw(/property paths|Patch syntax failure/)
+    })
   })
 })
 

--- a/tests/unit/sparql-to-query-test.js
+++ b/tests/unit/sparql-to-query-test.js
@@ -1,0 +1,202 @@
+'use strict'
+
+import { expect } from 'chai'
+import * as rdf from '../../src/index'
+
+const { SPARQLToQuery } = rdf
+
+describe('SPARQLToQuery', () => {
+  describe('structural mapping onto Query.pat / Query.vars', () => {
+    it('maps a basic SELECT query', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(
+        'SELECT ?s ?o WHERE { ?s <http://xmlns.com/foaf/0.1/knows> ?o . }', true, kb)
+      expect(q.vars.map(v => v.termType)).to.eql(['Variable', 'Variable'])
+      expect(q.vars.map(v => v.value)).to.eql(['s', 'o'])
+      expect(q.vars.map(v => v.label)).to.eql(['s', 'o'])
+      expect(q.pat.statements).to.have.length(1)
+      const st = q.pat.statements[0]
+      expect(st.subject.termType).to.equal('Variable')
+      expect(st.predicate.value).to.equal('http://xmlns.com/foaf/0.1/knows')
+      expect(st.object.termType).to.equal('Variable')
+      // the same variable object is reused across the query
+      expect(st.subject).to.equal(q.vars[0])
+    })
+
+    it('expands prefixed names and the "a" keyword', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(`PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        SELECT ?s WHERE { ?s a foaf:Person . }`, true, kb)
+      const st = q.pat.statements[0]
+      expect(st.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+      expect(st.object.value).to.equal('http://xmlns.com/foaf/0.1/Person')
+    })
+
+    it('declares rdf: and rdfs: prefixes by default, like the old parser', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery('SELECT ?s WHERE { ?s rdf:type ?o . }', true, kb)
+      expect(q.pat.statements[0].predicate.value)
+        .to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
+    })
+
+    it('populates query.vars from the pattern for SELECT *', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery('SELECT * WHERE { ?s ?p ?o . }', true, kb)
+      expect(q.vars.map(v => v.value)).to.eql(['s', 'p', 'o'])
+    })
+
+    it('maps OPTIONAL groups onto the optional formula list', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(`SELECT ?s ?age WHERE {
+          ?s <http://ex.org/p> ?o .
+          OPTIONAL { ?s <http://ex.org/age> ?age . }
+        }`, true, kb)
+      expect(q.pat.statements).to.have.length(1)
+      expect(q.pat.optional).to.have.length(1)
+      const opt = q.pat.optional[0]
+      expect(opt.statements).to.have.length(1)
+      expect(opt.statements[0].predicate.value).to.equal('http://ex.org/age')
+      // optional shares the variable instances of the main pattern
+      expect(opt.statements[0].subject).to.equal(q.pat.statements[0].subject)
+    })
+
+    it('maps FILTER (?x = constant) onto an equality constraint', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(
+        'SELECT ?s WHERE { ?s <http://ex.org/p> ?o . FILTER ( ?o = "x" ) }', true, kb)
+      const constraint = q.pat.constraints['?o']
+      expect(constraint).to.be.an('object')
+      expect(constraint.describe('?o')).to.equal('?o = "x"')
+      expect(constraint.test(kb.literal('x'))).to.equal(true)
+      expect(constraint.test(kb.literal('y'))).to.equal(false)
+    })
+
+    it('maps FILTER > and < onto real comparisons', () => {
+      // The old parser silently turned > and < into equality tests
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(
+        'SELECT ?s WHERE { ?s <http://ex.org/age> ?age . FILTER ( ?age > 21 ) }', true, kb)
+      const constraint = q.pat.constraints['?age']
+      expect(constraint.test(kb.literal('25'))).to.equal(true)
+      expect(constraint.test(kb.literal('21'))).to.equal(false)
+      expect(constraint.test(kb.literal('7'))).to.equal(false)
+
+      const q2 = SPARQLToQuery(
+        'SELECT ?s WHERE { ?s <http://ex.org/age> ?age . FILTER ( ?age < 21 ) }', true, kb)
+      expect(q2.pat.constraints['?age'].test(kb.literal('7'))).to.equal(true)
+      expect(q2.pat.constraints['?age'].test(kb.literal('25'))).to.equal(false)
+    })
+
+    it('maps FILTER regex(?x, "pattern") onto a regex constraint', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(
+        'SELECT ?s WHERE { ?s <http://ex.org/p> ?name . FILTER regex(?name, "^Ali") }', true, kb)
+      const constraint = q.pat.constraints['?name']
+      expect(constraint.test(kb.literal('Alice'))).to.equal(true)
+      expect(constraint.test(kb.literal('Bob'))).to.equal(false)
+    })
+
+    it('supports regex flags', () => {
+      const kb = rdf.graph()
+      const q = SPARQLToQuery(
+        'SELECT ?s WHERE { ?s <http://ex.org/p> ?name . FILTER regex(?name, "^ali", "i") }', true, kb)
+      expect(q.pat.constraints['?name'].test(kb.literal('Alice'))).to.equal(true)
+    })
+  })
+
+  describe('running parsed queries against a store', () => {
+    it('answers a SELECT query over the store', () => {
+      const kb = rdf.graph()
+      const doc = rdf.sym('https://example.com/data')
+      kb.add(rdf.sym('https://example.com/alice#i'),
+        rdf.sym('http://xmlns.com/foaf/0.1/name'), rdf.lit('Alice'), doc)
+      kb.add(rdf.sym('https://example.com/bob#me'),
+        rdf.sym('http://xmlns.com/foaf/0.1/name'), rdf.lit('Bob'), doc)
+
+      const q = SPARQLToQuery(`PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        SELECT ?who WHERE { ?who foaf:name "Alice" . }`, true, kb)
+      const results = kb.querySync(q)
+      expect(results).to.have.length(1)
+      expect(results[0]['?who'].value).to.equal('https://example.com/alice#i')
+    })
+
+    it('does not require the trailing dot the spec makes optional (#459)', () => {
+      const kb = rdf.graph()
+      kb.add(kb.sym('https://example.com/A'), kb.sym('https://example.com/foo'), 'bar')
+
+      const q = SPARQLToQuery(
+        'SELECT ?nodeA ?nodeB WHERE { ?nodeA <https://example.com/foo> ?nodeB }', true, kb)
+      expect(q.pat.statements).to.have.length(1) // old parser silently produced none
+      const results = kb.querySync(q)
+      expect(results).to.have.length(1)
+      expect(results[0]['?nodeB'].value).to.equal('bar')
+    })
+
+    it('runs the exact CONSTRUCT WHERE repro of #459 as a binding query', () => {
+      const kb = rdf.graph()
+      kb.add(kb.sym('https://example.com/A'), kb.sym('https://example.com/foo'), 'bar')
+
+      const q = SPARQLToQuery('CONSTRUCT WHERE { ?nodeA ?edge ?nodeB }', true, kb)
+      expect(q.vars.map(v => v.value)).to.eql(['nodeA', 'edge', 'nodeB'])
+      const results = kb.querySync(q)
+      expect(results).to.have.length(1)
+      expect(results[0]['?nodeA'].value).to.equal('https://example.com/A')
+      expect(results[0]['?nodeB'].value).to.equal('bar')
+    })
+
+    it('handles parenthesized IRIs (#308)', () => {
+      const kb = rdf.graph()
+      const pred = kb.sym('http://www.example.com/Using_Business_Organisation_(L4)')
+      kb.add(kb.sym('http://ex.org/doc#subject'), pred, 'Data')
+
+      const q = SPARQLToQuery(`SELECT * WHERE {
+          ?s <http://www.example.com/Using_Business_Organisation_(L4)> ?o .
+        }`, true, kb)
+      expect(q.pat.statements[0].predicate.value).to.equal(pred.value)
+      const results = kb.querySync(q)
+      expect(results).to.have.length(1)
+      expect(results[0]['?o'].value).to.equal('Data')
+    })
+
+    it('applies FILTER constraints when matching', () => {
+      const kb = rdf.graph()
+      const age = kb.sym('http://xmlns.com/foaf/0.1/age')
+      kb.add(kb.sym('http://ex.org/#alice'), age, kb.literal('21'))
+      kb.add(kb.sym('http://ex.org/#bob'), age, kb.literal('30'))
+
+      const q = SPARQLToQuery(`SELECT ?s WHERE {
+          ?s <http://xmlns.com/foaf/0.1/age> ?age . FILTER ( ?age > 25 )
+        }`, true, kb)
+      const results = kb.querySync(q)
+      expect(results).to.have.length(1)
+      expect(results[0]['?s'].value).to.equal('http://ex.org/#bob')
+    })
+  })
+
+  describe('error reporting for unsupported SPARQL', () => {
+    const cases = [
+      ['ASK queries', 'ASK { ?s ?p ?o }', /ASK queries are not supported/],
+      ['DESCRIBE queries', 'DESCRIBE <http://ex.org/x>', /DESCRIBE queries are not supported/],
+      ['update operations', 'INSERT DATA { <http://ex.org/s> <http://ex.org/p> "v" }', /only SPARQL queries are supported/],
+      ['UNION', 'SELECT ?s WHERE { { ?s <http://ex.org/a> ?o } UNION { ?s <http://ex.org/b> ?o } }', /'UNION' construct is not supported/],
+      ['property paths', 'SELECT ?s WHERE { ?s <http://ex.org/a>/<http://ex.org/b> ?o }', /property paths are not supported/],
+      ['FROM clauses', 'SELECT ?s FROM <http://ex.org/g> WHERE { ?s ?p ?o }', /FROM clauses are not supported/],
+      ['SELECT expressions', 'SELECT (COUNT(?s) AS ?n) WHERE { ?s ?p ?o }', /SELECT expressions|aggregates/],
+      ['solution modifiers', 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 5', /solution modifiers/],
+      ['unsupported FILTER operators', 'SELECT ?s WHERE { ?s ?p ?o . FILTER ( ?o != "x" ) }', /FILTER operator '!=' is not supported/],
+      ['syntax errors', 'SELECT WHERE ?s { }', /could not parse the query/],
+    ]
+    for (const [name, query, message] of cases) {
+      it(`throws a clear error for ${name}`, () => {
+        const kb = rdf.graph()
+        expect(() => SPARQLToQuery(query, true, kb)).to.throw(message)
+      })
+    }
+
+    it('mentions the supported subset in errors', () => {
+      const kb = rdf.graph()
+      expect(() => SPARQLToQuery('ASK { ?s ?p ?o }', true, kb))
+        .to.throw(/supported subset is: SELECT/)
+    })
+  })
+})

--- a/tests/unit/update-manager-sparql-insert-test.ts
+++ b/tests/unit/update-manager-sparql-insert-test.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai'
 import {Headers} from 'cross-fetch'
 import * as sinon from 'sinon'
 import * as sinonChai from 'sinon-chai'
-import {Fetcher, graph, lit, st, sym, UpdateManager} from '../../src/index'
+import {Collection, Fetcher, graph, lit, st, sym, UpdateManager} from '../../src/index'
 import BlankNode from '../../src/blank-node';
 
 
@@ -37,24 +37,21 @@ describe('sparql updates via update manager', () => {
     it('calls PATCH to insert a triple', async () => {
         const st1 = st(subject, predicate, lit("literal value"), subject.doc())
         await updater.update([], [st1])
-        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal value" .
- }
+        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal value". }
 `)
     })
 
     it('calls PATCH to insert a triple including line feed', async () => {
         const st1 = st(subject, predicate, lit("literal\nvalue"), subject.doc())
         await updater.update([], [st1])
-        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal\\nvalue" .
- }
+        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal\\nvalue". }
 `)
     })
 
     it('calls PATCH to insert a triple including carriage return line feed', async () => {
         const st1 = st(subject, predicate, lit("literal\r\nvalue"), subject.doc())
         await updater.update([], [st1])
-        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal\\r\\nvalue" .
- }
+        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { <https://pod.example/test/foo#subject> <https://pod.example/test/foo#predicate> "literal\\r\\nvalue". }
 `)
     })
 
@@ -65,10 +62,210 @@ describe('sparql updates via update manager', () => {
         const st1 = st(bNode, predicate, subject, subject.doc())
         await updater.update([], [st1])
         expect(updater.anonymize).to.not.have.been.called;
-        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { _:subj <https://pod.example/test/foo#predicate> <https://pod.example/test/foo#subject> .
- }
+        expect(getPatchCall().lastArg.body).to.equal(`INSERT DATA { _:subj <https://pod.example/test/foo#predicate> <https://pod.example/test/foo#subject>. }
 `)
     });
+
+    it('sends spec-conformant DELETE DATA ; INSERT DATA for combined updates', async () => {
+        const st1 = st(subject, predicate, lit('old'), subject.doc())
+        const st2 = st(subject, predicate, lit('new'), subject.doc())
+        store.add(st1.subject, st1.predicate, st1.object, st1.graph)
+        await updater.update([st1], [st2])
+        const body = getPatchCall().lastArg.body
+        expect(body).to.match(/^DELETE DATA \{[^}]*"old"[^}]*\};\s*\nINSERT DATA \{[^}]*"new"[^}]*\}\n$/)
+    })
+
+    it('keeps the callback API contract of update()', done => {
+        const st1 = st(subject, predicate, lit('value'), subject.doc())
+        updater.update([], [st1], (uri, ok, errorBody, response) => {
+            try {
+                expect(uri).to.equal(subject.doc().value)
+                expect(ok).to.equal(true)
+                expect(response).to.be.an('object')
+                done()
+            } catch (e) {
+                done(e)
+            }
+        })
+    })
+
+    describe('blank node grounding (#313)', () => {
+        const acl = 'http://www.w3.org/ns/auth/acl#'
+        const me = sym('https://pod.example/profile/card#me')
+        const doc = me.doc()
+        const trustedApp = sym(acl + 'trustedApp')
+        const origin = sym(acl + 'origin')
+        const mode = sym(acl + 'mode')
+
+        it('rewrites a known blank node to one consistent variable across DELETE/INSERT/WHERE', async () => {
+            const app = new BlankNode('app')
+            store.add(me, trustedApp, app, doc)
+            store.add(app, origin, sym('https://trusted.app'), doc)
+            store.add(app, mode, sym(acl + 'Read'), doc)
+
+            await updater.update(
+                [st(app, mode, sym(acl + 'Read'), doc)],
+                [st(app, mode, sym(acl + 'Write'), doc)])
+            const body = getPatchCall().lastArg.body
+
+            // No blank node labels may survive into the SPARQL text
+            expect(body).to.not.include('_:')
+            const deleteVar = (body.match(/DELETE \{\s*\?([A-Za-z0-9_]+)/) || [])[1]
+            const insertVar = (body.match(/INSERT \{\s*\?([A-Za-z0-9_]+)/) || [])[1]
+            expect(deleteVar, 'DELETE clause variable').to.be.a('string')
+            // the same variable is used in all three clauses, so the WHERE
+            // clause grounds the variable the INSERT clause uses
+            expect(insertVar).to.equal(deleteVar)
+            const whereSection = body.slice(body.indexOf('WHERE'))
+            expect(whereSection).to.include('?' + deleteVar)
+            expect(whereSection).to.include('https://trusted.app')
+        })
+
+        it('gives distinct blank nodes collision-free distinct variables', async () => {
+            const b1 = new BlankNode('x-1')
+            const b2 = new BlankNode('x_1')
+            store.add(me, trustedApp, b1, doc)
+            store.add(b1, origin, sym('https://one.example'), doc)
+            store.add(me, trustedApp, b2, doc)
+            store.add(b2, origin, sym('https://two.example'), doc)
+
+            await updater.update(
+                [st(b1, origin, sym('https://one.example'), doc),
+                 st(b2, origin, sym('https://two.example'), doc)], [])
+            const body = getPatchCall().lastArg.body
+            expect(body).to.not.include('_:')
+            const deleteSection = body.slice(body.indexOf('DELETE'), body.indexOf('WHERE'))
+            const vars = new Set(Array.from(deleteSection.matchAll(/\?([A-Za-z0-9_]+)/g) as any[])
+                .map((m: any) => m[1]))
+            expect(vars.size, 'two distinct variables for two distinct bnodes').to.equal(2)
+        })
+
+        it('keeps fresh blank nodes as blank nodes in insertions while grounding known ones', async () => {
+            const app = new BlankNode('known')
+            store.add(me, trustedApp, app, doc)
+            store.add(app, origin, sym('https://trusted.app'), doc)
+            const fresh = new BlankNode('fresh')
+
+            await updater.update([], [
+                st(app, mode, sym(acl + 'Write'), doc),
+                st(me, trustedApp, fresh, doc),
+                st(fresh, origin, sym('https://new.app'), doc)
+            ])
+            const body = getPatchCall().lastArg.body
+            expect(body).to.include('_:fresh')
+            expect(body).to.not.include('_:known')
+            const insertSection = body.slice(body.indexOf('INSERT'), body.indexOf('WHERE'))
+            const whereSection = body.slice(body.indexOf('WHERE'))
+            const insertVars = Array.from(insertSection.matchAll(/\?([A-Za-z0-9_]+)/g) as any[])
+                .map((m: any) => m[1])
+            expect(insertVars.length).to.be.greaterThan(0)
+            for (const v of insertVars) {
+                expect(whereSection, `INSERT variable ?${v} is grounded by WHERE`).to.include('?' + v)
+            }
+        })
+
+        it('throws a clear error when deleting a statement with an unknown blank node', async () => {
+            const ghost = new BlankNode('ghost')
+            const st1 = st(ghost, predicate, lit('x'), subject.doc())
+            try {
+                await updater.update([st1], [])
+                throw new Error('update should have rejected')
+            } catch (e) {
+                expect(String(e)).to.match(/cannot delete a statement containing the blank node _:ghost/)
+            }
+        })
+    })
+
+    describe('term validation (#278)', () => {
+        it('rejects a plain string in a term position with a TypeError naming it', async () => {
+            const bad = {
+                subject: subject,
+                predicate: predicate,
+                object: 'plain string, not a term',
+                graph: subject.doc()
+            }
+            try {
+                await updater.update([], [bad as any])
+                throw new Error('update should have rejected')
+            } catch (e) {
+                expect(String(e)).to.include('TypeError')
+                expect(String(e)).to.include('the object of insertions[0] is the string "plain string, not a term"')
+                expect(String(e)).to.include('sym()')
+            }
+            expect(fetchMock).to.not.have.been.called
+        })
+
+        it('rejects a string that st() coerced into a Literal predicate', async () => {
+            const st1 = st(subject, 'https://pod.example/test/foo#predicate' as any,
+                lit('x'), subject.doc())
+            try {
+                await updater.update([], [st1])
+                throw new Error('update should have rejected')
+            } catch (e) {
+                expect(String(e)).to.include('TypeError')
+                expect(String(e)).to.include('the predicate of insertions[0] is a Literal')
+                expect(String(e)).to.include('expected a NamedNode')
+            }
+        })
+
+        it('rejects a non-NamedNode graph with a TypeError instead of the confusing destination error', async () => {
+            const good = st(subject, predicate, lit('x'), subject.doc())
+            const bad = {
+                subject: subject,
+                predicate: predicate,
+                object: lit('y'),
+                graph: 'https://pod.example/test/foo'
+            }
+            try {
+                await updater.update([good, bad as any], [])
+                throw new Error('update should have rejected')
+            } catch (e) {
+                expect(String(e)).to.include('TypeError')
+                expect(String(e)).to.include('the graph of deletions[1] is the string')
+            }
+        })
+
+        it('reports the callback error shape for invalid terms', done => {
+            const bad = {
+                subject: 'not-a-term',
+                predicate: predicate,
+                object: lit('x'),
+                graph: subject.doc()
+            }
+            updater.update([], [bad as any], (uri, ok, errorBody) => {
+                try {
+                    expect(ok).to.equal(false)
+                    expect(errorBody).to.include('the subject of insertions[0] is the string "not-a-term"')
+                    done()
+                } catch (e) {
+                    done(e)
+                }
+            })
+        })
+    })
+
+    describe('collections', () => {
+        it('desugars a Collection object in insertions into rdf:first/rest triples', async () => {
+            const list = new Collection([sym('https://ex.example/a'), lit('two')] as any)
+            const st1 = st(subject, predicate, list as any, subject.doc())
+            await updater.update([], [st1])
+            const body = getPatchCall().lastArg.body
+            expect(body).to.include('<http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://ex.example/a>')
+            expect(body).to.include('<http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "two"')
+            expect(body).to.include('<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>')
+        })
+
+        it('throws a clear error for a Collection in deletions', async () => {
+            const list = new Collection([sym('https://ex.example/a')] as any)
+            const st1 = st(subject, predicate, list as any, subject.doc())
+            try {
+                await updater.update([st1], [])
+                throw new Error('update should have rejected')
+            } catch (e) {
+                expect(String(e)).to.include('cannot delete a statement containing a Collection')
+            }
+        })
+    })
 
     function getPatchCall() {
         return fetchMock.getCalls().find(it => it.lastArg.method === 'PATCH');


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review — prepared with Claude; nothing here progresses without his personal review.

This PR replaces rdflib's three pieces of hand-rolled SPARQL handling with [sparqljs](https://github.com/RubenVerborgh/SPARQL.js) (SPARQL 1.1 parser + generator, grammar-derived), per the cleanup roadmap (#823 / #824):

1. **`src/patch-parser.js`** — the regex/N3-parser-driven `sparqlUpdateParser` now normalizes legacy patch shapes (WHERE-first clause order, `@prefix` directives, `;`-separated `DATA` operations) into spec-conformant SPARQL 1.1 Update text and parses it with the sparqljs **Parser**, using the store's own data factory so it produces rdflib terms directly.
2. **`src/update-manager.ts`** — `constructSparqlUpdateQuery` now builds a sparqljs update AST and serializes it with the sparqljs **Generator** instead of concatenating `toNT()` strings. `update(deletions, insertions, callback, secondTry, options)` and all protocol logic (`editable()`, 409/retry, WebSocket `updates-via`, the N3-PATCH branch) are untouched.
3. **`src/sparql-to-query.js`** — `SPARQLToQuery(sparql, testMode, kb)` keeps its signature and the returned `Query.pat`/`Query.vars` shape (the matcher in `src/query.js` is untouched, and solid-ui's table panes keep working), but the SPARQL text is parsed by sparqljs and mapped onto the existing engine.

Closes #651
Closes #459
Closes #308
Closes #313
Closes #278
Closes #301

## Design notes — why two whole bug classes die structurally

**The PREFIX/grammar class (#651, #459, #308):** the old code implemented its own tokenizers (one N3-flavored, one regex/space-splitting). Every grammar detail it got wrong — `PREFIX` vs `@prefix`, the optional trailing `.` before `}`, parentheses inside IRIs — was a standalone bug. sparqljs is generated from the SPARQL 1.1 grammar, so this class of bug cannot recur; rdflib-level code only decides *which* constructs to accept and how to map them.

**The string-assembly class (#313, #278):** the old generator built update text with string concatenation over `toNT()`, so type errors and naming mistakes surfaced only as server-side 400s/500s. Generation is now AST-level:
- Blank nodes are illegal in DELETE templates and denote *fresh* nodes in WHERE patterns, so every blank node that already exists in the store is rewritten to **one collision-free variable used consistently across the DELETE, INSERT and WHERE clauses** — the WHERE context (built from the same connected-statement logic as before) always grounds exactly the variables the templates use. The #313 failure (an INSERT clause referring to `?n2` while the WHERE clause bound `?_g_L16C506`) is unrepresentable in this scheme. Genuinely fresh blank nodes are kept as blank nodes in insertions, which is legal SPARQL.
- Statements are validated up front: a plain string (or the `Literal` that `st()` silently coerces a string into) in a term position throws a `TypeError` naming the offending argument (`the object of insertions[0] is the string "..."; expected ...`) instead of the notorious `destination <X> inconsistent with delete quad X` (#278).
- rdflib `Collection` objects in insertions are desugared into standard `rdf:first`/`rdf:rest` triples (equivalent graph, accepted by any spec-conformant server).

**Base-IRI handling (the #831 fragment-base class):** `sparqlUpdateParser` now resolves against the *document part* of the base (fragment stripped) and mints the `#query` node on the document. A base of `https://ex.org/doc#section` previously produced the double-fragment query node `…doc#section#query`; there is a regression test for exactly this. This is the same fragment-base hazard flagged in the #831 breaking-change assessment (its M2 mitigation) — see the surface-shrink note below.

**What deliberately stays rdflib-owned:** the `Query`/`indexedFormulaQuery` matcher, `editable()`/HTTP metadata protocol logic, N3-PATCH generation, and `updates-via`. `src/query-to-sparql.js` is **left untouched** as a follow-up: `Query.pat.constraints` are opaque closures (`describe()`/`test()`) with no AST representation, so a sparqljs-Generator swap there is not the trivially clean drop this PR limits itself to.

## Behavior deltas

Every intentional behavior change, tabled. "FLAGGED" rows are the ones @jeswr should look at before merging; everything else is either invisible to conformant callers or a straight bug fix.

### patch-parser (`sparqlUpdateParser`)

| delta | before | after | why acceptable / FLAGGED |
|---|---|---|---|
| `PREFIX` declarations | rejected ("Bad syntax") | parsed natively | fix for #651 |
| `@prefix foo: <x> .` | parsed via n3parser | still accepted; normalized to `PREFIX` before sparqljs | documented compat leniency, kept for legacy clients |
| clause order (incl. WHERE-first) | any order accepted | any order still accepted; pre-normalized to spec order `DELETE/INSERT/WHERE` before sparqljs | kept: old rdflib clients emitted WHERE-first patches |
| keyword case | uppercase only | case-insensitive | SPARQL keywords are case-insensitive; strictly more accepting |
| base with fragment | query node `doc#frag#query`; resolution against the fragment base | document part used for resolution and the `#query` node | bug fix (the #831 fragment-base hazard); identical output for fragmentless bases (the normal case); regression-tested |
| error values | plain strings thrown (`"Line N of <uri>: Bad syntax…"`) | `Error` objects: `Patch syntax failure in <doc>: …` with sparqljs line info | consumers (NSS-style) only display the message |
| blank nodes in DELETE templates | accepted, forwarded | clear error | **FLAGGED** — SPARQL forbids them, and a fresh bnode can never match; previously produced undefined server behavior |
| multiple clauses of one kind + WHERE | last one silently won in `clauses`, yet *all* were added to the kb | clear error | **FLAGGED** — old behavior silently dropped data; believed unused |
| N3-only syntax inside clause bodies (`=>`, formulae, paths) | parsed as N3 | strict SPARQL BGPs only; clear error | **FLAGGED** — such patches were never valid SPARQL; `GRAPH`, property paths etc. error with named constructs |
| `INSERT DATA` alongside `WHERE` | `DATA` ignored ("Whatever") | same, via normalization | kept |

### UpdateManager

| delta | before | after | why acceptable / FLAGGED |
|---|---|---|---|
| generated SPARQL text shape | hand-concatenated (`INSERT DATA { … .\n }\n`, ` ; ` between ops) | sparqljs Generator layout (`INSERT DATA { … . }`, ops joined `;`) | spec-conformant; NSS/CSS accept conformant updates; golden tests updated (rows below) |
| golden: insert one triple | `INSERT DATA { <s> <p> "v" .\n }\n` | `INSERT DATA { <s> <p> "v". }\n` | same triple, Generator formatting |
| literal escaping | `toNT()` | Generator escaping (`\n`, `\r`, `\"`, `\\` verified by tests) | equivalent, now grammar-owned |
| bnode→variable naming | `?<label>` only when "mentioned"; INSERT could receive variables the WHERE never bound (#313) | one collision-free variable per bnode, shared across DELETE/INSERT/WHERE; fresh bnodes stay bnodes in INSERT | fix for #313; regression tests incl. shared and colliding labels (`x-1` vs `x_1`) |
| string / wrong-typed terms | garbage SPARQL or confusing "inconsistent destination" error | up-front `TypeError` naming argument + expected type; term kinds enforced (subject NamedNode/BlankNode, predicate NamedNode, graph NamedNode) | fix for #278; conceivably rejects exotic previously-"working" inputs — **FLAGGED** (mildly) |
| deleting a statement with a bnode not in the store | emitted `_:label` inside `DELETE DATA` (invalid SPARQL, server rejected) | clear client-side error | **FLAGGED** — same net failure, but immediate and explained |
| mentioned bnode with no identifying context in its doc | emitted `?var` inside a `DATA` op (invalid SPARQL) | clear client-side error | **FLAGGED** — was never expressible; now fails with an explanation |
| `Collection` in insertions | emitted `( … )` collection syntax | desugared to `rdf:first`/`rdf:rest`/`rdf:nil` triples | equivalent graph, spec-conformant, tested |
| `Collection` in deletions | emitted `( … )` — implicit bnodes make this illegal in DELETE; servers reject | clear error suggesting deleting the underlying statements | **FLAGGED** |
| deprecated `update_statement`/`insert_statement`/`delete_statement` | string-concatenated | **untouched** | left alone to avoid colliding with #833 (which owns #231 in that region); candidates for deprecation there |

### SPARQLToQuery

| delta | before | after | why acceptable / FLAGGED |
|---|---|---|---|
| trailing `.` before `}` | required; silently produced an empty pattern | optional, per spec | fix for #459 |
| parenthesized IRIs | tokenizer mangled them; threw "not a predicate type" | parse correctly | fix for #308 |
| `SELECT *` | `query.vars` left empty | `vars` populated from the pattern, in order of first occurrence | matcher bindings unchanged; better for UI consumers |
| `CONSTRUCT` | half-worked by accident (empty vars; pattern only if dotted) | executed as a binding query over its WHERE clause; documented | keeps the #459 repro (and the old dotted workaround) working |
| `FILTER >` / `<` | silently treated as **equality** | real numeric/term comparisons | correctness fix — **FLAGGED** for queries that depended on the bug |
| `FILTER regexp("re", ?v)` (legacy arg order) | silently ignored (never registered) | standard `regex(?v, "re"[, "flags"])` supported; the legacy form errors | the legacy form never worked |
| unsupported forms (ASK/DESCRIBE, UNION, paths, GRAPH, FROM, BIND, VALUES, aggregates, ORDER/LIMIT/DISTINCT, other FILTERs) | silent misparse, junk patterns, or `return false` | throw an `Error` naming the construct and stating the supported subset | **FLAGGED** — callers relying on a `false` return or on silent behavior now get exceptions with actionable messages |
| undeclared prefixes | junk tokens passed through (`rdf:`/`rdfs:` defaulted) | parse error (`rdf:`/`rdfs:` still predeclared) | correct; matches old defaults |
| relative IRIs | silently became relative NamedNodes (matched nothing) | parse error (the API has no base parameter) | **FLAGGED** — never useful before; flagged in case someone fed pre-resolved text |
| `is <p> of` N3 idiom | swapped subject/object | not supported (error) | **FLAGGED** — not SPARQL; solid-ui builds Query objects directly, so believed unused |

## Downstream contract — preserved

- `sparqlUpdateParser(str, kb, base)` returns `clauses = { query, where?, insert?, delete? }` with the same term/formula shapes (`kb.sym(doc + '#query')`, `IndexedFormula` subgraphs whose statements carry the document as `why`, `Variable` terms for `?x`), and still adds `query patch:where|insert|delete <formula>` into the kb (`http://www.w3.org/ns/pim/patch#`) — locked in by a characterization test suite written against the old implementation's observed output before the swap.
- `UpdateManager.update()` signature, callback and promise semantics unchanged (tested).
- `Query.pat` / `Query.vars` shapes unchanged; `src/query.js` untouched.

## sparqljs usage notes

- Runtime dep `sparqljs@^3.7.4` (+ dev `@types/sparqljs`); patch-parser's dependency on the legacy `n3parser` is **removed**.
- Both the patch parser and `SPARQLToQuery` pass the store's `rdfFactory` as sparqljs's `factory`, so parsed ASTs contain real rdflib terms (matching how `n3parser` built terms through the kb) — no term-conversion layer.

## #831 surface-shrink note

This PR removes patch-parser's import of the legacy `src/n3parser.js`. For the in-flight #831 (Turtle/N3 → N3.js) that means the patch-parser corner of its migration surface disappears: the **M2 mitigation (the fragment-base patch-parser fix) becomes moot** — the fragment-base behavior is fixed here structurally and regression-tested. One fewer consumer of the old parser to reason about when deleting it.

## Rebase note (#833)

This branch is cut from `main` and will be rebased over the UpdateManager-correctness PR #833 once that merges. #833 explicitly excluded #278 and deferred it to this PR; conversely this PR does not touch #231 (`anonymize` `this`-binding), #479 (promise rejection wiring) or #250 (load-then-retry), and leaves the deprecated `update_statement` trio alone so the two changesets stay disjoint.

## Test evidence

Baseline on the branch point (eb1e18d), before any changes: `test:unit` **308 passing** (exit 0), `test:serialize` exit 0, `test:types` exit 0.

Final, after the migration: `test:unit` **365 passing** (exit 0), `test:serialize` exit 0, `test:types` exit 0, `lint` exit 0 (0 errors; the 5 pre-existing warnings are all in untouched files).

**57 new tests** (`tests/unit/**-test.*`):
- `patch-parser-test.js` (+20): output-contract characterization (query node, formula graphs, kb patch statements, shared variables); legacy compat (WHERE-first, `DATA` ops + semicolons, `@prefix`, `PREFIX` #651, lowercase, empty patch, WHERE-only patch); term handling (bnode identity, typed + language literals); **fragment-base regression**; error shapes (unknown syntax, unterminated group, invalid contents, bnode-in-DELETE, GRAPH, property paths).
- `sparql-to-query-test.js` (new file, +25): structural mapping (vars/labels, shared variable instances, prefixed names + `a`, default `rdf:`/`rdfs:`, `SELECT *`, OPTIONAL, all four FILTER forms, regex flags); end-to-end matches against a store (**#459 trailing dot, the exact #459 CONSTRUCT repro, #308 parenthesized IRI**, FILTER application); 10 unsupported-form error shapes + subset mention.
- `update-manager-sparql-insert-test.ts` (+12, and 4 goldens updated to Generator output): DELETE DATA;INSERT DATA shape; callback API compat; **#313** (consistent variable across clauses, collision-free names for `x-1`/`x_1`, fresh-vs-known bnodes with WHERE-groundedness assertion, unknown-bnode delete error); **#278** (TypeError shapes for string object, Literal predicate, string graph, callback error shape); Collection desugaring + delete error.

## LOC (branch tip vs `main`, excluding `package-lock.json`)

- Overall: **+1225 / −575** across 8 files (the bulk of additions is tests: +617 test lines).
- `src/` only: **+548 / −564** (net −16): `sparql-to-query.js` 517 → 257; `patch-parser.js` 94 → 217 (the top-level compat scanner/normalizer is the price of keeping legacy patch shapes working on a strict grammar); `update-manager.ts` net +121 for AST generation, validation and Collection desugaring.
- Removes the last non-Turtle consumer of `n3parser.js`.
