### PR TITLE
feat: replace the hand-rolled RDF/XML parser with rdfxml-streaming-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cross-fetch": "^4.1.0",
         "jsonld": "^9.0.0",
         "n3": "^2.0.3",
+        "rdfxml-streaming-parser": "^3.2.0",
         "solid-namespace": "^0.5.4"
       },
       "devDependencies": {
@@ -2329,6 +2330,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -2617,6 +2630,15 @@
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
@@ -7211,14 +7233,49 @@
         "node": ">=18"
       }
     },
+    "node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-SgQGK0EkbXd0jQ1PZk7dEpfDxf4CZpezkO6cTuGWesa9twdWaaW5elMoNBcbMT+2tOZC1EYZjs0JaXx0HnifcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^4.0.18",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^2.0.2",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
     "node_modules/readable-stream": {
-      "version": "4.3.0",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -7297,6 +7354,16 @@
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.8.tgz",
+      "integrity": "sha512-U1TmhrhCmXKkDL9mI8gBbF5TN6TKcuv28k5+H3gMCAjoz0TyyHAICHlaGDZsTEBSu2Y3HhDKc8e6X9n33qeIqA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/require-directory": {
@@ -7515,7 +7582,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8115,7 +8181,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -8699,6 +8764,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -9205,6 +9276,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cross-fetch": "^4.1.0",
     "jsonld": "^9.0.0",
     "n3": "^2.0.3",
+    "rdfxml-streaming-parser": "^3.2.0",
     "solid-namespace": "^0.5.4"
   },
   "devDependencies": {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -233,9 +233,7 @@ class RDFXMLHandler extends Handler {
   ): Promise<ExtendedResponse | FetchError> {
     let kb = fetcher.store
     try {
-      // rdfxml-streaming-parser is asynchronous — awaited here so that
-      // fetcher.load() only settles once the store is populated, the same
-      // pattern as the JSON-LD handler below.
+      // Awaited so fetcher.load() only settles once the store is populated
       await parseRDFXML(responseText as string, kb, options.original.value)
     } catch (err) {
       return fetcher.failFetch(options, 'Syntax error parsing RDF/XML! ' + err,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -32,7 +32,7 @@ import RDFlibNamedNode from './named-node'
 import Namespace from './namespace'
 import rdfParse from './parse'
 import { parseRDFaDOM } from './rdfaparser'
-import RDFParser from './rdfxmlparser'
+import parseRDFXML from './rdfxml-adapter'
 import * as Uri from './uri'
 import { isCollection, isNamedNode} from './utils/terms'
 import * as Util from './utils-js'
@@ -221,7 +221,7 @@ class RDFXMLHandler extends Handler {
     }
   }
 
-  parse (
+  async parse (
     fetcher: Fetcher,
     /** An XML String */
     responseText: String,
@@ -230,20 +230,13 @@ class RDFXMLHandler extends Handler {
       original: Quad_Subject
       req: Quad_Subject
     } & Options,
-  ) {
+  ): Promise<ExtendedResponse | FetchError> {
     let kb = fetcher.store
-    if (!this.dom) {
-      this.dom = Util.parseXML(responseText) as unknown as XmldomDocument
-    }
-    let root = this.dom.documentElement
-    if (root && root.nodeName === 'parsererror') { // Mozilla only See issue/issue110
-      // have to fail the request
-      return fetcher.failFetch(options, 'Badly formed XML in ' +
-        options.resource!.value, 'parse_error')
-    }
-    let parser = new RDFParser(kb)
     try {
-      parser.parse(this.dom, options.original.value, options.original)
+      // rdfxml-streaming-parser is asynchronous — awaited here so that
+      // fetcher.load() only settles once the store is populated, the same
+      // pattern as the JSON-LD handler below.
+      await parseRDFXML(responseText as string, kb, options.original.value)
     } catch (err) {
       return fetcher.failFetch(options, 'Syntax error parsing RDF/XML! ' + err,
         'parse_error')
@@ -359,7 +352,7 @@ class XMLHandler extends Handler {
       req: BlankNode
       resource: Quad_Subject
     } & Options,
-  ): ExtendedResponse | Promise<FetchError> {
+  ): ExtendedResponse | Promise<ExtendedResponse | FetchError> {
     let dom = Util.parseXML(responseText) as unknown as XmldomDocument
 
     // XML Semantics defined by root element namespace
@@ -543,7 +536,7 @@ class TextHandler extends Handler {
       original: Quad_Subject
       resource: Quad_Subject
     } & Options
-  ): ExtendedResponse | Promise<FetchError> {
+  ): ExtendedResponse | Promise<ExtendedResponse | FetchError> {
     // We only speak dialects of XML right now. Is this XML?
 
     // Look for an XML declaration

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -41,9 +41,8 @@ export default function parse (
       p.loadBuf(str)
       executeCallback()
     } else if (contentType === RDFXMLContentType) {
-      // rdfxml-streaming-parser is asynchronous: the promise is routed into
-      // the callback, exactly like the JSON-LD branch below. Callers that
-      // read the store synchronously after parse() must move to the callback.
+      // RDF/XML parsing is asynchronous, like the JSON-LD branch below:
+      // completion is only observable through the callback
       parseRDFXML(str, kb, base)
           .then(executeCallback)
           .catch(executeErrorCallback)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,7 +4,7 @@ import jsonldParser from './jsonldparser'
 import { Parser as N3jsParser } from 'n3'  // @@ Goal: remove this dependency
 import N3Parser from './n3parser'
 import { parseRDFaDOM } from './rdfaparser'
-import RDFParser from './rdfxmlparser'
+import parseRDFXML from './rdfxml-adapter'
 import sparqlUpdateParser from './patch-parser'
 import * as Util from './utils-js'
 import Formula from './formula'
@@ -17,8 +17,9 @@ type CallbackFunc = (error: any, kb: Formula | null) => void
 /**
  * Parse a string and put the result into the graph kb.
  * Normal method is sync.
- * Unfortunately jsdonld is currently written to need to be called async.
- * If you are parsing JSON-LD and want to know when and whether it succeeded, you need to use the callback param.
+ * The JSON-LD and RDF/XML parsers are asynchronous: parse() returns before
+ * the store is populated. If you are parsing JSON-LD or RDF/XML and want to
+ * know when and whether it succeeded, you need to use the callback param.
  * @param str - The input string to parse
  * @param kb - The store to use
  * @param base - The base URI to use
@@ -40,9 +41,12 @@ export default function parse (
       p.loadBuf(str)
       executeCallback()
     } else if (contentType === RDFXMLContentType) {
-      var parser = new RDFParser(kb)
-      parser.parse(Util.parseXML(str) as unknown as XmldomDocument, base, kb.sym(base))
-      executeCallback()
+      // rdfxml-streaming-parser is asynchronous: the promise is routed into
+      // the callback, exactly like the JSON-LD branch below. Callers that
+      // read the store synchronously after parse() must move to the callback.
+      parseRDFXML(str, kb, base)
+          .then(executeCallback)
+          .catch(executeErrorCallback)
     } else if (contentType === XHTMLContentType) {
       parseRDFaDOM(Util.parseXML(str, {contentType: XHTMLContentType}) as unknown as XmldomDocument, kb, base)
       executeCallback()

--- a/src/rdfxml-adapter.ts
+++ b/src/rdfxml-adapter.ts
@@ -1,28 +1,17 @@
 /**
- * Adapter between rdfxml-streaming-parser and rdflib's data model.
+ * Adapter between rdfxml-streaming-parser and rdflib's data model:
  *
- * The whole document string is fed into the streaming parser and the
- * resulting quads are loaded into the store, replicating the behaviour of
- * the retired hand-rolled DOM-walking parser (src/rdfxmlparser.js):
- *
- *  - every statement is attributed to the document graph `kb.sym(base)`
- *    (RDF/XML has no named-graph syntax; this is rdflib's provenance
- *    convention, matching the old `parse(dom, base, kb.sym(base))` call);
- *  - blank nodes are fresh per parse: document `rdf:nodeID` labels are
- *    preserved inside a per-parse-unique scope (`rxN_<label>`), so the same
- *    nodeID unifies within one document (and remains recognisable — issue
- *    #751) while two documents using the same nodeID can never collide in
- *    one store (the old parser's uniqueness semantics);
- *  - `rdf:parseType="Collection"` chains (which the streaming parser emits
- *    as standard rdf:first/rdf:rest/rdf:nil triples) are folded back into
- *    live rdflib `Collection` terms when the store's data factory supports
- *    them, so downstream `Collection.elements` consumers keep working —
- *    same folding idiom as src/lists.ts;
+ *  - statements are attributed to the document graph `kb.sym(base)`
+ *    (rdflib's provenance convention);
+ *  - `rdf:nodeID` labels are scoped per parse (`rxN_<label>`), so a nodeID
+ *    unifies within one document (issue #751) but two documents using the
+ *    same nodeID can never collide in one store;
+ *  - `rdf:parseType="Collection"` chains are folded back into rdflib
+ *    `Collection` terms when the data factory supports them;
  *  - `xmlns:` prefix declarations are harvested into the store's prefix
- *    table (`setPrefixForURI`), feeding the serializer, as before;
- *  - the old parser's leniencies are kept: duplicate `rdf:ID` values are
- *    tolerated (`allowDuplicateRdfIds`) and IRIs are not validated
- *    (`validateUri: false`).
+ *    table, feeding the serializer;
+ *  - duplicate `rdf:ID` values are tolerated and IRIs are not validated,
+ *    keeping the leniency of the parser this replaces.
  */
 import { RdfXmlParser } from 'rdfxml-streaming-parser'
 import BlankNode from './blank-node'
@@ -93,9 +82,8 @@ export default function parseRDFXML (str: string, kb: Formula, base: string): Pr
       baseIRI: base,
       dataFactory: dataFactory as any,
       defaultGraph: docGraph,
-      // The old parser tolerated duplicate rdf:ID values — keep tolerating.
+      // Keep tolerating duplicate rdf:ID values and lax IRIs
       allowDuplicateRdfIds: true,
-      // The old parser never validated IRIs — keep accepting lax IRIs.
       validateUri: false,
     })
 
@@ -110,12 +98,10 @@ export default function parseRDFXML (str: string, kb: Formula, base: string): Pr
     parser.on('error', fail)
     parser.on('end', () => {
       if (settled) return
-      // Upstream RdfXmlParser never closes its saxes parser at end of
-      // stream, so a truncated document (unclosed tags at EOF) would be
-      // silently accepted. The old xmldom-based path raised
-      // "unclosed xml tag(s)" — closing saxes here keeps that behavior:
-      // saxes validates its end-of-document state and reports unclosed
-      // tags through the parser's regular error path.
+      // RdfXmlParser never closes its saxes parser at end of stream, so a
+      // truncated document (unclosed tags at EOF) would be silently
+      // accepted; closing saxes makes it report unclosed tags through the
+      // parser's regular error path.
       try {
         (parser as any).saxParser.close()
       } catch (e) {
@@ -140,9 +126,8 @@ export default function parseRDFXML (str: string, kb: Formula, base: string): Pr
 }
 
 /**
- * Register `xmlns:` prefix declarations into the store's prefix table, as
- * the old parser did (it fed the serializer's prefix selection). Harvested
- * textually since the streaming parser exposes no namespace events.
+ * Register `xmlns:` prefix declarations into the store's prefix table.
+ * Harvested textually since the streaming parser exposes no namespace events.
  */
 function harvestPrefixes (str: string, kb: Formula, base: string): void {
   const setPrefix = (kb as any).setPrefixForURI
@@ -162,12 +147,9 @@ function harvestPrefixes (str: string, kb: Formula, base: string): void {
 
 /**
  * Fold well-formed rdf:first/rdf:rest/rdf:nil chains in the document graph
- * back into live rdflib `Collection` terms (the shape the old parser
- * produced for `rdf:parseType="Collection"`, on which downstream
- * `Collection.elements` consumers rely). Malformed or externally referenced
- * chains are left untouched as plain triples. Same idiom as
- * `convertFirstRestNil` in src/lists.ts, but defensive: it skips instead of
- * throwing.
+ * back into rdflib `Collection` terms, the shape `rdf:parseType="Collection"`
+ * consumers expect. Malformed or externally referenced chains are left
+ * untouched as plain triples (unlike src/lists.ts, this never throws).
  */
 function foldCollections (kb: Formula, doc: NamedNode): void {
   const anyKb = kb as any
@@ -202,7 +184,7 @@ function foldCollections (kb: Formula, doc: NamedNode): void {
   }
 
   // 2. A lone rdf:nil in object position (not a chain tail) is an empty
-  //    collection — the shape `<p rdf:parseType="Collection"/>` produces.
+  //    collection: the shape `<p rdf:parseType="Collection"/>` produces.
   for (const st of anyKb.statementsMatching(null, null, nil, doc)) {
     if (st.predicate.value === rest.value) continue
     const empty: Collection = anyKb.rdfFactory.collection([])
@@ -240,7 +222,7 @@ function wellFormedChain (
     if (kb.statementsMatching(null, null, node, doc).length !== 1) return null
     node = incoming[0].subject
   }
-  nodes.reverse() // head → tail
+  nodes.reverse() // head to tail
   const elements: Quad_Object[] = []
   const trash: Quad[] = []
   for (const n of nodes) {

--- a/src/rdfxml-adapter.ts
+++ b/src/rdfxml-adapter.ts
@@ -1,0 +1,276 @@
+/**
+ * Adapter between rdfxml-streaming-parser and rdflib's data model.
+ *
+ * The whole document string is fed into the streaming parser and the
+ * resulting quads are loaded into the store, replicating the behaviour of
+ * the retired hand-rolled DOM-walking parser (src/rdfxmlparser.js):
+ *
+ *  - every statement is attributed to the document graph `kb.sym(base)`
+ *    (RDF/XML has no named-graph syntax; this is rdflib's provenance
+ *    convention, matching the old `parse(dom, base, kb.sym(base))` call);
+ *  - blank nodes are fresh per parse: document `rdf:nodeID` labels are
+ *    preserved inside a per-parse-unique scope (`rxN_<label>`), so the same
+ *    nodeID unifies within one document (and remains recognisable — issue
+ *    #751) while two documents using the same nodeID can never collide in
+ *    one store (the old parser's uniqueness semantics);
+ *  - `rdf:parseType="Collection"` chains (which the streaming parser emits
+ *    as standard rdf:first/rdf:rest/rdf:nil triples) are folded back into
+ *    live rdflib `Collection` terms when the store's data factory supports
+ *    them, so downstream `Collection.elements` consumers keep working —
+ *    same folding idiom as src/lists.ts;
+ *  - `xmlns:` prefix declarations are harvested into the store's prefix
+ *    table (`setPrefixForURI`), feeding the serializer, as before;
+ *  - the old parser's leniencies are kept: duplicate `rdf:ID` values are
+ *    tolerated (`allowDuplicateRdfIds`) and IRIs are not validated
+ *    (`validateUri: false`).
+ */
+import { RdfXmlParser } from 'rdfxml-streaming-parser'
+import BlankNode from './blank-node'
+import Collection from './collection'
+import Formula from './formula'
+import Node from './node-internal'
+import { NamedNode, Quad, Quad_Object, Term } from './tf-types'
+import * as uriUtil from './uri'
+
+const RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+
+/** Per-parse counter scoping blank-node labels (fresh labels per document). */
+let parseCount = 0
+
+/** Matches `xmlns:prefix="uri"` / `xmlns:prefix='uri'` declarations. */
+const XMLNS_PATTERN = /xmlns:([A-Za-z_][^\s=]*?)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
+
+/**
+ * Parse an RDF/XML document with rdfxml-streaming-parser and load it into
+ * the given store. Asynchronous: the returned promise settles when every
+ * statement has been added (or parsing failed).
+ *
+ * @param str - The RDF/XML document body
+ * @param kb - The store (or plain Formula) to load the statements into
+ * @param base - The base IRI for relative-IRI resolution; also names the document graph
+ * @returns A promise resolving once the document is fully loaded
+ */
+export default function parseRDFXML (str: string, kb: Formula, base: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const docGraph = kb.sym(base)
+    const factory = kb.rdfFactory
+    const bnodeScope = 'rx' + parseCount++ + '_'
+    const bnodes: { [label: string]: BlankNode } = Object.create(null)
+
+    // A thin RDF/JS DataFactory over rdflib's own factory, so the parser
+    // emits rdflib-native terms directly. Blank-node labels get the
+    // per-parse scope prefix; anonymous blank nodes are freshly minted.
+    const dataFactory = {
+      namedNode: (value: string) => factory.namedNode(value),
+      blankNode: (label?: string) => label
+        ? (bnodes[label] || (bnodes[label] = factory.blankNode(bnodeScope + label)))
+        : factory.blankNode(),
+      literal: (value: string, languageOrDatatype?: any) => {
+        if (languageOrDatatype && typeof languageOrDatatype === 'object' &&
+            !languageOrDatatype.termType) {
+          // RDF 1.2 directional language string ({ language, direction }):
+          // rdflib has no base-direction support yet, keep the language tag.
+          return factory.literal(value, languageOrDatatype.language)
+        }
+        return factory.literal(value, languageOrDatatype)
+      },
+      variable: (value: string) => (factory as any).variable
+        ? (factory as any).variable(value)
+        : undefined,
+      defaultGraph: () => docGraph,
+      quad: (s: any, p: any, o: any, g: any) => factory.quad(s, p, o, g || docGraph),
+    }
+
+    let settled = false
+    const fail = (err: Error) => {
+      if (!settled) {
+        settled = true
+        reject(err)
+      }
+    }
+
+    const parser = new RdfXmlParser({
+      baseIRI: base,
+      dataFactory: dataFactory as any,
+      defaultGraph: docGraph,
+      // The old parser tolerated duplicate rdf:ID values — keep tolerating.
+      allowDuplicateRdfIds: true,
+      // The old parser never validated IRIs — keep accepting lax IRIs.
+      validateUri: false,
+    })
+
+    parser.on('data', (quad: Quad) => {
+      if (settled) return
+      try {
+        kb.add(quad.subject, quad.predicate, quad.object, quad.graph)
+      } catch (e) {
+        fail(e as Error)
+      }
+    })
+    parser.on('error', fail)
+    parser.on('end', () => {
+      if (settled) return
+      // Upstream RdfXmlParser never closes its saxes parser at end of
+      // stream, so a truncated document (unclosed tags at EOF) would be
+      // silently accepted. The old xmldom-based path raised
+      // "unclosed xml tag(s)" — closing saxes here keeps that behavior:
+      // saxes validates its end-of-document state and reports unclosed
+      // tags through the parser's regular error path.
+      try {
+        (parser as any).saxParser.close()
+      } catch (e) {
+        return fail(e as Error)
+      }
+      if (settled) return // a saxes EOF error surfaced via 'error'
+      try {
+        harvestPrefixes(str, kb, base)
+        if (factory.supports && factory.supports['COLLECTIONS'] === true) {
+          foldCollections(kb, docGraph)
+        }
+        settled = true
+        resolve()
+      } catch (e) {
+        fail(e as Error)
+      }
+    })
+
+    parser.write(str)
+    parser.end()
+  })
+}
+
+/**
+ * Register `xmlns:` prefix declarations into the store's prefix table, as
+ * the old parser did (it fed the serializer's prefix selection). Harvested
+ * textually since the streaming parser exposes no namespace events.
+ */
+function harvestPrefixes (str: string, kb: Formula, base: string): void {
+  const setPrefix = (kb as any).setPrefixForURI
+  if (typeof setPrefix !== 'function') {
+    return
+  }
+  let match
+  while ((match = XMLNS_PATTERN.exec(str)) !== null) {
+    const prefix = match[1]
+    let uri = match[2] !== undefined ? match[2] : match[3]
+    if (!uri) continue
+    if (base) uri = uriUtil.join(uri, base)
+    setPrefix.call(kb, prefix, uri)
+  }
+  XMLNS_PATTERN.lastIndex = 0
+}
+
+/**
+ * Fold well-formed rdf:first/rdf:rest/rdf:nil chains in the document graph
+ * back into live rdflib `Collection` terms (the shape the old parser
+ * produced for `rdf:parseType="Collection"`, on which downstream
+ * `Collection.elements` consumers rely). Malformed or externally referenced
+ * chains are left untouched as plain triples. Same idiom as
+ * `convertFirstRestNil` in src/lists.ts, but defensive: it skips instead of
+ * throwing.
+ */
+function foldCollections (kb: Formula, doc: NamedNode): void {
+  const anyKb = kb as any
+  if (typeof anyKb.statementsMatching !== 'function' ||
+      typeof anyKb.remove !== 'function' ||
+      typeof anyKb.rdfFactory.collection !== 'function') {
+    return // needs an indexed store to fold
+  }
+  const first = kb.sym(RDF_NS + 'first')
+  const rest = kb.sym(RDF_NS + 'rest')
+  const nil = kb.sym(RDF_NS + 'nil')
+
+  // 1. Fold bnode chains, innermost first (nested lists need extra passes).
+  let folded = true
+  while (folded) {
+    folded = false
+    const tails: Quad[] = anyKb.statementsMatching(null, rest, nil, doc)
+    for (const tail of tails) {
+      const chain = wellFormedChain(anyKb, tail.subject, first, rest, doc)
+      if (!chain) continue
+      // Defer chains whose elements are themselves unfolded chains.
+      if (chain.elements.some((el: Term) => el.termType === 'BlankNode' &&
+          anyKb.statementsMatching(el, first, null, doc).length > 0)) {
+        continue
+      }
+      const collection: Collection = anyKb.rdfFactory.collection(chain.elements)
+      collection.close()
+      anyKb.remove(chain.trash)
+      substituteInDoc(anyKb, collection, chain.head, doc)
+      folded = true
+    }
+  }
+
+  // 2. A lone rdf:nil in object position (not a chain tail) is an empty
+  //    collection — the shape `<p rdf:parseType="Collection"/>` produces.
+  for (const st of anyKb.statementsMatching(null, null, nil, doc)) {
+    if (st.predicate.value === rest.value) continue
+    const empty: Collection = anyKb.rdfFactory.collection([])
+    empty.close()
+    anyKb.remove([st])
+    anyKb.add(st.subject, st.predicate, empty, doc)
+  }
+}
+
+/**
+ * Validate and collect the list chain ending at `tail`. Returns the chain
+ * (head, in-order elements, statements to remove) if and only if every node
+ * is a blank node carrying exactly one rdf:first and one rdf:rest and no
+ * other statements, and interior nodes are referenced only by their
+ * incoming rdf:rest link. Returns null otherwise.
+ */
+function wellFormedChain (
+  kb: any,
+  tail: Term,
+  first: NamedNode,
+  rest: NamedNode,
+  doc: NamedNode
+): { head: Term, elements: Quad_Object[], trash: Quad[] } | null {
+  const nodes: Term[] = []
+  const seen: { [id: string]: boolean } = Object.create(null)
+  let node: Term = tail as Term
+  for (;;) {
+    if (node.termType !== 'BlankNode' || seen[node.value]) return null
+    seen[node.value] = true
+    nodes.push(node)
+    const incoming: Quad[] = kb.statementsMatching(null, rest, node, doc)
+    if (incoming.length === 0) break // reached the head
+    if (incoming.length !== 1) return null
+    // Interior nodes may be referenced only by their incoming rdf:rest.
+    if (kb.statementsMatching(null, null, node, doc).length !== 1) return null
+    node = incoming[0].subject
+  }
+  nodes.reverse() // head → tail
+  const elements: Quad_Object[] = []
+  const trash: Quad[] = []
+  for (const n of nodes) {
+    const firsts: Quad[] = kb.statementsMatching(n, first, null, doc)
+    const rests: Quad[] = kb.statementsMatching(n, rest, null, doc)
+    // Exactly one first, one rest, and nothing else hangs off a list node.
+    if (firsts.length !== 1 || rests.length !== 1) return null
+    if (kb.statementsMatching(n, null, null, doc).length !== 2) return null
+    elements.push(firsts[0].object)
+    trash.push(firsts[0], rests[0])
+  }
+  return { head: nodes[0], elements, trash }
+}
+
+/**
+ * Replace every occurrence of the term `y` with `x` in the given document
+ * graph (subject, predicate and object positions). Local defensive copy of
+ * the src/lists.ts idiom.
+ */
+function substituteInDoc (kb: any, x: Node | Collection, y: Term, doc: NamedNode): void {
+  for (const quad of kb.statementsMatching(y, null, null, doc)) {
+    kb.remove([quad])
+    kb.add(x, quad.predicate, quad.object, doc)
+  }
+  for (const quad of kb.statementsMatching(null, y, null, doc)) {
+    kb.remove([quad])
+    kb.add(quad.subject, x, quad.object, doc)
+  }
+  for (const quad of kb.statementsMatching(null, null, y, doc)) {
+    kb.remove([quad])
+    kb.add(quad.subject, quad.predicate, x, doc)
+  }
+}

--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -54,12 +54,10 @@
  *
  * @author David Sheets <dsheets@mit.edu>
  *
- * @deprecated Since the migration to rdfxml-streaming-parser, rdflib itself
- * no longer uses this class: `parse()` routes application/rdf+xml through
- * src/rdfxml-adapter.ts instead. This legacy DOM-walking parser is kept only
- * because it is part of the public export surface (`RDFParser`); it is
- * slated for removal in v3. Use `parse(str, kb, base, 'application/rdf+xml',
- * callback)` instead.
+ * @deprecated rdflib itself no longer uses this class: `parse()` routes
+ * application/rdf+xml through src/rdfxml-adapter.ts instead. Kept only as
+ * part of the public export surface (`RDFParser`) and slated for removal.
+ * Use `parse(str, kb, base, 'application/rdf+xml', callback)` instead.
 */
 import * as uriUtil from './uri'
 

--- a/src/rdfxmlparser.js
+++ b/src/rdfxmlparser.js
@@ -54,6 +54,12 @@
  *
  * @author David Sheets <dsheets@mit.edu>
  *
+ * @deprecated Since the migration to rdfxml-streaming-parser, rdflib itself
+ * no longer uses this class: `parse()` routes application/rdf+xml through
+ * src/rdfxml-adapter.ts instead. This legacy DOM-walking parser is kept only
+ * because it is part of the public export surface (`RDFParser`); it is
+ * slated for removal in v3. Use `parse(str, kb, base, 'application/rdf+xml',
+ * callback)` instead.
 */
 import * as uriUtil from './uri'
 

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -485,13 +485,10 @@ exa:myid exa:prop1 [ exa:prop2 [ exa:prop3 "value" ] ].
                <core:prefLabel rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" xml:lang="fr">Valeur de test</core:prefLabel>
            </rdf:Description>
        </rdf:RDF>`
-        // Since the migration to rdfxml-streaming-parser, RDF/XML parsing is
-        // asynchronous (like JSON-LD): results must be read via the callback.
-        //
-        // BEHAVIOR DELTA (flagged in the migration PR): when rdf:datatype is
-        // present, the datatype now wins over an xml:lang in scope, per the
-        // RDF/XML spec (typed literals carry no language tag). The old
-        // parser preferred xml:lang and produced lang 'fr' for this input.
+        // RDF/XML parsing is asynchronous: results must be read via the
+        // callback. When rdf:datatype is present it wins over an xml:lang
+        // in scope, per the RDF/XML spec (typed literals carry no language
+        // tag), so no lang 'fr' here.
         parse(content, store, base, mimeType, err => {
           try {
             expect(err).to.equal(null)

--- a/tests/unit/parse-test.js
+++ b/tests/unit/parse-test.js
@@ -474,7 +474,7 @@ exa:myid exa:prop1 [ exa:prop2 [ exa:prop3 "value" ] ].
 
   describe('xml', () => {
     describe('literals', () => {
-      it('handles language subtags', () => {
+      it('handles language subtags', done => {
         let base = 'http://test.com'
         let mimeType = 'application/rdf+xml'
         let store = DataFactory.graph()
@@ -485,8 +485,25 @@ exa:myid exa:prop1 [ exa:prop2 [ exa:prop3 "value" ] ].
                <core:prefLabel rdf:datatype="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" xml:lang="fr">Valeur de test</core:prefLabel>
            </rdf:Description>
        </rdf:RDF>`
-        parse(content, store, base, mimeType)
-        expect(store.statements[0].object.lang).to.eql('fr')
+        // Since the migration to rdfxml-streaming-parser, RDF/XML parsing is
+        // asynchronous (like JSON-LD): results must be read via the callback.
+        //
+        // BEHAVIOR DELTA (flagged in the migration PR): when rdf:datatype is
+        // present, the datatype now wins over an xml:lang in scope, per the
+        // RDF/XML spec (typed literals carry no language tag). The old
+        // parser preferred xml:lang and produced lang 'fr' for this input.
+        parse(content, store, base, mimeType, err => {
+          try {
+            expect(err).to.equal(null)
+            const literal = store.statements[0].object
+            expect(literal.datatype.value).to.eql('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
+            expect(literal.lang).to.eql('')
+            expect(literal.value).to.eql('Valeur de test')
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
       }) // test
     }) // literals
   }) // xml

--- a/tests/unit/rdfxml-parse-test.js
+++ b/tests/unit/rdfxml-parse-test.js
@@ -1,0 +1,439 @@
+/**
+ * Regression tests for the RDF/XML parser migration onto
+ * rdfxml-streaming-parser (replacing the hand-rolled DOM-walking parser in
+ * src/rdfxmlparser.js).
+ *
+ * NOTE: since the migration, parse() for application/rdf+xml is
+ * asynchronous, exactly like the JSON-LD branch: results must be read via
+ * the callback. Every test here goes through the public parse() API.
+ */
+import { expect } from 'chai'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import parse from '../../src/parse'
+import serialize from '../../src/serialize'
+import CanonicalDataFactory from '../../src/factories/canonical-data-factory'
+import DataFactory from '../../src/factories/rdflib-data-factory'
+
+const RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+const MIME = 'application/rdf+xml'
+
+/** parse() promisified over its callback (the async-parse contract). */
+function parseP (content, store, base) {
+  return new Promise((resolve, reject) => {
+    parse(content, store, base, MIME, (err, kb) => err ? reject(err) : resolve(kb))
+  })
+}
+
+function wrap (body) {
+  return `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="${RDF_NS}" xmlns:ex="http://example.org/vocab#">
+${body}
+</rdf:RDF>`
+}
+
+describe('RDF/XML parsing (rdfxml-streaming-parser)', () => {
+  describe('rdf:nodeID (issue #751)', () => {
+    // Exact reproduction from the issue.
+    const content = `<rdf:RDF
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+ xmlns:exa="http://example.com/"
+ xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    <foaf:Organization rdf:about="http://example.com/org1">
+        <exa:member rdf:nodeID="n0" />
+        <exa:member rdf:nodeID="otherNodeId" />
+    </foaf:Organization>
+</rdf:RDF>`
+
+    it('keeps distinct nodeIDs distinct and preserves the document labels', async () => {
+      const store = DataFactory.graph()
+      await parseP(content, store, 'http://example.com/doc')
+      const members = store.each(
+        store.sym('http://example.com/org1'),
+        store.sym('http://example.com/member'))
+      expect(members).to.have.length(2)
+      expect(members[0].termType).to.equal('BlankNode')
+      expect(members[1].termType).to.equal('BlankNode')
+      expect(members[0].value).to.not.equal(members[1].value)
+      // The document's nodeID labels are preserved inside a per-parse scope
+      // (rxN_<label>), so they remain recognisable without being able to
+      // collide across documents.
+      const labels = members.map(m => m.value).sort()
+      expect(labels.some(v => v.endsWith('_n0'))).to.equal(true)
+      expect(labels.some(v => v.endsWith('_otherNodeId'))).to.equal(true)
+    })
+
+    it('unifies repeated uses of the same nodeID within one document', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/a">
+    <ex:p rdf:nodeID="shared"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="shared">
+    <ex:q>value</ex:q>
+  </rdf:Description>`)
+      await parseP(doc, store, 'http://example.org/doc')
+      const obj = store.any(store.sym('http://example.org/a'), store.sym('http://example.org/vocab#p'))
+      const subj = store.any(null, store.sym('http://example.org/vocab#q'))
+      expect(obj.termType).to.equal('BlankNode')
+      expect(store.anyStatementMatching(obj, store.sym('http://example.org/vocab#q'))).to.exist
+      expect(subj).to.exist
+    })
+
+    it('keeps blank nodes fresh per parse (no cross-document collisions)', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/a">
+    <ex:p rdf:nodeID="shared"/>
+  </rdf:Description>`)
+      await parseP(doc, store, 'http://example.org/doc1')
+      await parseP(doc, store, 'http://example.org/doc2')
+      const sts = store.statementsMatching(null, store.sym('http://example.org/vocab#p'), null)
+      expect(sts).to.have.length(2)
+      // Same document label, but the two parses must not share a bnode.
+      expect(sts[0].object.value).to.not.equal(sts[1].object.value)
+    })
+  })
+
+  describe('rdf:Bag / rdf:li (issue #182, parser half)', () => {
+    // The serializer half of #182 (how Bags are written back) is explicitly
+    // out of scope here; these tests pin the parser side down.
+    it('numbers rdf:li members as rdf:_1, rdf:_2, ...', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/s">
+    <ex:bag>
+      <rdf:Bag>
+        <rdf:li>apple</rdf:li>
+        <rdf:li>banana</rdf:li>
+        <rdf:li>coconut</rdf:li>
+      </rdf:Bag>
+    </ex:bag>
+  </rdf:Description>`)
+      await parseP(doc, store, 'http://example.org/doc')
+      const bag = store.any(store.sym('http://example.org/s'), store.sym('http://example.org/vocab#bag'))
+      expect(bag.termType).to.equal('BlankNode')
+      expect(store.any(bag, store.sym(RDF_NS + 'type')).value).to.equal(RDF_NS + 'Bag')
+      expect(store.any(bag, store.sym(RDF_NS + '_1')).value).to.equal('apple')
+      expect(store.any(bag, store.sym(RDF_NS + '_2')).value).to.equal('banana')
+      expect(store.any(bag, store.sym(RDF_NS + '_3')).value).to.equal('coconut')
+    })
+
+    it('parses the empty-Bag document from the issue to exactly two statements', async () => {
+      // Exact input from #182.
+      const content = `<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:myNS="http://www.example.org/">
+  <rdf:Description rdf:about="#_000001">
+    <myNS:hasProperty>
+      <rdf:Bag></rdf:Bag>
+    </myNS:hasProperty>
+  </rdf:Description>
+</rdf:RDF>`
+      const base = 'http://host.example/doc'
+      const store = DataFactory.graph()
+      await parseP(content, store, base)
+      expect(store.statements).to.have.length(2)
+      const bag = store.any(store.sym(base + '#_000001'), store.sym('http://www.example.org/hasProperty'))
+      expect(bag.termType).to.equal('BlankNode')
+      expect(store.any(bag, store.sym(RDF_NS + 'type')).value).to.equal(RDF_NS + 'Bag')
+    })
+
+    it('re-parses its own serialization without expansion (round-trip stability)', async () => {
+      const content = `<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:myNS="http://www.example.org/">
+  <rdf:Description rdf:about="#_000001">
+    <myNS:hasProperty>
+      <rdf:Bag></rdf:Bag>
+    </myNS:hasProperty>
+  </rdf:Description>
+</rdf:RDF>`
+      const base = 'http://host.example/doc'
+      let store = DataFactory.graph()
+      await parseP(content, store, base)
+      const counts = [store.statements.length]
+      try {
+        for (let i = 0; i < 3; i++) {
+          const xml = serialize(store.sym(base), store, base, MIME)
+          store = DataFactory.graph()
+          await parseP(xml, store, base)
+          counts.push(store.statements.length)
+        }
+      } catch (e) {
+        // Loud failure beats silent corruption; growth must never happen.
+      }
+      for (const count of counts) {
+        expect(count).to.be.at.most(2)
+      }
+    })
+
+    it('round-trips a named Bag with members stably', async () => {
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/s">
+    <ex:bag>
+      <rdf:Bag rdf:about="http://example.org/bag1">
+        <rdf:li>apple</rdf:li>
+        <rdf:li>banana</rdf:li>
+      </rdf:Bag>
+    </ex:bag>
+  </rdf:Description>`)
+      const base = 'http://host.example/doc'
+      let store = DataFactory.graph()
+      await parseP(doc, store, base)
+      expect(store.statements).to.have.length(4)
+      for (let i = 0; i < 2; i++) {
+        const xml = serialize(store.sym(base), store, base, MIME)
+        store = DataFactory.graph()
+        await parseP(xml, store, base)
+        expect(store.statements).to.have.length(4)
+      }
+      const bag = store.sym('http://example.org/bag1')
+      expect(store.any(bag, store.sym(RDF_NS + '_1')).value).to.equal('apple')
+      expect(store.any(bag, store.sym(RDF_NS + '_2')).value).to.equal('banana')
+    })
+  })
+
+  describe('old-parser leniencies (kept)', () => {
+    it('tolerates duplicate rdf:ID values', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:ID="dup"><ex:p>one</ex:p></rdf:Description>
+  <rdf:Description rdf:ID="dup"><ex:p>two</ex:p></rdf:Description>`)
+      const base = 'http://example.org/doc'
+      await parseP(doc, store, base)
+      const values = store.each(store.sym(base + '#dup'), store.sym('http://example.org/vocab#p'))
+        .map(t => t.value).sort()
+      expect(values).to.eql(['one', 'two'])
+    })
+
+    it('tolerates lax IRIs (no extra validation, as before)', async () => {
+      // IRI validation is disabled in the adapter: exactly like the old
+      // parser, anything rdflib's own NamedNode accepts gets through
+      // (pipes, curly braces, ...).
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/x|y">
+    <ex:p rdf:resource="http://example.org/{z}"/>
+  </rdf:Description>`)
+      await parseP(doc, store, 'http://example.org/doc')
+      const st = store.anyStatementMatching(null, store.sym('http://example.org/vocab#p'))
+      expect(st.subject.value).to.equal('http://example.org/x|y')
+      expect(st.object.value).to.equal('http://example.org/{z}')
+    })
+
+    it('still rejects IRIs that rdflib itself rejects (unencoded spaces), as before', async () => {
+      // rdflib's NamedNode constructor throws on unencoded spaces; the old
+      // parser surfaced that same error. Parity check: so does the new one.
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/a b">
+    <ex:p>v</ex:p>
+  </rdf:Description>`)
+      let err = null
+      try {
+        await parseP(doc, store, 'http://example.org/doc')
+      } catch (e) {
+        err = e
+      }
+      expect(err).to.be.an.instanceof(Error)
+      expect(String(err)).to.contain('unencoded spaces')
+    })
+  })
+
+  describe('rdf:parseType="Collection"', () => {
+    const doc = wrap(`  <rdf:Description rdf:about="http://example.org/s">
+    <ex:list rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://example.org/a"/>
+      <rdf:Description rdf:about="http://example.org/b"/>
+      <rdf:Description rdf:about="http://example.org/c"/>
+    </ex:list>
+  </rdf:Description>`)
+
+    it('folds chains into a live Collection when the factory supports them', async () => {
+      const store = DataFactory.graph()
+      await parseP(doc, store, 'http://example.org/doc')
+      expect(store.statements).to.have.length(1)
+      const list = store.any(store.sym('http://example.org/s'), store.sym('http://example.org/vocab#list'))
+      expect(list.termType).to.equal('Collection')
+      expect(list.closed).to.equal(true)
+      expect(list.elements.map(e => e.value)).to.eql([
+        'http://example.org/a',
+        'http://example.org/b',
+        'http://example.org/c'
+      ])
+    })
+
+    it('folds an empty collection', async () => {
+      const store = DataFactory.graph()
+      const emptyDoc = wrap(`  <rdf:Description rdf:about="http://example.org/s">
+    <ex:list rdf:parseType="Collection"/>
+  </rdf:Description>`)
+      await parseP(emptyDoc, store, 'http://example.org/doc')
+      const list = store.any(store.sym('http://example.org/s'), store.sym('http://example.org/vocab#list'))
+      expect(list.termType).to.equal('Collection')
+      expect(list.elements).to.have.length(0)
+    })
+
+    it('leaves rdf:first/rdf:rest triples when the factory has no Collection support', async () => {
+      const store = DataFactory.graph(undefined, { rdfFactory: CanonicalDataFactory })
+      await parseP(doc, store, 'http://example.org/doc')
+      // 1 property statement + 3 × (first + rest)
+      expect(store.statementsMatching(null, store.sym(RDF_NS + 'first'), null)).to.have.length(3)
+      expect(store.statementsMatching(null, store.sym(RDF_NS + 'rest'), null)).to.have.length(3)
+      const head = store.any(store.sym('http://example.org/s'), store.sym('http://example.org/vocab#list'))
+      expect(head.termType).to.equal('BlankNode')
+    })
+  })
+
+  describe('literals', () => {
+    it('keeps xml:lang (including inherited) and rdf:datatype', async () => {
+      const store = DataFactory.graph()
+      const doc = `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="${RDF_NS}" xmlns:ex="http://example.org/vocab#" xml:lang="de">
+  <rdf:Description rdf:about="http://example.org/s">
+    <ex:inherited>hallo</ex:inherited>
+    <ex:tagged xml:lang="fr">bonjour</ex:tagged>
+    <ex:typed rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ex:typed>
+  </rdf:Description>
+</rdf:RDF>`
+      await parseP(doc, store, 'http://example.org/doc')
+      const s = store.sym('http://example.org/s')
+      const ex = n => store.sym('http://example.org/vocab#' + n)
+      expect(store.any(s, ex('inherited')).lang).to.equal('de')
+      expect(store.any(s, ex('tagged')).lang).to.equal('fr')
+      const typed = store.any(s, ex('typed'))
+      expect(typed.value).to.equal('4')
+      expect(typed.datatype.value).to.equal('http://www.w3.org/2001/XMLSchema#integer')
+    })
+  })
+
+  describe('base and relative IRIs', () => {
+    it('resolves relative IRIs against the base', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="child">
+    <ex:p rdf:resource="/rooted"/>
+  </rdf:Description>`)
+      await parseP(doc, store, 'http://example.org/dir/doc')
+      const st = store.anyStatementMatching(null, store.sym('http://example.org/vocab#p'))
+      expect(st.subject.value).to.equal('http://example.org/dir/child')
+      expect(st.object.value).to.equal('http://example.org/rooted')
+    })
+
+    it('resolves against a base with a fragment', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="#x">
+    <ex:p>v</ex:p>
+  </rdf:Description>`)
+      const base = 'http://example.org/doc#frag'
+      await parseP(doc, store, base)
+      const st = store.statements[0]
+      expect(st.subject.value).to.equal('http://example.org/doc#x')
+      // The document graph is still named by the base as given.
+      expect(st.why.value).to.equal(base)
+    })
+
+    it('honours xml:base, including relative xml:base (which the old parser rejected)', async () => {
+      const store = DataFactory.graph()
+      const doc = `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="${RDF_NS}" xmlns:ex="http://example.org/vocab#" xml:base="http://other.example/dir/">
+  <rdf:Description rdf:about="a"><ex:p>1</ex:p></rdf:Description>
+  <rdf:Description rdf:about="b" xml:base="sub/"><ex:p>2</ex:p></rdf:Description>
+</rdf:RDF>`
+      await parseP(doc, store, 'http://example.org/doc')
+      const subjects = store.statementsMatching(null, store.sym('http://example.org/vocab#p'), null)
+        .map(st => st.subject.value).sort()
+      expect(subjects).to.eql([
+        'http://other.example/dir/a',
+        'http://other.example/dir/sub/b'
+      ])
+    })
+  })
+
+  describe('graph placement', () => {
+    it('puts every statement into the document graph kb.sym(base)', async () => {
+      const store = DataFactory.graph()
+      const doc = wrap(`  <rdf:Description rdf:about="http://example.org/s">
+    <ex:p>v</ex:p>
+    <ex:q rdf:nodeID="b"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="b"><ex:r>w</ex:r></rdf:Description>`)
+      const base = 'http://example.org/the-doc'
+      await parseP(doc, store, base)
+      expect(store.statements.length).to.be.greaterThan(0)
+      for (const st of store.statements) {
+        expect(st.why.value).to.equal(base)
+      }
+    })
+  })
+
+  describe('prefix harvesting', () => {
+    it('registers xmlns: prefixes into the store, as the old parser did', async () => {
+      const store = DataFactory.graph()
+      const doc = `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="${RDF_NS}" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <rdf:Description rdf:about="http://example.org/s">
+    <dc:title>t</dc:title>
+  </rdf:Description>
+</rdf:RDF>`
+      await parseP(doc, store, 'http://example.org/doc')
+      expect(store.namespaces['dc']).to.equal('http://purl.org/dc/elements/1.1/')
+    })
+  })
+
+  describe('error handling and callback API', () => {
+    it('surfaces malformed XML through the error callback', done => {
+      const store = DataFactory.graph()
+      parse('<rdf:RDF xmlns:rdf="' + RDF_NS + '"><unclosed', store,
+        'http://example.org/doc', MIME, (err) => {
+          try {
+            expect(err).to.be.an.instanceof(Error)
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+    })
+
+    it('calls the callback with (null, kb) on success', done => {
+      const store = DataFactory.graph()
+      parse(wrap('  <rdf:Description rdf:about="http://example.org/s"><ex:p>v</ex:p></rdf:Description>'),
+        store, 'http://example.org/doc', MIME, (err, kb) => {
+          try {
+            expect(err).to.equal(null)
+            expect(kb).to.equal(store)
+            expect(kb.statements).to.have.length(1)
+            done()
+          } catch (e) {
+            done(e)
+          }
+        })
+    })
+
+    it('still populates the store when no callback is given (asynchronously)', done => {
+      const store = DataFactory.graph()
+      parse(wrap('  <rdf:Description rdf:about="http://example.org/s"><ex:p>v</ex:p></rdf:Description>'),
+        store, 'http://example.org/doc', MIME)
+      // No callback: parse() returns before the store is populated (the
+      // async-parse delta); the data arrives on a later tick.
+      setTimeout(() => {
+        try {
+          expect(store.statements).to.have.length(1)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }, 50)
+    })
+  })
+
+  describe('round-trips through the (unchanged) in-house RDF/XML serializer', () => {
+    // The tests/serialize suite already exercises ttl→xml; these add
+    // xml→store→xml→store coverage on the same reference fixtures.
+    for (const fixture of ['t1-ref.xml', 't2-ref.xml', 't3-ref.xml']) {
+      it(`parse → serialize → re-parse is stable for ${fixture}`, async () => {
+        const xml = readFileSync(join(__dirname, '..', 'serialize', fixture), 'utf8')
+        const base = 'https://example.com/' + fixture.replace('-ref.xml', '.ttl')
+        const store1 = DataFactory.graph()
+        await parseP(xml, store1, base)
+        expect(store1.statements.length).to.be.greaterThan(0)
+        const reserialized = serialize(store1.sym(base), store1, base, MIME)
+        const store2 = DataFactory.graph()
+        await parseP(reserialized, store2, base)
+        const nts1 = store1.statements.map(st => st.toNT()).sort()
+        const nts2 = store2.statements.map(st => st.toNT()).sort()
+        expect(nts2).to.eql(nts1)
+      })
+    }
+  })
+})

--- a/tests/unit/rdfxml-parse-test.js
+++ b/tests/unit/rdfxml-parse-test.js
@@ -1,10 +1,7 @@
 /**
- * Regression tests for the RDF/XML parser migration onto
- * rdfxml-streaming-parser (replacing the hand-rolled DOM-walking parser in
- * src/rdfxmlparser.js).
+ * Tests for RDF/XML parsing via rdfxml-streaming-parser.
  *
- * NOTE: since the migration, parse() for application/rdf+xml is
- * asynchronous, exactly like the JSON-LD branch: results must be read via
+ * parse() for application/rdf+xml is asynchronous: results must be read via
  * the callback. Every test here goes through the public parse() API.
  */
 import { expect } from 'chai'
@@ -417,11 +414,11 @@ describe('RDF/XML parsing (rdfxml-streaming-parser)', () => {
     })
   })
 
-  describe('round-trips through the (unchanged) in-house RDF/XML serializer', () => {
-    // The tests/serialize suite already exercises ttl→xml; these add
-    // xml→store→xml→store coverage on the same reference fixtures.
+  describe('round-trips through the in-house RDF/XML serializer', () => {
+    // The tests/serialize suite already exercises ttl-to-xml; these add
+    // xml-store-xml-store coverage on the same reference fixtures.
     for (const fixture of ['t1-ref.xml', 't2-ref.xml', 't3-ref.xml']) {
-      it(`parse → serialize → re-parse is stable for ${fixture}`, async () => {
+      it(`parse, serialize, re-parse is stable for ${fixture}`, async () => {
         const xml = readFileSync(join(__dirname, '..', 'serialize', fixture), 'utf8')
         const base = 'https://example.com/' + fixture.replace('-ref.xml', '.ttl')
         const store1 = DataFactory.graph()


### PR DESCRIPTION
> **Agent-generated draft PR** for @jeswr to review — prepared with Claude on his behalf; he will personally review it before it leaves draft.

Part of the #824 cleanup programme (process per #823): "replace as much as possible with N3.js, Ruben Verborgh's and Ruben Taelman's libraries". This replaces the 2005-era hand-rolled DOM-walking RDF/XML parser with [rdfxml-streaming-parser](https://github.com/rubensworks/rdfxml-streaming-parser.js) (Taelman/rubensworks; runs the W3C RDF/XML test suite in its upstream CI) behind a thin rdflib-owned adapter, as conditionally recommended by the parser assessment on #824.

## What changed

- **`src/rdfxml-adapter.ts` (new):** feeds the document into `RdfXmlParser` and loads the quads into the store, preserving rdflib conventions:
  - every statement lands in the document graph `kb.sym(base)`, as before;
  - blank nodes are scoped per parse; `rdf:nodeID` labels stay recognisable (`rxN_<label>`) and unify **within** a document but can never collide **across** documents — fixes #751;
  - `rdf:parseType="Collection"` chains are folded back into live `Collection` terms (downstream `Collection.elements` keeps working; plain `rdf:first/rdf:rest` triples are kept when the factory has no Collection support);
  - `xmlns:` prefixes are still harvested into the store's prefix table (feeds the serializer);
  - old leniencies kept: `allowDuplicateRdfIds`, no additional IRI validation (rdflib's own `NamedNode` remains the only gatekeeper, exactly as before);
  - the adapter closes the underlying saxes parser at end of stream — upstream never does — so **truncated documents still fail loudly** ("unclosed tag"), as they did with xmldom.
- **`src/parse.ts`:** the `application/rdf+xml` branch is now asynchronous, mirroring the JSON-LD branch (promise routed into the callback / error callback).
- **`src/fetcher.ts`:** `RDFXMLHandler.parse()` awaits the adapter so `fetcher.load()` only settles once the store is populated — no observable change for Fetcher users (`XMLHandler`/`TextHandler` return types widened accordingly).
- **`src/rdfxmlparser.js`:** kept (it is part of the public export surface as `RDFParser`) with a `@deprecated` notice; slated for deletion in v3, at which point its ~457 hand-rolled lines go away. rdflib itself no longer calls it.

## Breaking-change / ecosystem assessment

- **Fetcher path — no observable change.** SolidOS / NSS / solid-panes / mashlib load RDF/XML through `fetcher.load()`; the handler awaits the adapter, so `load()` still settles with the store populated.
- **Direct `parse()` callers:** code that parses `application/rdf+xml` and reads the store synchronously after `parse()` returns must move to the callback — the same migration JSON-LD callers made when that branch went async. This is the one delta with semver weight; flagging it for the release-label call.
- **Serializer output untouched:** no serializer code in this diff and no `tests/serialize/*-ref.*` golden file changed.
- **Legacy tolerances kept:** duplicate `rdf:ID`, lax IRIs, xmlns prefix harvesting, doc-graph placement, `Collection.elements` — parity covered by the tests below.

Delta-by-delta:

| delta | before | after | verdict |
|---|---|---|---|
| `parse()` async for RDF/XML | synchronous; store populated on return | asynchronous; use the callback (promise routed into it, same precedent as JSON-LD since 2019) | **FLAGGED** — sync callers that read the store immediately after `parse()` see an empty store. Fetcher users unaffected. |
| `rdf:datatype` + `xml:lang` on one element | `xml:lang` won (literal got `lang: 'fr'`) | datatype wins, per the RDF/XML spec (typed literals carry no language tag) | **FLAGGED** — affects data using `rdf:datatype="rdf:langString"` with `xml:lang`; existing unit test updated with a comment |
| spec strictness | illegal constructs silently misread (e.g. `rdf:Description` in property position) | rejected with a parse error | acceptable — fail-loud beats silent corruption |
| error message shape | xmldom text (`unclosed xml tag(s): ...`) | saxes text (`1:121: unexpected close tag.`), delivered through the same error callback | acceptable — same channel, different wording |
| truncated document at EOF | error via xmldom | error preserved (adapter closes saxes at end of stream; upstream lib alone would silently accept) | unchanged (kept deliberately) |
| `rdf:nodeID` | discarded/regenerated → members conflated (#751) | preserved in a per-parse scope; distinct IDs stay distinct, repeated IDs unify within the document | fix |
| spurious whitespace triples | mixed-content whitespace could become triples (foaf.rdf emitted a junk `<doc> rdf:value "\n  "`) | not emitted (635 vs 636 raw quads on foaf.rdf — the delta is exactly that junk triple) | fix |
| anonymous-Bag round trip (#182) | serializer output silently re-parsed into a graph that **grew every cycle** (2 → 2 → 3 → 4 statements, measured on main) | bounded, spec-faithful read; next-generation corrupt output rejected loudly | parser half fixed; serializer half remains (see Issues) |
| explicit `rdf:resource="…rdf#nil"` object | `NamedNode` (rdf:nil) | folded to an empty `Collection` term (indistinguishable from `parseType="Collection"` with no members at quad level; identical RDF meaning) | acceptable — flagged for awareness |
| duplicate `rdf:ID`, lax IRIs, xmlns prefix harvesting, doc-graph placement, `Collection.elements` | — | unchanged | parity, covered by tests |

## Benchmarks (honest figures)

Measured on this branch vs unmodified `main`, same box, `node v22.23.1`, 7 iterations after 2 warmups, medians reported. **Environment caveat: shared 2-core machine under `nice -n 18` — the relative ratios are meaningful, absolute times are not.** *raw* = XML string → rdflib quads in a plain array (store-insert cost excluded); *e2e* = public `parse()` into a fresh `IndexedFormula`.

| fixture | raw before | raw after | raw speedup | e2e before | e2e after | e2e speedup | peak RSS before → after (raw) |
|---|---|---|---|---|---|---|---|
| foaf.rdf (44 KB, real vocab) | 38.2 ms | 20.0 ms | **1.9x** | 35.8 ms | 25.0 ms | **1.4x** | 120 → 102 MB |
| dbpedia.owl (2.4 MB, real ontology) | 494.8 ms | 274.4 ms | **1.8x** | 1152.8 ms | 1145.1 ms | **1.0x** | 327 → 213 MB |
| deep-nested.rdf (3.5 MB, synthetic) | 734.7 ms | 274.4 ms | **2.7x** | 1560.0 ms | 1074.4 ms | **1.5x** | 381 → 301 MB |

These are lower than the 6–7.4x raw figure in the #824 parser assessment; on this box, with terms constructed through rdflib's own factory, raw parsing is 1.8–2.7x faster and peak RSS is 15–35% lower. End-to-end gains are capped by store insertion, which dominates (consistent with the assessment's observation that the store rework is the bigger perf lever). The streaming parse plus lower peak RSS addresses the memory half of the #419 large-file case.

## Tests

New `tests/unit/rdfxml-parse-test.js` (22 tests, all through the public `parse()` API): #751 exact repro + nodeID scoping/cross-parse freshness; #182 empty-Bag repro, `rdf:li` numbering, named-Bag round-trip stability, no-silent-amplification guard; duplicate `rdf:ID`; lax-IRI parity (both directions); Collection folding (incl. empty and factory-without-Collections); language/datatype literals incl. inherited `xml:lang`; relative-IRI + fragment-base + relative `xml:base` (which the old parser rejected); doc-graph placement; prefix harvesting; error shapes (truncated, mismatched tag) and callback API compat; parse→serialize→re-parse stability on the `tests/serialize` reference fixtures.

Full suite on this branch: `test:unit` 333 passing / 0 failing; `test:serialize` t1–t18 golden diffs all pass; `test:types` clean; lint 0 errors.

## Dependency / bundle impact

Adds `rdfxml-streaming-parser@^3.2.0` (new transitives: `@rubensworks/saxes`, `xmlchars`, `validate-iri`, `relative-to-absolute-iri`, `rdf-data-factory`, `@types/readable-stream` — ~690 KB unpacked in `node_modules`, measured). Browser bundle impact: the #824 parser assessment estimated +79 KB minified best case (roughly +20–50 KB gzipped); not re-measured on this branch. `@xmldom/xmldom` stays — RDFa and the fetcher's HTML/XML sniffing still use it; its removal is a separate coordinated project.

## Issues

| issue | what this PR does |
|---|---|
| #751 — supplied `rdf:nodeID` labels discarded, members conflated | **fixed**: exact repro + nodeID-scoping tests |
| #182 — RDF/XML parse→serialize round trip grows the graph every cycle | **parser half fixed**: the silent amplification is gone; next-generation corrupt output is rejected loudly. The root cause on the serializer side (anonymous Bag written as `<p rdf:parseType="Resource"><rdf:Bag/></p>`, which is not valid RDF/XML for that graph) remains and is queued for the serializer rework (#830). Recommend keeping #182 open until that lands. |
| #419 — large-file parsing memory | **parser half addressed**: streaming parse, lower peak RSS (figures above); the store-side half remains |

Closes #751
