### PR TITLE
feat: rebuild the JSON-LD parse path on jsonld.toRDF(), removing the bespoke walker and its SSRF surface

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -41,7 +41,7 @@ import crossFetch, { Headers } from 'cross-fetch'
 import type { Document as XmldomDocument, Element as XmldomElement, Node as XmldomNode } from '@xmldom/xmldom'
 
 import {
-  ContentType, TurtleContentType, RDFXMLContentType, XHTMLContentType
+  ContentType, TurtleContentType, RDFXMLContentType, XHTMLContentType, JsonLdDocumentLoader
 } from './types'
 import { termValue } from './utils/termValue'
 import {
@@ -178,6 +178,12 @@ export interface AutoInitOptions extends RequestInit{
   noRDFa?: boolean
   handlers?: Handler[]
   timeout?: number
+  /**
+   * JSON-LD only: loader used to resolve remote `@context` URLs. When
+   * omitted, remote context fetching is refused (SSRF protection) and
+   * documents that rely on it fail to parse.
+   */
+  documentLoader?: JsonLdDocumentLoader
   method?: HTTPMethods
   retriedWithNoCredentials?: boolean
   requestedURI?: string
@@ -511,7 +517,9 @@ class JsonLdHandler extends Handler {
   ): Promise<ExtendedResponse | FetchError> {
     const kb = fetcher.store
     try {
-      await jsonldParser(responseText, kb, options.original.value)
+      // Remote @context fetching is refused unless the caller explicitly
+      // injected options.documentLoader (deliberate SSRF protection)
+      await jsonldParser(responseText, kb, options.original.value, { documentLoader: options.documentLoader })
       fetcher.store.add(options.original, ns.rdf('type'), ns.link('RDFDocument'), fetcher.appNode)
       return fetcher.doneFetch(options, response)
     } catch (err) {

--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -101,8 +101,8 @@ function isNil (term) {
  * parse path does (see src/lists.ts) so `Collection.elements` keeps working
  * for downstream consumers.
  *
- * Operates only on the quads produced by the current parse — never on
- * pre-existing store content — and, unlike lists.ts's convertFirstRestNil,
+ * Operates only on the quads produced by the current parse (never on
+ * pre-existing store content) and, unlike lists.ts's convertFirstRestNil,
  * leaves non-well-formed chains as raw triples instead of throwing.
  *
  * @param kb - The store whose rdfFactory builds the Collections.

--- a/src/jsonldparser.js
+++ b/src/jsonldparser.js
@@ -1,145 +1,317 @@
-import {arrayToStatements} from './utils'
+const RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+const RDF_FIRST = RDF_NS + 'first'
+const RDF_REST = RDF_NS + 'rest'
+const RDF_NIL = RDF_NS + 'nil'
+const XSD_STRING = 'http://www.w3.org/2001/XMLSchema#string'
 
 /**
- * Parses json-ld formatted JS objects to a rdf Term.
- * @param kb - The DataFactory to use.
- * @param obj - The json-ld object to process.
- * @return {Literal|NamedNode|BlankNode|Collection}
+ * Marker property used to recognize our own remote-context refusal error when
+ * jsonld.js wraps it inside a JsonLdError.
  */
-export function jsonldObjectToTerm(kb, obj) {
-  if (typeof obj === 'string') {
-    return kb.rdfFactory.literal(obj)
-  }
+const REFUSED_REMOTE_CONTEXT = 'rdflibRemoteContextRefused'
 
-  if (Object.prototype.hasOwnProperty.call(obj, '@list')) {
-    if (kb.rdfFactory.supports["COLLECTIONS"] === true) {
-      return listToCollection(kb, obj['@list'])
+/**
+ * Builds the error thrown when a document requests a remote `@context` and no
+ * documentLoader has been injected by the caller.
+ */
+function remoteContextRefusedError (url) {
+  const err = new Error(
+    'Refused to fetch remote @context <' + url + '>: rdflib.js disables remote ' +
+    'JSON-LD context fetching by default, because dereferencing contexts from ' +
+    'untrusted documents lets attackers trigger arbitrary outbound HTTP(S) ' +
+    'requests (SSRF). To opt in, pass an explicit `documentLoader` in the ' +
+    'options argument of jsonldParser/parse (e.g. jsonld.js\'s ' +
+    'documentLoaders.node() or a loader backed by your own fetch policy).'
+  )
+  err[REFUSED_REMOTE_CONTEXT] = true
+  err.contextUrl = url
+  return err
+}
+
+/**
+ * The default documentLoader: refuses every remote context fetch.
+ */
+async function refusingDocumentLoader (url) {
+  throw remoteContextRefusedError(url)
+}
+
+/**
+ * jsonld.js wraps documentLoader failures in a JsonLdError whose generic
+ * message hides the cause. If our refusal error is anywhere in the cause
+ * chain, surface it directly so callers get the actionable message.
+ */
+function unwrapRefusalError (err) {
+  const seen = new Set()
+  let e = err
+  while (e && typeof e === 'object' && !seen.has(e)) {
+    seen.add(e)
+    if (e[REFUSED_REMOTE_CONTEXT]) {
+      return e
     }
-
-    return listToStatements(kb, obj)
+    e = e.cause || (e.details && e.details.cause)
   }
-
-  if (Object.prototype.hasOwnProperty.call(obj, '@id')) {
-    return nodeType(kb, obj)
-  }
-
-  if (Object.prototype.hasOwnProperty.call(obj, '@language')) {
-    return kb.rdfFactory.literal(obj['@value'], obj['@language'])
-  }
-
-  if (Object.prototype.hasOwnProperty.call(obj, '@type')) {
-    return kb.rdfFactory.literal(obj['@value'], kb.rdfFactory.namedNode(obj['@type']))
-  }
-
-  if (Object.prototype.hasOwnProperty.call(obj, '@value')) {
-    return kb.rdfFactory.literal(obj['@value'])
-  }
-
-  return kb.rdfFactory.literal(obj)
+  return err
 }
 
 /**
- * Adds the statements in a json-ld list object to {kb}.
+ * Maps an RDF/JS term (as emitted by jsonld.toRDF) onto an rdflib term
+ * built with {kb.rdfFactory}.
+ *
+ * Blank nodes are allocated fresh through {bnodeMap} (one map per parse), so
+ * labels from one document can never collide with blank nodes from another
+ * parse into the same store.
  */
-function listToStatements(kb, obj) {
-  const listId = obj['@id'] ? nodeType(kb, obj) : kb.rdfFactory.blankNode()
-
-  const items = obj['@list'].map((listItem => jsonldObjectToTerm(kb, listItem)))
-  const statements = arrayToStatements(kb.rdfFactory, listId, items)
-  kb.addAll(statements)
-
-  return listId
+function termToRdflibTerm (kb, term, bnodeMap) {
+  switch (term.termType) {
+    case 'NamedNode':
+      return kb.rdfFactory.namedNode(term.value)
+    case 'BlankNode': {
+      let bnode = bnodeMap.get(term.value)
+      if (!bnode) {
+        bnode = kb.rdfFactory.blankNode()
+        bnodeMap.set(term.value, bnode)
+      }
+      return bnode
+    }
+    case 'Literal': {
+      if (term.language) {
+        return kb.rdfFactory.literal(term.value, term.language)
+      }
+      if (term.datatype && term.datatype.value && term.datatype.value !== XSD_STRING) {
+        return kb.rdfFactory.literal(term.value, kb.rdfFactory.namedNode(term.datatype.value))
+      }
+      return kb.rdfFactory.literal(term.value)
+    }
+    default:
+      throw new Error('Unexpected term type from JSON-LD toRDF: ' + term.termType)
+  }
 }
 
-function listToCollection(kb, obj) {
-  if (!Array.isArray(obj)) {
-    throw new TypeError("Object must be an array")
-  }
-  return kb.rdfFactory.collection(obj.map((o) => jsonldObjectToTerm(kb, o)))
+function isBlank (term) {
+  return term.termType === 'BlankNode'
+}
+
+function isNil (term) {
+  return term.termType === 'NamedNode' && term.value === RDF_NIL
 }
 
 /**
- * Takes a json-ld formatted string {str} and adds its statements to {kb}.
+ * Folds well-formed rdf:first/rdf:rest chains (as emitted by toRDF for
+ * `@list`) back into rdflib Collection terms, mirroring what the Turtle
+ * parse path does (see src/lists.ts) so `Collection.elements` keeps working
+ * for downstream consumers.
+ *
+ * Operates only on the quads produced by the current parse — never on
+ * pre-existing store content — and, unlike lists.ts's convertFirstRestNil,
+ * leaves non-well-formed chains as raw triples instead of throwing.
+ *
+ * @param kb - The store whose rdfFactory builds the Collections.
+ * @param quads - The rdflib quads of this parse.
+ * @return The remaining quads with list heads replaced by Collections.
+ */
+function foldListChains (kb, quads) {
+  // Usage info per blank node label, over this parse's quads only
+  const info = new Map()
+  const getInfo = (id) => {
+    let i = info.get(id)
+    if (!i) {
+      i = { first: [], rest: [], otherOut: 0, inRefs: [], usedAsGraph: false }
+      info.set(id, i)
+    }
+    return i
+  }
+
+  for (const q of quads) {
+    if (isBlank(q.subject)) {
+      const i = getInfo(q.subject.value)
+      if (q.predicate.value === RDF_FIRST) {
+        i.first.push(q)
+      } else if (q.predicate.value === RDF_REST) {
+        i.rest.push(q)
+      } else {
+        i.otherOut += 1
+      }
+    }
+    if (isBlank(q.object)) {
+      getInfo(q.object.value).inRefs.push(q)
+    }
+    if (isBlank(q.graph)) {
+      getInfo(q.graph.value).usedAsGraph = true
+    }
+  }
+
+  // A blank node is a well-formed list node when it carries exactly one
+  // rdf:first, exactly one rdf:rest, nothing else, is referenced exactly
+  // once, and never names a graph.
+  const isListNode = (id) => {
+    const i = info.get(id)
+    return !!i && i.first.length === 1 && i.rest.length === 1 &&
+      i.otherOut === 0 && i.inRefs.length === 1 && !i.usedAsGraph
+  }
+
+  /**
+   * Walks the chain from {headId}, returning `{ elements, chain }` when the
+   * whole chain (and any nested chains reachable through rdf:first) is
+   * well-formed and lives in {graph}; `null` otherwise (fold nothing).
+   */
+  const foldFrom = (headId, graph, visited) => {
+    const elements = []
+    const chain = []
+    let cur = headId
+    for (;;) {
+      if (visited.has(cur) || !isListNode(cur)) {
+        return null
+      }
+      visited.add(cur)
+      const i = info.get(cur)
+      const firstQuad = i.first[0]
+      const restQuad = i.rest[0]
+      if (!firstQuad.graph.equals(graph) || !restQuad.graph.equals(graph)) {
+        return null
+      }
+      chain.push(firstQuad, restQuad)
+
+      let element = firstQuad.object
+      if (isBlank(element) && isListNode(element.value) &&
+          info.get(element.value).inRefs[0] === firstQuad) {
+        // Nested @list: fold it into a nested Collection when possible
+        const nested = foldFrom(element.value, graph, visited)
+        if (nested) {
+          element = kb.rdfFactory.collection(nested.elements)
+          chain.push(...nested.chain)
+        }
+      } else if (isNil(element)) {
+        // Nested empty @list
+        element = kb.rdfFactory.collection([])
+      }
+      elements.push(element)
+
+      const tail = restQuad.object
+      if (isNil(tail)) {
+        return { elements, chain }
+      }
+      if (!isBlank(tail) || !info.get(tail.value) ||
+          info.get(tail.value).inRefs[0] !== restQuad) {
+        return null
+      }
+      cur = tail.value
+    }
+  }
+
+  const consumed = new Set()
+  const replacements = new Map() // referencing quad -> Collection
+
+  for (const q of quads) {
+    if (q.predicate.value === RDF_REST || !isBlank(q.object)) {
+      continue
+    }
+    if (!isListNode(q.object.value) || info.get(q.object.value).inRefs[0] !== q) {
+      continue
+    }
+    if (q.predicate.value === RDF_FIRST && isBlank(q.subject) && isListNode(q.subject.value)) {
+      continue // owned by the enclosing chain's fold
+    }
+    const foldedList = foldFrom(q.object.value, q.graph, new Set())
+    if (foldedList) {
+      replacements.set(q, kb.rdfFactory.collection(foldedList.elements))
+      for (const chainQuad of foldedList.chain) {
+        consumed.add(chainQuad)
+      }
+    }
+  }
+
+  const result = []
+  for (const q of quads) {
+    if (consumed.has(q)) {
+      continue
+    }
+    let object = replacements.get(q)
+    if (!object && isNil(q.object) && q.predicate.value !== RDF_REST) {
+      // Lone rdf:nil object (e.g. an empty @list): empty Collection, matching
+      // the Turtle path's substituteNillsInDoc behavior.
+      object = kb.rdfFactory.collection([])
+    }
+    result.push(object ? kb.rdfFactory.quad(q.subject, q.predicate, object, q.graph) : q)
+  }
+  return result
+}
+
+/**
+ * Takes a json-ld formatted string {str} and adds its statements to {kb},
+ * using jsonld.js's toRDF() (the JSON-LD 1.1 "Deserialize JSON-LD to RDF"
+ * algorithm).
+ *
+ * Quads in the default graph are placed in the document graph named by
+ * {base} (rdflib's doc-graph convention); quads in named graphs keep their
+ * graph as `why`.
+ *
+ * Remote `@context` URLs are NOT dereferenced by default: parsing untrusted
+ * JSON-LD must not trigger outbound network requests (SSRF). Callers that
+ * want remote contexts resolved must inject `options.documentLoader`.
  *
  * Ensure that {kb.rdfFactory} is a DataFactory.
+ *
+ * @param str - The JSON-LD document as a string.
+ * @param kb - The store to add the parsed statements to.
+ * @param base - The base IRI (string or NamedNode); also names the doc graph.
+ * @param [options] - Optional parse options.
+ * @param [options.documentLoader] - A jsonld.js documentLoader
+ *   (`async (url) => ({ document, documentUrl, contextUrl })`) used to
+ *   resolve remote `@context` URLs. Omitted: remote contexts are refused.
+ * @param [options.expandContext] - A context to expand the document with,
+ *   for documents whose context is supplied out-of-band.
  */
-export default async function jsonldParser(str, kb, base) {
+export default async function jsonldParser (str, kb, base, options = {}) {
   const baseString = base && Object.prototype.hasOwnProperty.call(base, 'termType')
     ? base.value
     : base
 
   const jsonld = await import('jsonld')
   // ⚠ Unit tests also work without accessing `jsonld.default` explicitly, but real browser usage will fail with
-  // just calling `jsonld.flatten`, so please do not remove `default`
+  // just calling `jsonld.toRDF`, so please do not remove `default`
   // Handle both ESM (browser) and CommonJS (Node.js) module formats
-  // Browser ESM: jsonld.default.flatten
-  // Node.js CommonJS: jsonld.flatten
+  // Browser ESM: jsonld.default.toRDF
+  // Node.js CommonJS: jsonld.toRDF
   const jsonldLib = jsonld.default || jsonld
-  const flattened = await jsonldLib.flatten(JSON.parse(str), null, {base: baseString})
-  return flattened.reduce((store, flatResource) => processResource(store, base, flatResource), kb)
-}
 
-function nodeType(kb, obj) {
-  if (obj['@id'].startsWith('_:')) {
-    // This object is a Blank Node. Pass the id without the `_:` prefix
-    return kb.rdfFactory.blankNode(obj['@id'].substring(2))
-  } else {
-    // This object is a Named Node
-    return kb.rdfFactory.namedNode(obj['@id'])
+  const toRdfOptions = {
+    base: baseString,
+    documentLoader: options.documentLoader || refusingDocumentLoader
   }
-}
-
-function processResource(kb, base, flatResource) {
-  const id = flatResource['@id']
-    ? nodeType(kb, flatResource)
-    : kb.rdfFactory.blankNode()
-
-  for (const property of Object.keys(flatResource)) {
-    if (property === '@id') {
-      continue
-    } else if (property == '@graph') {
-      // the JSON-LD flattened structure may contain nested graphs
-      // the id value for this object is the new base (named graph id) for all nested flat resources
-      const graphId = id
-      // this is an array of resources
-      const nestedFlatResources = flatResource[property]
-
-      // recursively process all flat resources in the array, but with the graphId as base.
-      for (let i = 0; i < nestedFlatResources.length; i++) {
-        kb = processResource(kb, graphId, nestedFlatResources[i])
-      }
-    }
-
-    const value = flatResource[property]
-    if (Array.isArray(value)) {
-      for (let i = 0; i < value.length; i++) {
-        kb.addStatement(createStatement(kb, id, property, value[i], base))
-      }
-    } else {
-      kb.addStatement(createStatement(kb, id, property, value, base))
-    }
+  if (options.expandContext !== undefined) {
+    toRdfOptions.expandContext = options.expandContext
   }
 
+  let dataset
+  try {
+    dataset = await jsonldLib.toRDF(JSON.parse(str), toRdfOptions)
+  } catch (err) {
+    throw unwrapRefusalError(err)
+  }
+
+  const docGraph = kb.rdfFactory.namedNode(baseString)
+  // Fresh blank nodes per parse: never reuse the document's `_:` labels
+  const bnodeMap = new Map()
+
+  let quads = []
+  for (const quad of dataset) {
+    const graph = quad.graph.termType === 'DefaultGraph'
+      ? docGraph
+      : termToRdflibTerm(kb, quad.graph, bnodeMap)
+    quads.push(kb.rdfFactory.quad(
+      termToRdflibTerm(kb, quad.subject, bnodeMap),
+      termToRdflibTerm(kb, quad.predicate, bnodeMap),
+      termToRdflibTerm(kb, quad.object, bnodeMap),
+      graph
+    ))
+  }
+
+  if (kb.rdfFactory.supports['COLLECTIONS'] === true) {
+    quads = foldListChains(kb, quads)
+  }
+
+  for (const quad of quads) {
+    kb.addStatement(quad)
+  }
   return kb
-}
-
-/**
- * Create statement quad depending on @type being a type node
- * @param kb
- * @param subject id
- * @param property
- * @param value
- * @return quad statement
- */
-function createStatement(kb, id, property, value, base) {
-  let predicate, object
-
-  if (property === "@type") {
-    predicate = kb.rdfFactory.namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-    object = kb.rdfFactory.namedNode(value)
-  } else {
-    predicate = kb.rdfFactory.namedNode(property)
-    object = jsonldObjectToTerm(kb, value)
-  }
-  return kb.rdfFactory.quad(id, predicate, object, kb.rdfFactory.namedNode(base))
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,7 +8,7 @@ import RDFParser from './rdfxmlparser'
 import sparqlUpdateParser from './patch-parser'
 import * as Util from './utils-js'
 import Formula from './formula'
-import { ContentType, TurtleContentType, N3ContentType, RDFXMLContentType, XHTMLContentType, HTMLContentType, SPARQLUpdateContentType, SPARQLUpdateSingleMatchContentType, JSONLDContentType, NQuadsContentType, NQuadsAltContentType } from './types'
+import { ContentType, TurtleContentType, N3ContentType, RDFXMLContentType, XHTMLContentType, HTMLContentType, SPARQLUpdateContentType, SPARQLUpdateSingleMatchContentType, JSONLDContentType, NQuadsContentType, NQuadsAltContentType, JsonLdParserOptions } from './types'
 import { Quad } from './tf-types'
 import type { Document as XmldomDocument } from '@xmldom/xmldom'
 
@@ -24,13 +24,17 @@ type CallbackFunc = (error: any, kb: Formula | null) => void
  * @param base - The base URI to use
  * @param contentType - The MIME content type string for the input - defaults to text/turtle
  * @param [callback] - The callback to call when the data has been loaded
+ * @param [options] - Format-specific parse options. For JSON-LD: a
+ *   `documentLoader` to opt in to remote `@context` resolution (refused by
+ *   default to avoid SSRF) and an out-of-band `expandContext`.
  */
 export default function parse (
   str: string,
   kb: Formula,
   base: string,
   contentType: string | ContentType = 'text/turtle',
-  callback?: CallbackFunc
+  callback?: CallbackFunc,
+  options?: JsonLdParserOptions
 ) {
   contentType = contentType || TurtleContentType
   contentType = contentType.split(';')[0] as ContentType
@@ -56,7 +60,7 @@ export default function parse (
       // since we do not await the promise here, rejections will not be covered by the surrounding try catch
       // we do not use await, because parse() should stay sync
       // so, to not lose the async error, we need to catch the rejection and call the error callback here too
-      jsonldParser(str, kb, base)
+      jsonldParser(str, kb, base, options)
           .then(executeCallback)
           .catch(executeErrorCallback)
     } else if (contentType === NQuadsContentType ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,42 @@ export const TurtleLegacyContentType = "application/x-turtle" as const
 export const XHTMLContentType = "application/xhtml+xml" as const
 
 /**
+ * A jsonld.js documentLoader: resolves a (context) URL to a remote document.
+ * See https://github.com/digitalbazaar/jsonld.js#custom-document-loader
+ */
+export type JsonLdDocumentLoader = (
+  url: string,
+  options?: unknown
+) => Promise<{
+  /** The retrieved document, parsed */
+  document: unknown
+  /** The final URL of the document, after redirects */
+  documentUrl?: string
+  /** A context URL found in an HTTP Link header, if any */
+  contextUrl?: string | null
+}>
+
+/**
+ * Options accepted by the JSON-LD parser (and threaded through `parse()` for
+ * `application/ld+json` input).
+ */
+export interface JsonLdParserOptions {
+  /**
+   * Loader used to resolve remote `@context` URLs. When omitted, remote
+   * context fetching is REFUSED: parsing untrusted JSON-LD must not trigger
+   * outbound network requests (SSRF). Pass a loader (e.g. jsonld.js's
+   * `documentLoaders.node()` or one backed by your own fetch policy) to opt
+   * in.
+   */
+  documentLoader?: JsonLdDocumentLoader
+  /**
+   * A context to expand the input document with, for documents whose context
+   * is supplied out-of-band (JSON-LD API `expandContext`).
+   */
+  expandContext?: unknown
+}
+
+/**
  * A valid mime type header
  */
 export type ContentType = typeof RDFXMLContentType

--- a/tests/unit/fetcher-jsonld-test.js
+++ b/tests/unit/fetcher-jsonld-test.js
@@ -142,4 +142,58 @@ SyntaxError: Unexpected token`)
       })
     })
   })
+
+  describe('Given a JSON-LD resource that references a remote @context', () => {
+    const uri = 'http://localhost/remote-context.jsonld'
+
+    beforeEach(() => {
+      const docContents = `
+        {
+            "@context": "https://remote.example/context.jsonld",
+            "@id": "${uri}#it",
+            "name": "value"
+        }
+        `
+      nock('http://localhost').get('/remote-context.jsonld').reply(200, docContents, {
+        'Content-Type': 'application/ld+json',
+      })
+    })
+
+    describe('when it is fetched without a documentLoader', () => {
+      let fetcher, store
+      beforeEach(() => {
+        store = rdf.graph()
+        fetcher = rdf.fetcher(store)
+      })
+
+      it('then the load fails instead of issuing a network request for the context', async () => {
+        try {
+          await fetcher.load(uri)
+          expect.fail('Should have thrown an error')
+        } catch (e) {
+          expect(e.message).to.contain('Refused to fetch remote @context')
+          expect(e.message).to.contain('https://remote.example/context.jsonld')
+        }
+      })
+    })
+
+    describe('when it is fetched with an injected documentLoader', () => {
+      let fetcher, store
+      beforeEach(() => {
+        store = rdf.graph()
+        fetcher = rdf.fetcher(store)
+      })
+
+      it('then the context is resolved through the loader and the triples land in the store', async () => {
+        const documentLoader = async (url) => ({
+          documentUrl: url,
+          document: { '@context': { name: 'http://xmlns.com/foaf/0.1/name' } },
+          contextUrl: null,
+        })
+        await fetcher.load(uri, { documentLoader })
+        const match = store.anyStatementMatching(rdf.sym(uri + '#it'), rdf.sym('http://xmlns.com/foaf/0.1/name'))
+        expect(match.object.value).to.equal('value')
+      })
+    })
+  })
 })

--- a/tests/unit/jsonld-parser-test.js
+++ b/tests/unit/jsonld-parser-test.js
@@ -1,0 +1,500 @@
+import { expect } from 'chai'
+
+import parse from '../../src/parse'
+import jsonldParser from '../../src/jsonldparser'
+import CanonicalDataFactory from '../../src/factories/canonical-data-factory'
+import DataFactory from '../../src/factories/rdflib-data-factory'
+
+const RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+const XSD_NS = 'http://www.w3.org/2001/XMLSchema#'
+const JSONLD_MIME = 'application/ld+json'
+const BASE = 'https://www.example.org/abc/def'
+
+/** A store whose factory supports Collections (the rdflib default) */
+function collectionStore () {
+  return DataFactory.graph()
+}
+
+/** A store without Collection support: lists stay as raw first/rest quads */
+function canonicalStore () {
+  return DataFactory.graph(undefined, { rdfFactory: CanonicalDataFactory })
+}
+
+describe('JSON-LD parser (jsonld.toRDF)', () => {
+  describe('doc-graph placement', () => {
+    it('puts default-graph quads in the document graph named by base', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/subject',
+        'http://example.com/predicate': { '@id': 'http://example.com/object' }
+      }), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].why.termType).to.equal('NamedNode')
+      expect(store.statements[0].why.value).to.equal(BASE)
+    })
+
+    it('accepts a NamedNode as base, like the previous parser', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/subject',
+        'http://example.com/predicate': 'value'
+      }), store, store.sym(BASE))
+
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].why.value).to.equal(BASE)
+    })
+  })
+
+  describe('named graphs (regression: the old walker crashed on @graph)', () => {
+    const doc = {
+      '@id': 'http://example.com/graphs/g1',
+      '@graph': [{
+        '@id': 'http://example.com/a',
+        'http://example.com/p': { '@id': 'http://example.com/b' }
+      }],
+      'http://example.com/meta': 'about the graph'
+    }
+
+    it('parses without throwing and places quads in their named graph', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify(doc), store, BASE)
+
+      expect(store.statements).to.have.length(2)
+
+      const meta = store.statementsMatching(store.sym('http://example.com/graphs/g1'))[0]
+      expect(meta.object.value).to.equal('about the graph')
+      // Top-level statements stay in the doc graph
+      expect(meta.why.value).to.equal(BASE)
+
+      const inner = store.statementsMatching(store.sym('http://example.com/a'))[0]
+      expect(inner.object.value).to.equal('http://example.com/b')
+      // ... while @graph contents get the named graph as `why`
+      expect(inner.why.termType).to.equal('NamedNode')
+      expect(inner.why.value).to.equal('http://example.com/graphs/g1')
+    })
+
+    it('surfaces named-graph docs through parse() with a callback', done => {
+      const store = collectionStore()
+      parse(JSON.stringify(doc), store, BASE, JSONLD_MIME, (err, kb) => {
+        try {
+          expect(err).to.equal(null)
+          expect(kb.statements).to.have.length(2)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      })
+    })
+  })
+
+  describe('@json literals (regression: the old walker crashed on @json)', () => {
+    it('produces a literal with the rdf:JSON datatype', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/config': { '@value': { a: [1, 2] }, '@type': '@json' }
+      }), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      const object = store.statements[0].object
+      expect(object.termType).to.equal('Literal')
+      expect(object.datatype.value).to.equal(RDF_NS + 'JSON')
+      expect(JSON.parse(object.value)).to.deep.equal({ a: [1, 2] })
+    })
+  })
+
+  describe('native JSON values (regression: wrong datatypes before)', () => {
+    let store
+    before(async () => {
+      store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/bool': true,
+        'http://example.com/int': 42,
+        'http://example.com/double': 1.5,
+        'http://example.com/string': 'plain'
+      }), store, BASE)
+    })
+
+    const objectOf = property =>
+      store.statementsMatching(undefined, store.sym('http://example.com/' + property))[0].object
+
+    it('maps true to "true"^^xsd:boolean (canonical lexical form)', () => {
+      const o = objectOf('bool')
+      expect(o.value).to.equal('true')
+      expect(o.datatype.value).to.equal(XSD_NS + 'boolean')
+    })
+
+    it('maps 42 to "42"^^xsd:integer', () => {
+      const o = objectOf('int')
+      expect(o.value).to.equal('42')
+      expect(o.datatype.value).to.equal(XSD_NS + 'integer')
+    })
+
+    it('maps 1.5 to "1.5E0"^^xsd:double (canonical lexical form)', () => {
+      const o = objectOf('double')
+      expect(o.value).to.equal('1.5E0')
+      expect(o.datatype.value).to.equal(XSD_NS + 'double')
+    })
+
+    it('maps JSON strings to xsd:string literals', () => {
+      const o = objectOf('string')
+      expect(o.value).to.equal('plain')
+      expect(o.datatype.value).to.equal(XSD_NS + 'string')
+    })
+
+    it('keeps language-tagged values as language literals', async () => {
+      const langStore = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/label': { '@value': 'Die Königin', '@language': 'de' }
+      }), langStore, BASE)
+      const o = langStore.statements[0].object
+      expect(o.language).to.equal('de')
+      expect(o.value).to.equal('Die Königin')
+    })
+  })
+
+  describe('base IRI handling', () => {
+    it('resolves relative IRIs against the base', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': '../#me',
+        'http://example.com/knows': { '@id': 'other' }
+      }), store, BASE)
+
+      const st = store.statements[0]
+      expect(st.subject.value).to.equal('https://www.example.org/#me')
+      expect(st.object.value).to.equal('https://www.example.org/abc/other')
+    })
+
+    it('resolves relative IRIs against a base that carries a fragment', async () => {
+      const store = collectionStore()
+      const fragmentBase = 'https://www.example.org/dir/doc#frag'
+      await jsonldParser(JSON.stringify({
+        '@id': '#me',
+        'http://example.com/knows': { '@id': 'other' }
+      }), store, fragmentBase)
+
+      const st = store.statements[0]
+      expect(st.subject.value).to.equal('https://www.example.org/dir/doc#me')
+      expect(st.object.value).to.equal('https://www.example.org/dir/other')
+      // The doc graph keeps the base exactly as given (rdflib convention)
+      expect(st.why.value).to.equal(fragmentBase)
+    })
+  })
+
+  describe('blank nodes are fresh per parse (regression: cross-document conflation)', () => {
+    it('never conflates blank nodes from two documents parsed into one store', async () => {
+      const store = collectionStore()
+      // Both docs make jsonld.js emit the label _:b0 internally; the old
+      // walker copied those labels into the store, conflating the two nodes.
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/a',
+        'http://example.com/p': { 'http://example.com/q': 'first doc' }
+      }), store, 'https://www.example.org/doc1')
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/b',
+        'http://example.com/p': { 'http://example.com/q': 'second doc' }
+      }), store, 'https://www.example.org/doc2')
+
+      const inner = store.statementsMatching(undefined, store.sym('http://example.com/q'))
+      expect(inner).to.have.length(2)
+      expect(inner[0].subject.termType).to.equal('BlankNode')
+      expect(inner[1].subject.termType).to.equal('BlankNode')
+      expect(inner[0].subject.value).to.not.equal(inner[1].subject.value)
+    })
+
+    it('keeps blank node identity consistent within one parse', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/a',
+        'http://example.com/p': { 'http://example.com/q': 'inner' }
+      }), store, BASE)
+
+      const outer = store.statementsMatching(store.sym('http://example.com/a'))[0]
+      const inner = store.statementsMatching(undefined, store.sym('http://example.com/q'))[0]
+      expect(outer.object.termType).to.equal('BlankNode')
+      expect(outer.object.value).to.equal(inner.subject.value)
+    })
+  })
+
+  describe('@list handling', () => {
+    const listDoc = {
+      '@context': {
+        list: { '@id': 'https://example.org/ns#listProp', '@container': '@list' }
+      },
+      '@id': 'http://example.com/s',
+      list: ['a', 42, { '@id': 'http://example.com/item' }]
+    }
+
+    it('folds @list into a Collection when the factory supports them', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify(listDoc), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      const collection = store.statements[0].object
+      expect(collection.termType).to.equal('Collection')
+      expect(collection.elements).to.have.length(3)
+      expect(collection.elements[0].value).to.equal('a')
+      expect(collection.elements[1].value).to.equal('42')
+      expect(collection.elements[1].datatype.value).to.equal(XSD_NS + 'integer')
+      expect(collection.elements[2].termType).to.equal('NamedNode')
+      expect(collection.elements[2].value).to.equal('http://example.com/item')
+    })
+
+    it('folds nested @lists into nested Collections', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/list': { '@list': ['a', { '@list': ['x', 'y'] }, 'b'] }
+      }), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      const outer = store.statements[0].object
+      expect(outer.termType).to.equal('Collection')
+      expect(outer.elements).to.have.length(3)
+      expect(outer.elements[0].value).to.equal('a')
+      const nested = outer.elements[1]
+      expect(nested.termType).to.equal('Collection')
+      expect(nested.elements.map(e => e.value)).to.deep.equal(['x', 'y'])
+      expect(outer.elements[2].value).to.equal('b')
+    })
+
+    it('folds an empty @list into an empty Collection', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/list': { '@list': [] }
+      }), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      const collection = store.statements[0].object
+      expect(collection.termType).to.equal('Collection')
+      expect(collection.elements).to.have.length(0)
+    })
+
+    it('emits raw first/rest quads when the factory does not support Collections', async () => {
+      const store = canonicalStore()
+      await jsonldParser(JSON.stringify(listDoc), store, BASE)
+
+      // 3 x (rdf:first + rdf:rest) + the referencing statement
+      expect(store.statements).to.have.length(7)
+      const first = store.statementsMatching(undefined, store.sym(RDF_NS + 'first'))
+      expect(first).to.have.length(3)
+    })
+
+    it('leaves non-well-formed first/rest structures as raw triples', async () => {
+      const store = collectionStore()
+      // A hand-built node that looks list-like but carries an extra property:
+      // folding must not touch it (and must not throw, unlike convertFirstRestNil)
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/s',
+        'http://example.com/almostList': {
+          [RDF_NS + 'first']: 'a',
+          [RDF_NS + 'rest']: { '@id': RDF_NS + 'nil' },
+          'http://example.com/extra': 'not a list'
+        }
+      }), store, BASE)
+
+      const ref = store.statementsMatching(store.sym('http://example.com/s'))[0]
+      expect(ref.object.termType).to.equal('BlankNode')
+      expect(store.statementsMatching(undefined, store.sym(RDF_NS + 'first'))).to.have.length(1)
+      expect(store.statementsMatching(undefined, store.sym('http://example.com/extra'))).to.have.length(1)
+    })
+  })
+
+  describe('remote @context refusal (SSRF protection)', () => {
+    const remoteCtxDoc = JSON.stringify({
+      '@context': 'https://remote.example/context.jsonld',
+      '@id': 'http://example.com/s',
+      name: 'Jane'
+    })
+
+    it('rejects with an error naming the context URL and the opt-in', async () => {
+      const store = collectionStore()
+      try {
+        await jsonldParser(remoteCtxDoc, store, BASE)
+        throw new Error('should have rejected')
+      } catch (err) {
+        expect(err.message).to.contain('Refused to fetch remote @context')
+        expect(err.message).to.contain('https://remote.example/context.jsonld')
+        expect(err.message).to.contain('documentLoader')
+        expect(err.contextUrl).to.equal('https://remote.example/context.jsonld')
+      }
+      expect(store.statements).to.have.length(0)
+    })
+
+    it('surfaces the refusal through parse()\'s error callback', done => {
+      const store = collectionStore()
+      parse(remoteCtxDoc, store, BASE, JSONLD_MIME, (err, kb) => {
+        try {
+          expect(err).to.be.instanceOf(Error)
+          expect(err.message).to.contain('Refused to fetch remote @context')
+          expect(err.message).to.contain('https://remote.example/context.jsonld')
+          expect(kb.statements).to.have.length(0)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      })
+    })
+
+    it('resolves remote contexts when a documentLoader is injected', async () => {
+      const store = collectionStore()
+      const requested = []
+      const documentLoader = async (url) => {
+        requested.push(url)
+        return {
+          documentUrl: url,
+          document: {
+            '@context': {
+              name: 'http://xmlns.com/foaf/0.1/name',
+              link: { '@id': 'http://example.com/link', '@type': '@id' }
+            }
+          },
+          contextUrl: null
+        }
+      }
+
+      // ericprud's integration case 4 (#391): remote context, relative resolution
+      await jsonldParser(JSON.stringify({
+        '@context': 'https://remote.example/context.jsonld',
+        '@id': '#me',
+        name: 'Jane',
+        link: 'other'
+      }), store, BASE, { documentLoader })
+
+      expect(requested).to.deep.equal(['https://remote.example/context.jsonld'])
+      const me = store.sym('https://www.example.org/abc/def#me')
+      const name = store.statementsMatching(me, store.sym('http://xmlns.com/foaf/0.1/name'))[0]
+      expect(name.object.value).to.equal('Jane')
+      const link = store.statementsMatching(me, store.sym('http://example.com/link'))[0]
+      expect(link.object.termType).to.equal('NamedNode')
+      expect(link.object.value).to.equal('https://www.example.org/abc/other')
+    })
+
+    it('threads the documentLoader through parse()', done => {
+      const store = collectionStore()
+      const documentLoader = async (url) => ({
+        documentUrl: url,
+        document: { '@context': { name: 'http://xmlns.com/foaf/0.1/name' } },
+        contextUrl: null
+      })
+      const doc = JSON.stringify({
+        '@context': 'https://remote.example/context.jsonld',
+        '@id': 'http://example.com/s',
+        name: 'Jane'
+      })
+      parse(doc, store, BASE, JSONLD_MIME, (err, kb) => {
+        try {
+          expect(err).to.equal(null)
+          const name = kb.statementsMatching(undefined, kb.sym('http://xmlns.com/foaf/0.1/name'))[0]
+          expect(name.object.value).to.equal('Jane')
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }, { documentLoader })
+    })
+  })
+
+  describe('#391 integration cases (ericprud)', () => {
+    it('1. embedded @context', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@context': { name: 'http://xmlns.com/foaf/0.1/name' },
+        '@id': 'http://example.com/jane',
+        name: 'Jane Doe'
+      }), store, BASE)
+
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
+      expect(store.statements[0].object.value).to.equal('Jane Doe')
+    })
+
+    it('2. api-supplied context (options.expandContext)', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'http://example.com/jane',
+        name: 'Jane Doe'
+      }), store, BASE, {
+        expandContext: { name: 'http://xmlns.com/foaf/0.1/name' }
+      })
+
+      expect(store.statements).to.have.length(1)
+      expect(store.statements[0].predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
+      expect(store.statements[0].object.value).to.equal('Jane Doe')
+    })
+
+    it('3. api-supplied base', async () => {
+      const store = collectionStore()
+      await jsonldParser(JSON.stringify({
+        '@id': 'jane',
+        'http://xmlns.com/foaf/0.1/name': 'Jane Doe'
+      }), store, 'https://base.example/dir/')
+
+      expect(store.statements[0].subject.value).to.equal('https://base.example/dir/jane')
+    })
+
+    // 4. remote context with relative resolution: covered in the
+    // 'remote @context refusal' block above (injected documentLoader case)
+  })
+
+  describe('error shapes', () => {
+    it('rejects on invalid JSON with the JSON.parse error', async () => {
+      const store = collectionStore()
+      try {
+        await jsonldParser('this is not JSON', store, BASE)
+        throw new Error('should have rejected')
+      } catch (err) {
+        expect(err.message).to.contain('Unexpected token')
+      }
+    })
+
+    it('rejects on valid JSON that is invalid JSON-LD', async () => {
+      const store = collectionStore()
+      try {
+        await jsonldParser(JSON.stringify({ '@id': 5 }), store, BASE)
+        throw new Error('should have rejected')
+      } catch (err) {
+        expect(err.message).to.contain('Invalid JSON-LD syntax')
+      }
+    })
+  })
+
+  describe('parse() API compatibility', () => {
+    const doc = JSON.stringify({
+      '@id': 'http://example.com/s',
+      'http://example.com/p': 'value'
+    })
+
+    it('works with a callback', done => {
+      const store = collectionStore()
+      parse(doc, store, BASE, JSONLD_MIME, (err, kb) => {
+        try {
+          expect(err).to.equal(null)
+          expect(kb.statements).to.have.length(1)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      })
+    })
+
+    it('works without a callback (fills the store asynchronously)', async () => {
+      const store = collectionStore()
+      parse(doc, store, BASE, JSONLD_MIME)
+      // parse() stays sync for JSON-LD; completion is only observable async
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(store.statements).to.have.length(1)
+    })
+
+    it('jsonldParser resolves to the store', async () => {
+      const store = collectionStore()
+      const result = await jsonldParser(doc, store, BASE)
+      expect(result).to.equal(store)
+    })
+  })
+})

--- a/tests/unit/jsonld-parser-test.js
+++ b/tests/unit/jsonld-parser-test.js
@@ -188,8 +188,8 @@ describe('JSON-LD parser (jsonld.toRDF)', () => {
   describe('blank nodes are fresh per parse (regression: cross-document conflation)', () => {
     it('never conflates blank nodes from two documents parsed into one store', async () => {
       const store = collectionStore()
-      // Both docs make jsonld.js emit the label _:b0 internally; the old
-      // walker copied those labels into the store, conflating the two nodes.
+      // Both docs make jsonld.js emit the label _:b0 internally; the label
+      // must not be copied into the store verbatim
       await jsonldParser(JSON.stringify({
         '@id': 'http://example.com/a',
         'http://example.com/p': { 'http://example.com/q': 'first doc' }

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -261,73 +261,41 @@ ex:myid ex:prop1 [ ex:prop2 [ ex:prop3 "value" ] ].
       }) // before
 
       it('uses the specified base IRI', () => {
+        // Statement *insertion order* is an implementation detail of the
+        // parser (jsonld.toRDF emits node-map-sorted quads), so this test
+        // matches by pattern rather than by array index.
         expect(store.rdfFactory.supports["COLLECTIONS"]).to.equal(false)
 
         const homePageHeight = 5 // homepage + height + 3 x name
         const list = 2 * 3 + 1 // (rdf:first + rdf:rest) * 3 items + listProp
         expect(store.statements).to.have.length(homePageHeight + list)
 
-        const height = store.statements[0]
-        expect(height.subject.value).to.equal('https://www.example.org/#me')
-        expect(height.predicate.value).to.equal('http://schema.org/height')
+        const me = store.sym('https://www.example.org/#me')
+
+        const height = store.statementsMatching(me, store.sym('http://schema.org/height'))[0]
         expect(height.object.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#float')
         expect(height.object.termType).to.equal('Literal')
         expect(height.object.value).to.equal('173.9')
 
-        const homepage = store.statements[1]
-        expect(homepage.subject.value).to.equal('https://www.example.org/#me')
-        expect(homepage.predicate.value).to.equal('http://xmlns.com/foaf/0.1/homepage')
+        const homepage = store.statementsMatching(me, store.sym('http://xmlns.com/foaf/0.1/homepage'))[0]
         expect(homepage.object.value).to.equal('https://www.example.org/abc/xyz')
 
-        const nameDe1 = store.statements[2]
-        expect(nameDe1.subject.value).to.equal('https://www.example.org/#me')
-        expect(nameDe1.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
-        expect(nameDe1.object.value).to.equal('Die Königin')
+        const names = store.statementsMatching(me, store.sym('http://xmlns.com/foaf/0.1/name'))
+          .map(st => st.object.value).sort()
+        expect(names).to.eql(['Die Königin', 'Ihre Majestät', 'The Queen'])
 
-        const nameDe2 = store.statements[3]
-        expect(nameDe2.subject.value).to.equal('https://www.example.org/#me')
-        expect(nameDe2.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
-        expect(nameDe2.object.value).to.equal('Ihre Majestät')
-
-        const nameEn = store.statements[4]
-        expect(nameEn.subject.value).to.equal('https://www.example.org/#me')
-        expect(nameEn.predicate.value).to.equal('http://xmlns.com/foaf/0.1/name')
-        expect(nameEn.object.value).to.equal('The Queen')
-
-        const list0First = store.statements[5]
-        // expect(list0First.subject.value).to.equal('n0')
-        expect(list0First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
-        expect(list0First.object.value).to.equal('list item 0')
-
-        const list0Rest = store.statements[6]
-        expect(list0Rest.subject.termType).to.equal('BlankNode')
-        expect(list0Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
-        expect(list0Rest.object.value).to.equal(store.statements[7].subject.value)
-
-        const list1First = store.statements[7]
-        expect(list1First.subject.termType).to.equal('BlankNode')
-        expect(list1First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
-        expect(list1First.object.value).to.equal('list item 1')
-
-        const list1Rest = store.statements[8]
-        expect(list1Rest.subject.termType).to.eql('BlankNode')
-        expect(list1Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
-        expect(list1Rest.object.value).to.equal(store.statements[9].subject.value)
-
-        const list2First = store.statements[9]
-        expect(list2First.subject.termType).to.eql('BlankNode')
-        expect(list2First.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#first')
-        expect(list2First.object.value).to.equal('list item 2')
-
-        const list2Rest = store.statements[10]
-        expect(list2Rest.subject.termType).to.eql('BlankNode')
-        expect(list2Rest.predicate.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest')
-        expect(list2Rest.object.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')
-
-        const listProp = store.statements[11]
-        expect(listProp.subject.value).to.equal('https://www.example.org/#me')
-        expect(listProp.predicate.value).to.equal('https://example.org/ns#listProp')
-        expect(listProp.object.termType).to.eql('BlankNode')
+        // Walk the raw rdf:first/rdf:rest chain from the list property
+        const listProp = store.statementsMatching(me, store.sym('https://example.org/ns#listProp'))[0]
+        let node = listProp.object
+        const items = []
+        for (let i = 0; i < 3; i++) {
+          expect(node.termType).to.equal('BlankNode')
+          const first = store.statementsMatching(node, store.sym('http://www.w3.org/1999/02/22-rdf-syntax-ns#first'))[0]
+          items.push(first.object.value)
+          node = store.statementsMatching(node, store.sym('http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'))[0].object
+        }
+        expect(items).to.eql(['list item 0', 'list item 1', 'list item 2'])
+        expect(node.value).to.equal('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil')
     })
 
     describe('with collections enabled', () => {
@@ -443,10 +411,16 @@ ex:myid ex:prop1 [ ex:prop2 [ ex:prop3 "value" ] ].
 exa:myid exa:prop1 [ exa:prop2 [ exa:prop3 "value" ] ].
 
 `)
-        const nt = store.toNT()
-        expect(nt).to.include('<http://example.com#myid> <http://example.com#prop1> _:b0 .')
-        expect(nt).to.include('_:b0 <http://example.com#prop2> _:b1 .')
-        expect(nt).to.include('_:b1 <http://example.com#prop3> "value" .')
+        // Blank node labels are allocated fresh per parse (so labels of two
+        // documents can never collide in one store); match by structure, not
+        // by label
+        const prop1 = store.statementsMatching(store.sym('http://example.com#myid'), store.sym('http://example.com#prop1'))[0]
+        expect(prop1.object.termType).to.equal('BlankNode')
+        const prop2 = store.statementsMatching(prop1.object, store.sym('http://example.com#prop2'))[0]
+        expect(prop2.object.termType).to.equal('BlankNode')
+        expect(prop2.object.value).to.not.equal(prop1.object.value)
+        const prop3 = store.statementsMatching(prop2.object, store.sym('http://example.com#prop3'))[0]
+        expect(prop3.object.value).to.equal('value')
       })
     })
 

--- a/tests/unit/serialize-test.js
+++ b/tests/unit/serialize-test.js
@@ -362,6 +362,13 @@ vocab:building1 vocab:created "2012-03-12"^^xsd:date; vocab:length 145000.0e0 .
     })
 
     describe('source jsonld', () => {
+      // The JSON-LD parser (jsonld.toRDF) canonicalizes xsd:double lexical
+      // forms per the W3C JSON-LD 1.1 "Object to RDF Conversion" algorithm,
+      // so a non-canonical double lexical in a JSON-LD source document is
+      // stored canonically: "145000.0e0" -> "1.45E5"
+      const ttl0Parsed = ttl0.replace('145000.0e0', '1.45E5')
+      const jsonld0Parsed = jsonld0.replace('"145000.0e0"', '"1.45E5"')
+
       let store, base
       before(done => {
         base = 'https://www.example.org/abc/def'
@@ -378,11 +385,11 @@ vocab:building1 vocab:created "2012-03-12"^^xsd:date; vocab:length 145000.0e0 .
 
       it('serialize to ttl', () => {
         // console.log(serialize(null, store, base, 'text/turtle'))
-        expect(serialize(null, store, base, 'text/turtle')).to.eql(ttl0)
+        expect(serialize(null, store, base, 'text/turtle')).to.eql(ttl0Parsed)
       })
       it('serialize to jsonld', async () => {
         // console.log(serialize(null, store, base, 'application/ld+json'))
-        expect(await serialize(null, store, null, 'application/ld+json')).to.eql(jsonld0)
+        expect(await serialize(null, store, null, 'application/ld+json')).to.eql(jsonld0Parsed)
       })
     })
   })
@@ -486,6 +493,13 @@ vocab:building1 vocab:created "2012-03-12"^^xsd:date; vocab:length 145000.0e0 .
     })
 
     describe('source jsonld', () => {
+      // The JSON-LD parser (jsonld.toRDF) canonicalizes xsd:double lexical
+      // forms per the W3C JSON-LD 1.1 "Object to RDF Conversion" algorithm,
+      // so a non-canonical double lexical in a JSON-LD source document is
+      // stored canonically: "3.141e0" -> "3.141E0"
+      const ttl1Parsed = ttl1.replace('3.141e0', '3.141E0')
+      const jsonld1Parsed = jsonld1('def').replace('"3.141e0"', '"3.141E0"')
+
       let store, base
       before(done => {
         base = 'https://www.example.org/abc/def'
@@ -500,11 +514,11 @@ vocab:building1 vocab:created "2012-03-12"^^xsd:date; vocab:length 145000.0e0 .
       })
 
       it('serialize to ttl', () => {
-        expect(serialize(null, store, base, 'text/turtle')).to.eql(ttl1)
+        expect(serialize(null, store, base, 'text/turtle')).to.eql(ttl1Parsed)
       })
 
       it('serialize to jsonld', async () => {
-          expect(await serialize(null, store, base, 'application/ld+json')).to.eql(jsonld1('def'))
+          expect(await serialize(null, store, base, 'application/ld+json')).to.eql(jsonld1Parsed)
       })
     })
   })


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review, from the backlog-triage programme (#823 / #824). The flagged behaviour deltas below (especially 5 and 6) need his sign-off; nothing is final.

## Summary

This PR deletes the bespoke JSON-LD parse walker (a hand-rolled traversal of `jsonld.flatten()` output) and rebuilds `src/jsonldparser.js` on **`jsonld.toRDF()`** — the W3C JSON-LD 1.1 *Deserialize JSON-LD to RDF* algorithm from the **already-installed** `jsonld@^9` dependency. No new runtime dependencies; no bundle-size change (the dynamic `await import('jsonld')` + `jsonld.default || jsonld` browser-ESM dance is preserved verbatim).

The module keeps its public shape: `export default async function jsonldParser(str, kb, base)` — with one **additive** optional `options` argument (`{ documentLoader, expandContext }`) that is also threaded through `parse()` (new optional 6th parameter) and the Fetcher's JSON-LD handler (`options.documentLoader` on load options).

### Design

- `jsonld.toRDF(JSON.parse(str), { base, documentLoader, expandContext? })` produces abstract RDF/JS-style quads; a small adapter maps them onto rdflib terms via `kb.rdfFactory` and adds them with `kb.addStatement()`.
- **Doc-graph placement matches rdflib conventions**: default-graph quads get `why` = `kb.rdfFactory.namedNode(base)` (exactly as before); quads inside `@graph` get that named graph as `why`.
- **Blank nodes are fresh per parse**: a per-parse label→`blankNode()` map replaces the old pass-through of the document's `_:` labels, so two documents parsed into one store can never conflate blank nodes again.
- **`@list` → `Collection` folding is preserved**: when `kb.rdfFactory.supports["COLLECTIONS"]` is true, well-formed `rdf:first`/`rdf:rest` chains emitted by `toRDF` are folded back into rdflib `Collection` terms (nested and empty lists included), mirroring the Turtle path's idiom in `src/lists.ts` — but scoped to *this parse's quads only* and non-throwing: non-well-formed chains stay as raw triples. Downstream reliance on `Collection.elements` keeps working.
- Downstream contract untouched: `parse()` callback semantics, fetcher metadata-graph statement shapes, and `Collection.elements` are all preserved.

## SSRF surface removal

Until now, parsing attacker-controlled JSON-LD through rdflib invoked jsonld.js's **platform-default document loader** to dereference remote `@context` URLs — arbitrary outbound HTTP(S) requests from the process doing the parsing, bypassing rdflib's Fetcher entirely: a server-side request forgery surface for any service that parses untrusted JSON-LD through rdflib (NSS-style servers do), with no injection hook and no offline mode.

This PR **removes that SSRF surface: `parse()` no longer issues network requests for remote `@context` URLs unless a `documentLoader` is explicitly injected.** The new default loader refuses with an actionable error that names the context URL and points at the opt-in:

```
Refused to fetch remote @context <https://…/context.jsonld>: rdflib.js disables remote
JSON-LD context fetching by default, … To opt in, pass an explicit `documentLoader` …
```

Opt-in paths (all additive): `jsonldParser(str, kb, base, { documentLoader })`, `parse(str, kb, base, contentType, callback, { documentLoader })`, and `fetcher.load(uri, { documentLoader })`. The refusal surfaces through `parse()`'s error callback and through `Fetcher`'s `failFetch` path, both covered by tests.

## Behavior deltas

| # | Delta | Before (flatten-walker) | After (`jsonld.toRDF`) | Why acceptable |
|---|-------|-------------------------|------------------------|----------------|
| 1 | Named-graph documents (`@graph`) | **Crash**: `NamedNode IRI "@graph" must be absolute` — document unparseable | Parses; `@graph` contents get the named graph as `why`, top-level quads stay in the doc graph | Fixes a verified defect (regression-tested) |
| 2 | `@json` literals | **Crash** (`namedNode("@json")`) | Literal typed `rdf:JSON` | Fixes a verified defect |
| 3 | Native JSON booleans | `true` → `"1"^^xsd:boolean` | `"true"^^xsd:boolean` (canonical) | Spec-correct; same direction as #831's move to spec-mandated lexical forms |
| 4 | Native JSON non-integer numbers | `1.5` → `"1.5"^^xsd:decimal` (wrong datatype) | `"1.5E0"^^xsd:double` (spec datatype + canonical lexical) | Spec-correct; same direction as #831. Native integers are unchanged (`42` → `"42"^^xsd:integer`) |
| 5 | String values explicitly typed `xsd:double` | Lexical form preserved (`"3.141e0"`) | Canonicalized (`"3.141E0"`) — mandated by the W3C *Object to RDF Conversion* algorithm | **FLAGGED**: lexical change for non-canonical doubles in JSON-LD sources; two round-trip expectations in `tests/unit/serialize-test.js` updated accordingly (the `tests/serialize` golden refs are untouched). Other datatypes (`xsd:decimal`, `xsd:integer`, `xsd:boolean` as strings) keep their lexical forms |
| 6 | Remote `@context` URLs | Silently dereferenced over the network (SSRF) | **Refused by default** with a clear error; opt-in via injected `documentLoader` | **FLAGGED (breaking-ish)**: documents relying on remote contexts now error by default instead of silently fetching. This is the security point of the PR |
| 7 | Blank node labels | Document's `_:b0`-style labels copied into the store → cross-document conflation (data corruption) | Fresh store-allocated labels per parse | Fixes a verified defect; only raw label *strings* change, structure is identical (tests updated to match by structure) |
| 8 | Statement insertion order | `flatten()` output order | `toRDF` node-map-sorted order | Insertion order was never a documented contract; order-dependent tests rewritten to pattern matching |
| 9 | Empty `@list` / lone `rdf:nil` objects | `{"@list": []}` → empty `Collection`; `{"@id": "rdf:nil"}` → NamedNode | Any lone `rdf:nil` object (not under `rdf:rest`, COLLECTIONS mode) → empty `Collection` | `toRDF` emits `rdf:nil` for both, so they can no longer be distinguished; matches the Turtle path's `substituteNillsInDoc` behavior |
| 10 | Relative IRIs that cannot be resolved | Throw from the `NamedNode` constructor | Dropped silently (spec behavior) | Edge case; spec-mandated |
| 11 | Module-internal named exports (`jsonldObjectToTerm`) | Exported from `src/jsonldparser.js` | Removed with the walker | Never re-exported from the package index; not part of the public API |
| 12 | Error shapes for invalid JSON-LD | Walker/`NamedNode` constructor errors | jsonld.js `JsonLdError`s (e.g. `Invalid JSON-LD syntax; "@id" value must a string.`) | Invalid *JSON* still surfaces the familiar `JSON.parse` `SyntaxError` (existing tests unchanged); JSON-LD-level errors are now precise and spec-sourced |

## Ecosystem backward-compatibility (SolidOS / NSS / solid-panes / mashlib)

- **Only `application/ld+json` parsing changes.** Turtle/N3/RDFa/XML paths and the serializer are untouched; every `tests/serialize` golden ref passes unchanged.
- **The one delta consumers are likely to hit in the wild is 6**: a JSON-LD document whose `@context` is a remote URL now fails to parse — with an error naming the URL and the opt-in — instead of silently fetching it. Documents with inline contexts are unaffected. The opt-in (`documentLoader`) is available at every level: `jsonldParser`, `parse()`, and `fetcher.load()`.
- Deltas 5/7/8 change literal lexical forms (non-canonical `xsd:double` from JSON-LD sources only), blank-node label *strings*, and insertion order. None of these were documented contracts, but code matching on exact labels or statement order would notice.
- The API surface is purely additive (the optional `options` parameter); the only removed export is the module-internal `jsonldObjectToTerm` (delta 11), which was never re-exported from the package index.
- Semver: at least `release-minor` for the additive API; delta 6's default-behaviour change is the argument for treating it as major — maintainer's call on the label.

## W3C conformance

rdflib runs **zero** JSON-LD conformance tests today (#391). With this change, toRdf behavior is **inherited from jsonld.js's upstream W3C JSON-LD 1.1 test-suite CI** (digitalbazaar runs the official toRdf manifests) instead of a hand-rolled walker that was verifiably non-conformant on named graphs, `@json`, native datatypes, and blank-node handling. Locally, this PR adds the four integration cases @ericprud proposed in #391 (embedded `@context`, API-supplied context via `expandContext`, API-supplied base, remote context with relative IRI resolution) rather than mechanically importing the full suite.

## Tests

New file `tests/unit/jsonld-parser-test.js` (33 new tests overall) covering: doc-graph placement (string and NamedNode base), named graphs (regression for the crash, incl. through `parse()`'s callback), `@json` → `rdf:JSON`, native datatypes (boolean/integer/double/string/lang-tagged), relative-IRI resolution against base and against a base **with a fragment**, per-parse blank-node freshness (cross-document non-conflation + within-parse identity), `@list` → `Collection` (elements + datatypes), nested lists → nested Collections, empty list → empty Collection, raw first/rest chains under `CanonicalDataFactory`, non-well-formed chains staying raw (non-throwing), remote-context refusal (error message, `contextUrl`, via promise and via `parse()` error callback, empty store), injected `documentLoader` (incl. ericprud case 4 and threading through `parse()`), ericprud cases 1–3, invalid-JSON and invalid-JSON-LD error shapes, and callback/promise API compatibility.

`tests/unit/fetcher-jsonld-test.js`: kept green as-is, extended with two fetcher-level tests — remote-context document fails the load with the refusal message (no outbound request), injected `documentLoader` via `fetcher.load(uri, { documentLoader })` succeeds.

Updated with tabled justification: `tests/unit/parse-test.js` (deltas 7/8: index-based assertions → pattern-based; blank-node labels matched by structure) and `tests/unit/serialize-test.js` (delta 5: the two *source jsonld* round-trip blocks now expect canonical `xsd:double` lexicals; the *source ttl* golden blocks are untouched).

**Full suite**: `test:unit` 341 passing (308 on `main` + 33 new) · `test:serialize` green with zero golden-ref diffs, incl. t16's JSON-LD output (serializer untouched) · `test:types` green · `lint` 0 errors (5 pre-existing warnings in untouched files).

## LOC

- `src/`: **+327 / −107** across 4 files. The 144-line walker is fully deleted; its replacement is ~130 lines of `toRDF` adapter + ~120 lines of documented Collection-folding (the rest of the src delta is the additive `options` typing in `types.ts`/`parse.ts`/`fetcher.ts`).
- Overall: +932 / −170 (the bulk is the new 500-line test file).

## Issue closures

Closes #391.

Completes the JSON-LD half of #349 and the JSON-LD instance of #405 (both umbrella issues remain open for their other formats).

## Follow-up: JSON-LD serializer (#593)

Deliberately **not** bundled here. The natural counterpart of this PR is to replace the Turtle→`@frogcat/ttl2jsonld` serializer detour with `jsonld.fromRDF()` + `jsonld.compact()`, which would emit `@list` for Collections (the #593 ask) and drop the ttl2jsonld dependency — but it forces golden-output design decisions (the `tests/serialize` t16 byte-golden and the compaction-context/prefix-selection policy) that deserve their own focused review rather than riding a parser PR. Plan: `fromRDF` over the store's doc-graph quads (unfolding Collections to first/rest for the algorithm), then `compact` against a context assembled from the store's prefix map; golden updates reviewed as their own delta set.

## Merge-order note

No conflict with #831 (Turtle/N3 only). #836 touches neighbouring lines in `parse.ts`'s import block and moves `utils.ts` → `utils/index.ts`; this PR's rewritten `jsonldparser.js` no longer imports `./utils` at all, so the two merge cleanly in either order.

